### PR TITLE
feat(fix): add lexical path containment helper

### DIFF
--- a/internal/fix/contain.go
+++ b/internal/fix/contain.go
@@ -1,0 +1,85 @@
+package fix
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ContainmentPolicy selects how ContainPath treats an absolute input path.
+type ContainmentPolicy int
+
+const (
+	// PolicyRejectAbsolute refuses absolute input paths outright. Repair reports
+	// carry root-relative record paths by construction, so an absolute path in a
+	// report is malformed input rather than a legitimate target.
+	PolicyRejectAbsolute ContainmentPolicy = iota
+
+	// PolicyAcceptAbsolute accepts an absolute input path and still requires it to
+	// land inside the root. `schema propose` emits absolute .stem targets, so the
+	// propose->apply contract depends on absolute paths staying valid.
+	PolicyAcceptAbsolute
+)
+
+// ContainmentError reports a path that may not be written under the given root.
+// It carries the untouched requested path and the resolved root so callers can
+// render a message that names both.
+type ContainmentError struct {
+	Requested string // the path exactly as it appeared in the report
+	Root      string // the resolved absolute scan root
+	Message   string // the reason, e.g. "escapes root"
+}
+
+func (e *ContainmentError) Error() string {
+	return fmt.Sprintf("containment violation: path %q %s (root %q)", e.Requested, e.Message, e.Root)
+}
+
+// containmentFailure builds the error for a rejected path. Messages are kept
+// single-line because they are embedded verbatim in JSON output.
+func containmentFailure(requested, root, message string) error {
+	return &ContainmentError{Requested: requested, Root: root, Message: message}
+}
+
+// ContainPath checks that path resolves to a location inside root and returns
+// the validated absolute target.
+//
+// Containment is lexical: the check operates on cleaned path text and never
+// touches the filesystem, so it works for targets that do not exist yet (a
+// create_stem write, for instance) where filepath.EvalSymlinks would fail.
+//
+// Absolute inputs are cleaned and compared to root as-is. They are deliberately
+// NOT joined onto root first: filepath.Join(root, "/etc/.stem") silently yields
+// root/etc/.stem, which would report an out-of-root target as contained.
+//
+// Limitation: a symlink inside the target path is not resolved, so a link that
+// points outside root escapes at access time. Reports should come from trusted
+// producers, and apply commands should run without privileged write access.
+func ContainPath(root, path string, policy ContainmentPolicy) (string, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", containmentFailure(path, root, fmt.Sprintf("root cannot be resolved: %v", err))
+	}
+
+	var target string
+	if filepath.IsAbs(path) {
+		if policy == PolicyRejectAbsolute {
+			return "", containmentFailure(path, absRoot, "absolute paths are not allowed")
+		}
+		target = filepath.Clean(path)
+	} else {
+		target = filepath.Join(absRoot, path)
+	}
+
+	// filepath.Rel normalizes drive-letter case and handles UNC shares, and it
+	// fails when the two paths live on different volumes — which is itself a
+	// containment failure, not something to swallow.
+	rel, err := filepath.Rel(absRoot, target)
+	if err != nil {
+		return "", containmentFailure(path, absRoot, fmt.Sprintf("cannot be resolved relative to root: %v", err))
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", containmentFailure(path, absRoot, "escapes root")
+	}
+
+	return target, nil
+}

