### PR TITLE
fix(ci): make all pipelines pass green

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,6 +3,7 @@ name: OpenSSF Scorecard
 on:
   schedule:
     - cron: '0 4 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,11 +4,15 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
-permissions: read-all
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
 
 jobs:
   scorecard:
     uses: pablontiv/crossbeam/.github/workflows/scorecard.yml@v1
     permissions:
+      contents: read
       security-events: write
       id-token: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ CI/CD uses shared reusable workflows from `pablontiv/crossbeam@v1`:
 - `gitleaks.yml` — secret scanning
 - `go-release.yml` — auto-tag + goreleaser release
 - `codeql.yml` — CodeQL security scanning (Go)
-- `scorecard.yml` — OpenSSF Scorecard
+- `scorecard.yml` — OpenSSF Scorecard (runs nightly; also dispatchable manually via `gh workflow run "OpenSSF Scorecard"`)
 
 `docs-validate` is repo-specific (runs `rootline validate --all docs/epics/`) and stays inline in `ci.yml`.
 

--- a/cmd/rootline/render_tables_test.go
+++ b/cmd/rootline/render_tables_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/fix"
+	"github.com/spf13/cobra"
+)
+
+func newRenderTestCmd() (*cobra.Command, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	cmd := &cobra.Command{}
+	cmd.SetOut(buf)
+	cmd.SetErr(new(bytes.Buffer))
+	return cmd, buf
+}
+
+func TestRenderRepairTable_Empty(t *testing.T) {
+	cmd, buf := newRenderTestCmd()
+	result := &fix.RepairResult{Version: 1, Kind: "rootline/repair"}
+	if err := renderRepairTable(cmd, result); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No repairs applied") {
+		t.Errorf("expected 'No repairs applied', got: %s", buf.String())
+	}
+}
+
+func TestRenderRepairTable_AllSections(t *testing.T) {
+	cmd, buf := newRenderTestCmd()
+	result := &fix.RepairResult{
+		Version:  1,
+		Kind:     "rootline/repair",
+		DryRun:   true,
+		Changed:  []string{"correct foo: a->b in x.md"},
+		Skipped:  []string{"skipped y.md"},
+		Rejected: []string{"schema proposal z"},
+		Errors:   []string{"err one"},
+	}
+	if err := renderRepairTable(cmd, result); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"DRY RUN", "Changed (1)", "Skipped (1)", "Rejected", "Errors (1)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got: %s", want, out)
+		}
+	}
+}
+
+func TestRenderSchemaProposeTable_Empty(t *testing.T) {
+	cmd, buf := newRenderTestCmd()
+	report := &SchemaProposalsReport{Path: "docs/"}
+	if err := renderSchemaProposeTable(cmd, report); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No schema proposals") {
+		t.Errorf("expected 'No schema proposals' message")
+	}
+}
+
+func TestRenderSchemaProposeTable_WithProposals(t *testing.T) {
+	cmd, buf := newRenderTestCmd()
+	report := &SchemaProposalsReport{
+		Path: "docs/",
+		Proposals: []SchemaProposal{
+			{ID: "p1", Operation: "create_stem", Target: "docs/.stem", Confidence: 0.9, RequiresAgent: false},
+			{ID: "p2", Operation: "update_stem", Target: "docs/sub/.stem", Confidence: 0.7, RequiresAgent: true},
+		},
+		Summary: ProposalsSummary{Total: 2, RequiresAgent: 1, EngineResolved: 1},
+	}
+	if err := renderSchemaProposeTable(cmd, report); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"p1", "create_stem", "p2", "Summary"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got: %s", want, out)
+		}
+	}
+}
+
+func TestRenderSchemaApplyTable_DryRunWithItems(t *testing.T) {
+	cmd, buf := newRenderTestCmd()
+	result := &SchemaApplyResult{
+		Version: 1,
+		Kind:    "rootline/schema-apply",
+		DryRun:  true,
+		Applied: []string{"create docs/.stem"},
+		Skipped: []string{"requires-agent proposal"},
+		Errors:  []string{"some error"},
+	}
+	if err := renderSchemaApplyTable(cmd, result); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Dry run", "Would apply", "Skipped", "Errors"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got: %s", want, out)
+		}
+	}
+}
+
+func TestRenderSchemaApplyTable_Applied(t *testing.T) {
+	cmd, buf := newRenderTestCmd()
+	result := &SchemaApplyResult{
+		Version: 1,
+		Kind:    "rootline/schema-apply",
+		Applied: []string{"updated docs/.stem"},
+	}
+	if err := renderSchemaApplyTable(cmd, result); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Applied:") || !strings.Contains(out, "updated docs/.stem") {
+		t.Errorf("expected applied items in output, got: %s", out)
+	}
+}

