### PR TITLE
🧪 [testing improvement] implement tests for RenderHTML and refactor for testability

### DIFF
--- a/internal/graph/html.go
+++ b/internal/graph/html.go
@@ -6,31 +6,29 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 //go:embed templates/graph.html
 var templateFS embed.FS
 
+// osCreateTemp is a variable to allow mocking in tests.
+var osCreateTemp = os.CreateTemp
+
 // RenderHTML renders mermaidContent into a temporary HTML file using the
 // embedded graph.html template and returns the path to the created file.
 func RenderHTML(mermaidContent string) (string, error) {
-	tmplData, err := templateFS.ReadFile("templates/graph.html")
+	html, err := RenderHTMLContent(mermaidContent)
 	if err != nil {
 		return "", err
 	}
 
-	tmpl, err := template.New("graph").Parse(string(tmplData))
+	f, err := osCreateTemp("", "rootline-graph-*.html")
 	if err != nil {
 		return "", err
 	}
 
-	f, err := os.CreateTemp("", "rootline-graph-*.html")
-	if err != nil {
-		return "", err
-	}
-
-	data := struct{ Content template.HTML }{Content: template.HTML(mermaidContent)} //nolint:gosec
-	if err := tmpl.Execute(f, data); err != nil {
+	if _, err := f.WriteString(html); err != nil {
 		_ = f.Close()
 		_ = os.Remove(f.Name()) //nolint:gosec
 		return "", err
@@ -42,6 +40,28 @@ func RenderHTML(mermaidContent string) (string, error) {
 	}
 
 	return f.Name(), nil
+}
+
+// RenderHTMLContent renders mermaidContent into an HTML string using the
+// embedded graph.html template.
+func RenderHTMLContent(mermaidContent string) (string, error) {
+	tmplData, err := templateFS.ReadFile("templates/graph.html")
+	if err != nil {
+		return "", err
+	}
+
+	tmpl, err := template.New("graph").Parse(string(tmplData))
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	data := struct{ Content template.HTML }{Content: template.HTML(mermaidContent)} //nolint:gosec
+	if err := tmpl.Execute(&sb, data); err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
 }
 
 // OpenBrowser opens the file at path in the default browser.

--- a/internal/graph/html_test.go
+++ b/internal/graph/html_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -85,5 +86,70 @@ func TestRenderHTML_CreatesValidHTMLFile(t *testing.T) {
 	}
 	if info.Size() == 0 {
 		t.Errorf("expected non-empty HTML file, got size 0")
+	}
+}
+
+func TestRenderHTMLContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		contains []string
+	}{
+		{
+			name:    "simple graph",
+			content: "graph TD; A-->B;",
+			contains: []string{
+				"graph TD; A-->B;",
+				"<!DOCTYPE html>",
+				"mermaid.initialize",
+			},
+		},
+		{
+			name:    "empty content",
+			content: "",
+			contains: []string{
+				"<pre class=\"mermaid\"></pre>",
+			},
+		},
+		{
+			name:    "with html-like characters",
+			content: "graph TD; A[\"<b>Bold</b>\"] --> B;",
+			contains: []string{
+				"graph TD; A[\"<b>Bold</b>\"] --> B;",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RenderHTMLContent(tt.content)
+			if err != nil {
+				t.Fatalf("RenderHTMLContent() error = %v", err)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("RenderHTMLContent() = %v, want to contain %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderHTML_ErrorPaths(t *testing.T) {
+	// Backup and restore the mockable function
+	oldCreateTemp := osCreateTemp
+	t.Cleanup(func() { osCreateTemp = oldCreateTemp })
+
+	// Mock os.CreateTemp to return an error
+	osCreateTemp = func(dir, pattern string) (*os.File, error) {
+		return nil, errors.New("mocked error")
+	}
+
+	_, err := RenderHTML("graph TD; A-->B;")
+	if err == nil {
+		t.Fatal("expected error from RenderHTML, got nil")
+	}
+	if !strings.Contains(err.Error(), "mocked error") {
+		t.Errorf("expected error containing 'mocked error', got: %v", err)
 	}
 }


### PR DESCRIPTION
This PR improves the test coverage and reliability of the Mermaid-to-HTML rendering logic in `internal/graph/html.go`.

**Key Changes:**
- Refactored `RenderHTML` into two functions:
  - `RenderHTMLContent(mermaidContent string) (string, error)`: A pure function that renders the HTML string from the embedded template.
  - `RenderHTML(mermaidContent string) (string, error)`: A wrapper that calls `RenderHTMLContent` and handles temporary file creation and writing.
- Introduced a mockable `osCreateTemp` variable to enable testing of file system error paths.
- Added a comprehensive table-driven test suite in `internal/graph/html_test.go` covering:
  - Standard Mermaid graphs.
  - Empty content scenarios.
  - Handling of HTML-like characters in Mermaid content.
  - Error handling when temporary file creation fails.
- Added necessary imports (`strings`, `errors`) and verified the implementation in an isolated environment.

These changes increase the overall reliability of the graph visualization feature and provide a cleaner architecture for future enhancements.

---
*PR created automatically by Jules for task [11742270297916303953](https://jules.google.com/task/11742270297916303953) started by @pablontiv*