--- a/internal/fix/contain_test.go
+++ b/internal/fix/contain_test.go
@@ -1,0 +1,354 @@
+package fix
+
+import (
+	"errors"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// absPrefix is the platform's root prefix so that constructed test paths are
+// genuinely absolute on every OS (filepath.IsAbs(`\root`) is false on Windows).
+var absPrefix = func() string {
+	if runtime.GOOS == "windows" {
+		return `C:\`
+	}
+	return "/"
+}()
+
+// abs builds an absolute, platform-native path from slash-separated segments.
+func abs(parts ...string) string {
+	return filepath.Join(absPrefix, filepath.Join(parts...))
+}
+
+func TestContainPath(t *testing.T) {
+	root := abs("root")
+	nested := abs("root", "dir")
+
+	tests := []struct {
+		name       string
+		root       string
+		path       string
+		policy     ContainmentPolicy
+		wantErr    bool
+		wantMsg    string // substring expected in the error message
+		wantResult string // expected resolved path (only checked when wantErr is false)
+	}{
+		// --- relative paths that stay inside root ---
+		{
+			name:       "RejectAbsolute/relative file",
+			root:       root,
+			path:       "docs/page.md",
+			policy:     PolicyRejectAbsolute,
+			wantResult: abs("root", "docs", "page.md"),
+		},
+		{
+			name:       "RejectAbsolute/relative nested directories",
+			root:       root,
+			path:       "a/b/c.md",
+			policy:     PolicyRejectAbsolute,
+			wantResult: abs("root", "a", "b", "c.md"),
+		},
+		{
+			name:       "RejectAbsolute/dot resolves to root",
+			root:       root,
+			path:       ".",
+			policy:     PolicyRejectAbsolute,
+			wantResult: root,
+		},
+		{
+			name:       "RejectAbsolute/empty path resolves to root",
+			root:       root,
+			path:       "",
+			policy:     PolicyRejectAbsolute,
+			wantResult: root,
+		},
+		{
+			name:       "RejectAbsolute/trailing separator is cleaned",
+			root:       root,
+			path:       "docs/",
+			policy:     PolicyRejectAbsolute,
+			wantResult: abs("root", "docs"),
+		},
+		{
+			name:       "RejectAbsolute/nested dotdot staying inside",
+			root:       root,
+			path:       "a/../b/file.md",
+			policy:     PolicyRejectAbsolute,
+			wantResult: abs("root", "b", "file.md"),
+		},
+		{
+			// Spec Scenario 8: a/../../dir/file.md under /root/dir resolves back
+			// to /root/dir/file.md, which is still inside the root.
+			name:       "RejectAbsolute/scenario8 dotdot returns inside root",
+			root:       nested,
+			path:       "a/../../dir/file.md",
+			policy:     PolicyRejectAbsolute,
+			wantResult: abs("root", "dir", "file.md"),
+		},
+		{
+			name:       "RejectAbsolute/non-existent target is allowed",
+			root:       root,
+			path:       "does/not/exist.md",
+			policy:     PolicyRejectAbsolute,
+			wantResult: abs("root", "does", "not", "exist.md"),
+		},
+		{
+			name:       "AcceptAbsolute/relative path still allowed",
+			root:       root,
+			path:       "docs/page.md",
+			policy:     PolicyAcceptAbsolute,
+			wantResult: abs("root", "docs", "page.md"),
+		},
+
+		// --- relative paths that escape root ---
+		{
+			name:    "RejectAbsolute/parent escape",
+			root:    root,
+			path:    "../outside.md",
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			name:    "RejectAbsolute/deep parent escape",
+			root:    root,
+			path:    "../../../etc/shadow",
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			name:    "RejectAbsolute/bare dotdot",
+			root:    root,
+			path:    "..",
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			// Spec Scenario 9: ../.. under /root/dir resolves above the root.
+			name:    "RejectAbsolute/scenario9 double dotdot from nested root",
+			root:    nested,
+			path:    "../..",
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			name:    "RejectAbsolute/escape hidden behind a subdirectory",
+			root:    root,
+			path:    "docs/../../outside/.stem",
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			name:    "AcceptAbsolute/relative escape still rejected",
+			root:    root,
+			path:    "../outside.md",
+			policy:  PolicyAcceptAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+
+		// --- absolute paths under PolicyRejectAbsolute ---
+		{
+			// Spec Scenario 3: absolute input is a policy violation, not an I/O error.
+			name:    "RejectAbsolute/absolute outside root",
+			root:    root,
+			path:    abs("etc", "passwd"),
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "absolute paths are not allowed",
+		},
+		{
+			// Even a contained absolute path is refused: the policy is about the
+			// shape of the input, not only about where it lands.
+			name:    "RejectAbsolute/absolute inside root",
+			root:    root,
+			path:    abs("root", "docs", "page.md"),
+			policy:  PolicyRejectAbsolute,
+			wantErr: true,
+			wantMsg: "absolute paths are not allowed",
+		},
+
+		// --- absolute paths under PolicyAcceptAbsolute ---
+		{
+			// Spec Scenario 6: schema propose emits absolute targets; they must survive.
+			name:       "AcceptAbsolute/absolute inside root",
+			root:       root,
+			path:       abs("root", "docs", ".stem"),
+			policy:     PolicyAcceptAbsolute,
+			wantResult: abs("root", "docs", ".stem"),
+		},
+		{
+			name:       "AcceptAbsolute/absolute equal to root",
+			root:       root,
+			path:       root,
+			policy:     PolicyAcceptAbsolute,
+			wantResult: root,
+		},
+		{
+			// Spec Scenario 7: absolute target above the root.
+			name:    "AcceptAbsolute/absolute outside root",
+			root:    root,
+			path:    abs("tmp", ".stem"),
+			policy:  PolicyAcceptAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			// Spec Scenario 5: the absolute target only escapes after cleaning, which
+			// is exactly the case filepath.Join(root, path) would have hidden.
+			name:    "AcceptAbsolute/absolute escaping after clean",
+			root:    root,
+			path:    abs("root", "..", "etc", ".stem"),
+			policy:  PolicyAcceptAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+		{
+			// String-prefix containment checks accept this; filepath.Rel does not.
+			name:    "AcceptAbsolute/sibling directory sharing the root prefix",
+			root:    root,
+			path:    abs("rootother", "file.md"),
+			policy:  PolicyAcceptAbsolute,
+			wantErr: true,
+			wantMsg: "escapes root",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ContainPath(tt.root, tt.path, tt.policy)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ContainPath(%q, %q) = %q, want error", tt.root, tt.path, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantMsg) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantMsg)
+				}
+				if got != "" {
+					t.Errorf("resolved path = %q, want empty string on error", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ContainPath(%q, %q) returned unexpected error: %v", tt.root, tt.path, err)
+			}
+			if got != tt.wantResult {
+				t.Errorf("resolved path = %q, want %q", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestContainPathResolvesRelativeRoot(t *testing.T) {
+	// A relative root must be resolved against the working directory before the
+	// containment check, otherwise the returned path is not usable for a write.
+	got, err := ContainPath(".", "docs/page.md", PolicyRejectAbsolute)
+	if err != nil {
+		t.Fatalf("ContainPath returned unexpected error: %v", err)
+	}
+
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolving working directory: %v", err)
+	}
+	want := filepath.Join(cwd, "docs", "page.md")
+	if got != want {
+		t.Errorf("resolved path = %q, want %q", got, want)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("resolved path %q is not absolute", got)
+	}
+}
+
+func TestContainPathErrorCarriesContext(t *testing.T) {
+	root := abs("root")
+	_, err := ContainPath(root, "../../../etc/shadow", PolicyRejectAbsolute)
+	if err == nil {
+		t.Fatal("expected a containment error")
+	}
+
+	var cerr *ContainmentError
+	if !errors.As(err, &cerr) {
+		t.Fatalf("error type = %T, want *ContainmentError", err)
+	}
+	if cerr.Requested != "../../../etc/shadow" {
+		t.Errorf("Requested = %q, want the original proposal path", cerr.Requested)
+	}
+	if cerr.Root != root {
+		t.Errorf("Root = %q, want %q", cerr.Root, root)
+	}
+	if cerr.Message != "escapes root" {
+		t.Errorf("Message = %q, want %q", cerr.Message, "escapes root")
+	}
+
+	// The message goes straight into JSON output, so it must stay single-line
+	// and must name both the offending path and the root.
+	msg := err.Error()
+	if strings.ContainsAny(msg, "\n\r") {
+		t.Errorf("error message %q contains a line break", msg)
+	}
+	if !strings.Contains(msg, "../../../etc/shadow") {
+		t.Errorf("error message %q does not name the requested path", msg)
+	}
+	if !strings.Contains(msg, root) {
+		t.Errorf("error message %q does not name the root", msg)
+	}
+}
+
+func TestContainPathWindowsVolumes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("drive letters and UNC shares are only absolute paths on Windows")
+	}
+
+	t.Run("volume mismatch is a containment error", func(t *testing.T) {
+		// Spec Scenario 11: filepath.Rel cannot relate two different volumes and
+		// its error must surface as a containment violation, never be swallowed.
+		if _, err := ContainPath(`C:\root`, `D:\file.md`, PolicyAcceptAbsolute); err == nil {
+			t.Fatal("expected a containment error across volumes")
+		}
+	})
+
+	t.Run("drive letter case is normalized", func(t *testing.T) {
+		got, err := ContainPath(`C:\root`, `c:\root\docs\page.md`, PolicyAcceptAbsolute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == "" {
+			t.Error("expected a resolved path")
+		}
+	})
+
+	t.Run("UNC share is contained", func(t *testing.T) {
+		got, err := ContainPath(`\\server\share\root`, `docs\page.md`, PolicyRejectAbsolute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := `\\server\share\root\docs\page.md`; got != want {
+			t.Errorf("resolved path = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("UNC escape is rejected", func(t *testing.T) {
+		if _, err := ContainPath(`\\server\share\root`, `..\..\other\file.md`, PolicyRejectAbsolute); err == nil {
+			t.Fatal("expected a containment error")
+		}
+	})
+
+	t.Run("mixed separators are contained", func(t *testing.T) {
+		got, err := ContainPath(`C:\root`, `docs/page.md`, PolicyRejectAbsolute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := `C:\root\docs\page.md`; got != want {
+			t.Errorf("resolved path = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds `ContainPath` to `internal/fix` (`internal/fix/contain.go`) — a lexical containment check that validates a report-supplied path resolves inside a declared scan root, and returns the validated absolute target.

```go
func ContainPath(root, path string, policy ContainmentPolicy) (string, error)
```

- `ContainmentPolicy`: `PolicyRejectAbsolute` (repair reports) / `PolicyAcceptAbsolute` (schema propose targets)
- `ContainmentError{Requested, Root, Message}` carries both the offending path and the root so callers can render a message naming both

**No call sites in this PR.** Enforcement lands in the two follow-ups stacked on this branch (repair apply, then schema apply). PR 1 of 3 for #69.

## Why

`repair apply` and `schema apply` both take a JSON report and write to paths it names. Today neither validates that those paths stay under the scan root — nine `//nolint:gosec` comments assert the invariant instead of checking it (`internal/fix/repair.go:184,223,257,309`, `internal/fix/fix.go:321,367,404,473,488`).

Repro from #69 — a report proposal with `"path": "../../../etc/shadow"` is joined onto the root and written, no rejection.

Refs #69

## How

Two decisions worth reviewing:

**1. Absolute paths are compared to the root, not joined onto it** (`contain.go:64-72`).

The obvious check is broken:

```go
filepath.Rel(root, filepath.Join(root, path))
```

`filepath.Join("/scan/root", "/etc/.stem")` returns `/scan/root/etc/.stem` — Join treats the absolute second argument as a relative segment. `Rel` then reports `etc/.stem`, i.e. **contained**, for a path that names `/etc`. So `ContainPath` branches on `filepath.IsAbs(path)` first: absolute input is `filepath.Clean`ed and compared to the root as-is; only relative input is joined.

Covered by `AcceptAbsolute/absolute_outside_root` and `AcceptAbsolute/absolute_escaping_after_clean` (`contain_test.go:196-218`).

**2. Containment is lexical, never touching the filesystem** (`contain.go:44-47`).

`filepath.EvalSymlinks` errors on non-existent paths, and `create_stem` writes a `.stem` that is not on disk yet — so symlink resolution is not available at this boundary. Documented limitation in the doc comment (`contain.go:52-55`): a symlink *inside* the target path still escapes at access time. Mitigation is trusted report producers plus unprivileged write access; full resolution is deferred.

`filepath.Rel` is what does the comparison, which also gets Windows drive-letter case normalization and UNC handling for free, and surfaces a cross-volume mismatch as a containment error rather than swallowing it.

### Tests

`internal/fix/contain_test.go` — 22 table-driven cases plus 3 focused tests. Paths are constructed (`abs()` helper picks `C:\` vs `/` by GOOS), so nothing depends on host filesystem state.

Notable cases beyond the happy path:
- `sibling_directory_sharing_the_root_prefix` — `/rootother/file.md` under root `/root`; a `strings.HasPrefix` containment check would accept this, `Rel` rejects it
- `scenario8_dotdot_returns_inside_root` — `a/../../dir/file.md` under `/root/dir` lands back inside and is correctly **allowed**
- `RejectAbsolute/absolute_inside_root` — the policy is about input shape, so a contained absolute path is still refused under `PolicyRejectAbsolute`
- `TestContainPathErrorCarriesContext` — asserts the message is single-line (it is embedded verbatim in JSON output) and names both path and root

`TestContainPathWindowsVolumes` skips off Windows: `C:\root` and `\\server\share` are not absolute paths on Unix, so asserting them there would test nothing. This leaves the cross-volume `Rel` error branch unexecuted in CI — `ContainPath` sits at 86.7% statement coverage (that branch plus the `filepath.Abs` failure branch, which needs `os.Getwd` to fail). Package total is 88.5%, above the 85% floor.

## Checklist

- [x] Tests pass (`go test ./... -race`) — all 13 packages ok
- [x] Code is clean (`go vet ./...`) — `just check`: gofmt clean, golangci-lint 0 issues, build ok
- [ ] Changes are documented if user-facing — not user-facing yet; no call sites, no CLI or JSON contract change in this PR