--- a/internal/fix/repair_extra_test.go
+++ b/internal/fix/repair_extra_test.go
@@ -1,0 +1,263 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/proposal"
+)
+
+func TestApplyRepair_SetField(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	content := `---
+estado: Pending
+---
+# Test
+`
+	if err := os.WriteFile(testPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:        proposal.SetField,
+			Field:       "tipo",
+			Description: "set tipo",
+			Paths:       []string{"test.md"},
+			Value:       "Epic",
+		},
+	}
+
+	result, err := ApplyRepair(proposals, false, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if len(result.Changed) != 1 {
+		t.Errorf("expected 1 changed, got %d", len(result.Changed))
+	}
+
+	updated, _ := os.ReadFile(testPath)
+	if !contains(string(updated), "tipo: Epic") {
+		t.Errorf("file not updated: %s", string(updated))
+	}
+}
+
+func TestApplyRepair_SetField_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	original := `---
+estado: Pending
+---
+# Test
+`
+	if err := os.WriteFile(testPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:  proposal.SetField,
+			Field: "tipo",
+			Paths: []string{"test.md"},
+			Value: "Epic",
+		},
+	}
+
+	result, err := ApplyRepair(proposals, true, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if !result.DryRun {
+		t.Errorf("expected DryRun=true")
+	}
+	if len(result.Changed) != 1 {
+		t.Errorf("expected 1 changed entry, got %d", len(result.Changed))
+	}
+	got, _ := os.ReadFile(testPath)
+	if string(got) != original {
+		t.Errorf("file modified in dry-run")
+	}
+}
+
+func TestApplyRepair_SetSection_Create(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	content := `---
+estado: Pending
+---
+# Test
+
+Some content.
+`
+	if err := os.WriteFile(testPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:    proposal.SetSection,
+			Field:   "notes",
+			Paths:   []string{"test.md"},
+			Heading: "## Notes",
+			Value:   "Important note.",
+			Mode:    "create",
+		},
+	}
+
+	if _, err := ApplyRepair(proposals, false, tmpDir); err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+
+	updated, _ := os.ReadFile(testPath)
+	if !contains(string(updated), "## Notes") || !contains(string(updated), "Important note.") {
+		t.Errorf("section not created: %s", string(updated))
+	}
+}
+
+func TestApplyRepair_SetSection_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	original := `---
+estado: Pending
+---
+# Test
+`
+	if err := os.WriteFile(testPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:    proposal.SetSection,
+			Paths:   []string{"test.md"},
+			Heading: "## Notes",
+			Value:   "Note body",
+			Mode:    "create",
+		},
+	}
+
+	result, err := ApplyRepair(proposals, true, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if !result.DryRun {
+		t.Errorf("expected DryRun=true")
+	}
+	if len(result.Changed) != 1 {
+		t.Errorf("expected 1 changed entry, got %d", len(result.Changed))
+	}
+	got, _ := os.ReadFile(testPath)
+	if string(got) != original {
+		t.Errorf("file modified in dry-run mode")
+	}
+}
+
+func TestApplyRepair_CorrectLink(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	content := `---
+estado: Pending
+---
+# Test
+
+See [[oldname]] for details.
+`
+	if err := os.WriteFile(testPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:  proposal.CorrectLink,
+			Paths: []string{"test.md"},
+			From:  "[[oldname]]",
+			To:    "[[newname]]",
+		},
+	}
+
+	result, err := ApplyRepair(proposals, false, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if len(result.Changed) != 1 {
+		t.Errorf("expected 1 changed, got %d", len(result.Changed))
+	}
+
+	updated, _ := os.ReadFile(testPath)
+	if !contains(string(updated), "[[newname]]") || contains(string(updated), "[[oldname]]") {
+		t.Errorf("link not corrected: %s", string(updated))
+	}
+}
+
+func TestApplyRepair_CorrectLink_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	original := "See [[oldname]].\n"
+	if err := os.WriteFile(testPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:  proposal.CorrectLink,
+			Paths: []string{"test.md"},
+			From:  "[[oldname]]",
+			To:    "[[newname]]",
+		},
+	}
+
+	result, err := ApplyRepair(proposals, true, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if !result.DryRun {
+		t.Errorf("expected DryRun=true")
+	}
+	got, _ := os.ReadFile(testPath)
+	if string(got) != original {
+		t.Errorf("file modified in dry-run")
+	}
+}
+
+func TestApplyRepair_UnknownTypeRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	if err := os.WriteFile(testPath, []byte("---\nestado: x\n---\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Unknown repair type falls to default branch in applyRepair switch.
+	proposals := []proposal.Proposal{
+		{
+			Type:  proposal.Type("unknown_repair_type"),
+			Field: "estado",
+			Paths: []string{"test.md"},
+		},
+	}
+
+	result, err := ApplyRepair(proposals, true, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if len(result.Rejected) == 0 {
+		t.Errorf("expected rejected entry for unknown repair type")
+	}
+}
+
+func TestReplaceOnce(t *testing.T) {
+	cases := []struct {
+		s, old, new, want string
+	}{
+		{"foo bar foo", "foo", "baz", "baz bar foo"},
+		{"abc", "x", "y", "abc"},
+		{"abcabc", "abc", "X", "Xabc"},
+		{"", "x", "y", ""},
+	}
+	for _, c := range cases {
+		if got := replaceOnce(c.s, c.old, c.new); got != c.want {
+			t.Errorf("replaceOnce(%q,%q,%q) = %q, want %q", c.s, c.old, c.new, got, c.want)
+		}
+	}
+}

--- a/internal/fix/schema_proposals_test.go
+++ b/internal/fix/schema_proposals_test.go
@@ -1,0 +1,27 @@
+package fix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/proposal"
+)
+
+func TestApplySchemaProposals_Empty(t *testing.T) {
+	report := &proposal.Report{}
+	if err := ApplySchemaProposals(context.Background(), report, t.TempDir()); err != nil {
+		t.Errorf("expected nil for empty report, got %v", err)
+	}
+}
+
+func TestApplySchemaProposals_NoExtendEnum(t *testing.T) {
+	// Report with non-extend_enum proposals — should be a no-op.
+	report := &proposal.Report{
+		Proposals: []proposal.Proposal{
+			{Type: proposal.CorrectValue, Field: "estado", From: "x", To: "y"},
+		},
+	}
+	if err := ApplySchemaProposals(context.Background(), report, t.TempDir()); err != nil {
+		t.Errorf("expected nil for non-schema proposals, got %v", err)
+	}
+}

--- a/internal/infer/domain_coverage_test.go
+++ b/internal/infer/domain_coverage_test.go
@@ -1,0 +1,9 @@
+package infer
+
+import "testing"
+
+func TestDetectMissingDomains_Deprecated(t *testing.T) {
+	if got := DetectMissingDomains(nil); got != nil {
+		t.Errorf("DetectMissingDomains(nil) = %v, want nil", got)
+	}
+}

--- a/internal/infer/schema_gen_extra_test.go
+++ b/internal/infer/schema_gen_extra_test.go
@@ -1,0 +1,50 @@
+package infer
+
+import (
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/rules"
+)
+
+func TestGenerateAggregateExpr_NonEnum(t *testing.T) {
+	got := generateAggregateExpr("name", rules.SchemaField{Type: "string"})
+	if got != "" {
+		t.Errorf("expected empty for non-enum, got %q", got)
+	}
+}
+
+func TestGenerateAggregateExpr_EmptyValues(t *testing.T) {
+	got := generateAggregateExpr("estado", rules.SchemaField{Type: "enum", Values: nil})
+	if got != "" {
+		t.Errorf("expected empty for enum without values, got %q", got)
+	}
+}
+
+func TestGenerateAggregateExpr_SingleValue(t *testing.T) {
+	got := generateAggregateExpr("estado", rules.SchemaField{Type: "enum", Values: []string{"Done"}})
+	if got != `"Done"` {
+		t.Errorf("expected quoted single value, got %q", got)
+	}
+}
+
+func TestGenerateAggregateExpr_MultiValue(t *testing.T) {
+	got := generateAggregateExpr("estado", rules.SchemaField{Type: "enum", Values: []string{"Pending", "Done"}})
+	if got != `"Pending"` {
+		t.Errorf("expected first value, got %q", got)
+	}
+}
+
+func TestGenerateAggregateExpressions(t *testing.T) {
+	schema := map[string]rules.SchemaField{
+		"estado": {Type: "enum", Values: []string{"Pending", "Done"}},
+		"name":   {Type: "string"},
+		"empty":  {Type: "enum"},
+	}
+	got := generateAggregateExpressions(schema)
+	if len(got) != 1 {
+		t.Errorf("expected 1 aggregate expr, got %d: %v", len(got), got)
+	}
+	if got["estado"] != `"Pending"` {
+		t.Errorf("expected estado=\"Pending\", got %q", got["estado"])
+	}
+}

--- a/internal/proposal/aggregate_test.go
+++ b/internal/proposal/aggregate_test.go
@@ -1,0 +1,27 @@
+package proposal
+
+import (
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/rules"
+)
+
+func TestDetectMissingAggregates_NilEffective(t *testing.T) {
+	if got := DetectMissingAggregates(t.TempDir(), nil, nil); got != nil {
+		t.Errorf("expected nil for nil effective, got %v", got)
+	}
+}
+
+func TestDetectMissingAggregates_NoHierarchy(t *testing.T) {
+	// Empty records → hierarchy not detected → returns nil.
+	effective := &rules.StemFile{
+		Schema: map[string]rules.SchemaField{
+			"estado": {Type: "enum", Values: []string{"Pending", "Done"}},
+		},
+	}
+	got := DetectMissingAggregates(t.TempDir(), []*extract.Record{}, effective)
+	if got != nil {
+		t.Errorf("expected nil when no hierarchy detected, got %v", got)
+	}
+}

--- a/internal/proposal/infer_test.go
+++ b/internal/proposal/infer_test.go
@@ -1,0 +1,22 @@
+package proposal
+
+import "testing"
+
+func TestMapValue(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"completada", "Completed"},
+		{"COMPLETADA", "Completed"},
+		{"activa", "In Progress"},
+		{"activo", "In Progress"},
+		{"pendiente", "Pending"},
+		{"unknown", "unknown"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := mapValue(c.in); got != c.want {
+			t.Errorf("mapValue(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/rules/validate_structure_test.go
+++ b/internal/rules/validate_structure_test.go
@@ -1,0 +1,40 @@
+package rules
+
+import "testing"
+
+func TestValidateStructure_NoFrontmatter(t *testing.T) {
+	got := ValidateStructure([]byte("# Plain markdown\n"), "test.md")
+	if got != nil {
+		t.Errorf("expected nil for non-frontmatter file, got %v", got)
+	}
+}
+
+func TestValidateStructure_SingleDocument(t *testing.T) {
+	content := []byte("---\nestado: Pending\n---\n# Body\n")
+	got := ValidateStructure(content, "test.md")
+	if got != nil {
+		t.Errorf("expected nil for single document, got %v", got)
+	}
+}
+
+func TestValidateStructure_MultipleDocuments(t *testing.T) {
+	content := []byte("---\nfoo: 1\n---\nbody1\n---\nbar: 2\n---\nbody2\n")
+	got := ValidateStructure(content, "test.md")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(got))
+	}
+	if got[0].Rule != "multiple_yaml_documents" {
+		t.Errorf("expected rule multiple_yaml_documents, got %s", got[0].Rule)
+	}
+	if got[0].Severity != "error" {
+		t.Errorf("expected severity error, got %s", got[0].Severity)
+	}
+}
+
+func TestValidateStructure_CRLFFrontmatter(t *testing.T) {
+	content := []byte("---\r\nfoo: 1\r\n---\r\nbody\r\n")
+	got := ValidateStructure(content, "test.md")
+	if got != nil {
+		t.Errorf("expected nil for valid CRLF frontmatter, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two unrelated CI/CD failures were causing red pipelines:

- **CI**: `go-ci.yml` enforces a 85% coverage gate. Recent runs sat at 83.7% and failed. Added targeted tests for previously-uncovered helpers in `internal/proposal`, `internal/fix`, `internal/infer`, `internal/rules`, and `cmd/rootline` render paths. Total coverage now **85.6%**.
- **Scorecard**: Daily scheduled `OpenSSF Scorecard` runs failed with `startup_failure`. The caller workflow declared `permissions: read-all` at the top level, but the reusable workflow needs `security-events: write` and `id-token: write`. `GITHUB_TOKEN` permissions can only be downgraded by called workflows — the caller must also grant the writes.

## Test plan

- [x] `just test` passes locally (race + cover)
- [x] `just check` passes (gofmt + golangci-lint + build)
- [x] `just validate` passes (108/108 records valid)
- [x] Local coverage 85.6% ≥ 85%
- [ ] CI green on this branch
- [ ] Next nightly Scorecard run no longer reports `startup_failure`