### PR TITLE
feat(migrate): restore split integrity — child version, root marker, overwrite guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 - Root marker support: `.stem` files can now declare `root: true` to establish a schema discovery boundary
 - Stem-health check for nested root markers (`nested-root-marker` info-level diagnostic)
 - Interactive migration prompt: when running on a terminal, rootline prompts to add the root marker to existing projects
+- `migrate --split --force` — overwrite existing child `.stem` files (see the matching **BREAKING** entry below)
 
 ### Changed
 
@@ -25,9 +26,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 - Schema discovery is now stable: resolution depends only on the target path and filesystem `.stem` files, never on the process working directory.
 - `set` command no longer requires a `.git` directory to function.
 - `rootline init` now emits `root: true` in generated `.stem` files, marking new projects as their own boundaries.
+- **BREAKING**: `migrate --split` now refuses to overwrite existing child `.stem` files. It stats every child target before writing anything and fails with `<path> already exists (use --force to overwrite)`, leaving all files untouched. Invocations that previously succeeded by silently clobbering child stems must now pass `--force`. The root `.stem` at the target is the input being rewritten in place and is never guarded. `--dry-run` annotates each target that would be overwritten.
 
 ### Fixed
 
+- `migrate --split` emitted child `.stem` files without a version key, so every child parsed as version 0 and the loader rejected it with `stem version 0 is no longer supported`. Child stems now carry `version: 2`.
+- `migrate --split` dropped `root: true` from the regenerated root `.stem`, leaving the project with no declared boundary: walk-up escaped into ancestor `.stem` files and `validate --all` failed with `Schema discovery reached the filesystem root without finding a declared boundary`. The marker is now preserved when present (and not invented when absent).
 - False-green validation: `validate --all` on a directory outside any schema now correctly exits with an error instead of succeeding with zero validated records.
 - Schema discovery boundary violations: walking up the filesystem no longer accidentally collects `.stem` files from outside the project (e.g., from home directory).
 - Working directory dependence: schema resolution is now stable regardless of where commands are invoked from.

--- a/cmd/rootline/commands_test.go
+++ b/cmd/rootline/commands_test.go
@@ -91,6 +91,7 @@ func resetFlags() {
 	migrateRename = ""
 	migrateSplit = false
 	migrateScaffold = false
+	migrateForce = false
 	analyzeIncremental = false
 	analyzeThreshold = 0.60
 	setDryRun = false
@@ -148,6 +149,10 @@ func resetFlags() {
 		f.Changed = false
 	}
 	if f := migrateCmd.Flags().Lookup("dry-run"); f != nil {
+		_ = f.Value.Set("false")
+		f.Changed = false
+	}
+	if f := migrateCmd.Flags().Lookup("force"); f != nil {
 		_ = f.Value.Set("false")
 		f.Changed = false
 	}

--- a/cmd/rootline/migrate.go
+++ b/cmd/rootline/migrate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
@@ -21,6 +22,7 @@ var (
 	migrateRename   string
 	migrateSplit    bool
 	migrateScaffold bool
+	migrateForce    bool
 )
 
 var migrateCmd = &cobra.Command{
@@ -42,6 +44,7 @@ func init() {
 	migrateCmd.Flags().StringVar(&migrateRename, "rename", "", "rename a field: old_field=new_field")
 	migrateCmd.Flags().BoolVar(&migrateSplit, "split", false, "split a flat .stem into hierarchical .stem files per level")
 	migrateCmd.Flags().BoolVar(&migrateScaffold, "scaffold", false, "scaffold missing required section fields in documents")
+	migrateCmd.Flags().BoolVar(&migrateForce, "force", false, "with --split: overwrite existing child .stem files")
 	rootCmd.AddCommand(migrateCmd)
 }
 
@@ -436,6 +439,8 @@ func runMigrateSplit(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: auto-generated aggregate for '%s'\n", name)
 	}
 
+	collisions := splitCollisions(absTarget, result.Stems)
+
 	if migrateDryRun {
 		for i, sf := range result.Stems {
 			if i > 0 {
@@ -446,9 +451,17 @@ func runMigrateSplit(cmd *cobra.Command, args []string) error {
 				relPath = sf.Path
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "# --- %s ---\n", relPath)
+			if collisions[sf.Path] {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "# (existing file will be overwritten)")
+			}
 			_, _ = fmt.Fprint(cmd.OutOrStdout(), sf.Content)
 		}
 		return nil
+	}
+
+	// Pre-flight guard: refuse before any write so a split is all-or-nothing.
+	if len(collisions) > 0 && !migrateForce {
+		return errSplitCollisions(absTarget, collisions)
 	}
 
 	// Write all .stem files.
@@ -462,4 +475,41 @@ func runMigrateSplit(cmd *cobra.Command, args []string) error {
 		"Split .stem into %d files across %d levels (derive/aggregate/links preserved at root)\n",
 		len(result.Stems), len(hierarchy.Levels))
 	return nil
+}
+
+// splitCollisions stats every child .stem target and reports which already exist.
+// The root .stem at <absTarget>/.stem is the input being rewritten in place, so it
+// is never a collision. The root is matched by path rather than by index so the
+// check stays correct if BuildSplitStems ever reorders its output.
+func splitCollisions(absTarget string, stems []migrate.StemOutput) map[string]bool {
+	rootPath := filepath.Join(absTarget, ".stem")
+	found := make(map[string]bool)
+	for _, sf := range stems {
+		if sf.Path == rootPath {
+			continue
+		}
+		if _, err := os.Stat(sf.Path); err == nil {
+			found[sf.Path] = true
+		}
+	}
+	return found
+}
+
+// errSplitCollisions renders the refusal, naming every colliding target so the
+// user sees the full scope in one error instead of discovering them one at a time.
+func errSplitCollisions(absTarget string, collisions map[string]bool) error {
+	rels := make([]string, 0, len(collisions))
+	for path := range collisions {
+		rel, err := filepath.Rel(absTarget, path)
+		if err != nil {
+			rel = path
+		}
+		rels = append(rels, rel)
+	}
+	sort.Strings(rels)
+
+	if len(rels) == 1 {
+		return fmt.Errorf("%s already exists (use --force to overwrite)", rels[0])
+	}
+	return fmt.Errorf("cannot split: %s already exist (use --force to overwrite)", strings.Join(rels, ", "))
 }

--- a/cmd/rootline/migrate_test.go
+++ b/cmd/rootline/migrate_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -720,5 +721,103 @@ func TestMigrateSplit_PreservesExistingAggregate(t *testing.T) {
 	}
 	if !strings.Contains(rootStr, `estado:`) || !strings.Contains(rootStr, `Completed`) {
 		t.Errorf("expected original aggregate expression preserved, got:\n%s", rootStr)
+	}
+}
+
+// sentinelStem is written to a child target before invoking --split so tests can
+// prove byte-for-byte that no partial write happened.
+const sentinelStem = "version: 2\nschema:\n  test_marker:\n    type: string\n"
+
+func writeSentinelChildStem(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "E01-infra", ".stem")
+	mustWriteFile(t, path, []byte(sentinelStem), 0644)
+	return path
+}
+
+func TestRunMigrateSplit_PreFlightGuardCollisionsRefused(t *testing.T) {
+	dir := setupSplitDir(t)
+	sentinel := writeSentinelChildStem(t, dir)
+
+	out, err := runCmd(t, "migrate", dir, "--split")
+	if err == nil {
+		t.Fatalf("expected collision error, got success\noutput: %s", out)
+	}
+	if !strings.Contains(err.Error(), "already exist") ||
+		!strings.Contains(err.Error(), "use --force to overwrite") {
+		t.Errorf("expected collision message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), filepath.Join("E01-infra", ".stem")) {
+		t.Errorf("expected colliding child path in message, got: %v", err)
+	}
+
+	// Zero partial writes: the sentinel must be byte-identical.
+	got, readErr := os.ReadFile(sentinel)
+	if readErr != nil {
+		t.Fatalf("reading sentinel: %v", readErr)
+	}
+	if string(got) != sentinelStem {
+		t.Errorf("sentinel child .stem was modified:\n%s", got)
+	}
+
+	// No other child .stem may have been created either.
+	if _, statErr := os.Stat(filepath.Join(dir, "E02-platform", ".stem")); statErr == nil {
+		t.Error("expected no child .stem written when the guard refuses")
+	}
+}
+
+func TestRunMigrateSplit_PreFlightGuardForceBypass(t *testing.T) {
+	dir := setupSplitDir(t)
+	sentinel := writeSentinelChildStem(t, dir)
+
+	out, err := runCmd(t, "migrate", dir, "--split", "--force")
+	if err != nil {
+		t.Fatalf("unexpected error with --force: %v\noutput: %s", err, out)
+	}
+
+	got, readErr := os.ReadFile(sentinel)
+	if readErr != nil {
+		t.Fatalf("reading child .stem: %v", readErr)
+	}
+	if string(got) == sentinelStem {
+		t.Error("expected child .stem to be overwritten with --force")
+	}
+	if !strings.Contains(string(got), "prefix: F") {
+		t.Errorf("expected regenerated child .stem, got:\n%s", got)
+	}
+}
+
+func TestRunMigrateSplit_DryRunAnnotatesCollisions(t *testing.T) {
+	dir := setupSplitDir(t)
+	sentinel := writeSentinelChildStem(t, dir)
+
+	out, err := runCmd(t, "migrate", dir, "--split", "--dry-run")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	header := fmt.Sprintf("# --- %s ---\n# (existing file will be overwritten)\n", filepath.Join("E01-infra", ".stem"))
+	if !strings.Contains(out, header) {
+		t.Errorf("expected collision annotation directly after the header, got:\n%s", out)
+	}
+	// The root .stem is the input being rewritten; it is never a collision.
+	if strings.Contains(out, "# --- .stem ---\n# (existing file will be overwritten)") {
+		t.Errorf("root .stem must not be annotated as a collision, got:\n%s", out)
+	}
+	// A non-colliding child gets no annotation.
+	if strings.Contains(out, fmt.Sprintf("# --- %s ---\n# (existing file will be overwritten)", filepath.Join("E02-platform", ".stem"))) {
+		t.Errorf("non-colliding child must not be annotated, got:\n%s", out)
+	}
+
+	// Dry-run writes nothing.
+	got, readErr := os.ReadFile(sentinel)
+	if readErr != nil {
+		t.Fatalf("reading sentinel: %v", readErr)
+	}
+	if string(got) != sentinelStem {
+		t.Errorf("dry-run modified the sentinel:\n%s", got)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "E02-platform", ".stem")); statErr == nil {
+		t.Error("expected no child .stem written in dry-run mode")
 	}
 }

--- a/internal/migrate/split.go
+++ b/internal/migrate/split.go
@@ -93,6 +93,10 @@ func buildSplitRootYAML(existing *rules.StemFile, rootFields map[string]rules.Sc
 	var b strings.Builder
 
 	b.WriteString("version: 2\n")
+	// Preserve the project boundary marker so walk-up resolution keeps stopping here.
+	if existing.Root {
+		b.WriteString("root: true\n")
+	}
 	if existing.Scope.Match != "" {
 		fmt.Fprintf(&b, "scope:\n  match: %q\n", existing.Scope.Match)
 	}

--- a/internal/migrate/split.go
+++ b/internal/migrate/split.go
@@ -230,6 +230,7 @@ func buildSplitRootYAML(existing *rules.StemFile, rootFields map[string]rules.Sc
 // buildSplitChildYAML generates a child .stem with level-specific overrides.
 func buildSplitChildYAML(ls *infer.LevelSchema, extraFields map[string]rules.SchemaField) string {
 	var b strings.Builder
+	b.WriteString("version: 2\n")
 	b.WriteString("schema:\n")
 
 	// Sequence id.

--- a/internal/migrate/split_test.go
+++ b/internal/migrate/split_test.go
@@ -1,6 +1,8 @@
 package migrate
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -394,6 +396,183 @@ func TestBuildSplitStems_ChildVersionEmitted(t *testing.T) {
 		if !strings.HasPrefix(sf.Content, "version: 2\n") {
 			t.Errorf("%s: expected version on first line, got:\n%s", sf.Path, sf.Content)
 		}
+	}
+}
+
+func TestBuildSplitStems_RootPreservation(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     bool
+		wantRoot bool
+	}{
+		{name: "root marker present", root: true, wantRoot: true},
+		{name: "root marker absent", root: false, wantRoot: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := &rules.StemFile{
+				Version: 2,
+				Root:    tt.root,
+				Scope:   rules.Scope{Match: "*.md"},
+				Schema: map[string]rules.SchemaField{
+					"id":     {Type: "sequence", Prefix: "E", Digits: 2},
+					"estado": {Type: "enum", Values: []string{"Pending", "Done"}, Required: true},
+				},
+			}
+
+			hierarchy := makeHierarchy(
+				map[string]rules.SchemaField{
+					"estado": {Type: "enum", Values: []string{"Pending", "Done"}, Required: true},
+				},
+				[]infer.LevelSchema{
+					{
+						Level: infer.Level{
+							Prefix: "E", Digits: 2, Depth: 0,
+							DirPaths: []string{"E01-infra"},
+						},
+						OnlyHere: map[string]rules.SchemaField{
+							"id": {Type: "sequence", Prefix: "E", Digits: 2},
+						},
+					},
+					{
+						Level: infer.Level{
+							Prefix: "F", Digits: 2, Depth: 1,
+							DirPaths: []string{"E01-infra/F01-net"},
+						},
+						OnlyHere: map[string]rules.SchemaField{
+							"id": {Type: "sequence", Prefix: "F", Digits: 2},
+						},
+					},
+				},
+			)
+
+			result := BuildSplitStems("/proj", existing, hierarchy)
+			rootStem := result.Stems[0]
+
+			parsed, err := rules.ParseStem(rootStem.Path, []byte(rootStem.Content))
+			if err != nil {
+				t.Fatalf("ParseStem failed: %v\ncontent:\n%s", err, rootStem.Content)
+			}
+			if parsed.Root != tt.wantRoot {
+				t.Errorf("expected Root %v, got %v\ncontent:\n%s", tt.wantRoot, parsed.Root, rootStem.Content)
+			}
+			if tt.wantRoot && !strings.Contains(rootStem.Content, "root: true\n") {
+				t.Errorf("expected literal 'root: true' in root stem, got:\n%s", rootStem.Content)
+			}
+			if !tt.wantRoot && strings.Contains(rootStem.Content, "root:") {
+				t.Errorf("expected no root key when input root is false, got:\n%s", rootStem.Content)
+			}
+
+			// Child stems never carry the root marker.
+			for _, sf := range result.Stems[1:] {
+				if strings.Contains(sf.Content, "root:") {
+					t.Errorf("child %s must not carry root marker, got:\n%s", sf.Path, sf.Content)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildSplitStems_NestedAncestorBoundary(t *testing.T) {
+	// Ancestor tree that must NOT be reachable from inside the project.
+	ancestor := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ancestor, ".stem"),
+		[]byte("version: 2\nschema:\n  ancestor_field:\n    type: string\n"), 0o644); err != nil {
+		t.Fatalf("writing ancestor .stem: %v", err)
+	}
+
+	project := filepath.Join(ancestor, "project")
+	nested := filepath.Join(project, "E01-infra", "F01-net")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("creating nested dirs: %v", err)
+	}
+
+	existing := &rules.StemFile{
+		Version: 2,
+		Root:    true,
+		Scope:   rules.Scope{Match: "*.md"},
+		Schema: map[string]rules.SchemaField{
+			"id":     {Type: "sequence", Prefix: "E", Digits: 2},
+			"estado": {Type: "enum", Values: []string{"Pending", "Done"}, Required: true},
+		},
+	}
+
+	hierarchy := makeHierarchy(
+		map[string]rules.SchemaField{
+			"estado": {Type: "enum", Values: []string{"Pending", "Done"}, Required: true},
+		},
+		[]infer.LevelSchema{
+			{
+				Level: infer.Level{
+					Prefix: "E", Digits: 2, Depth: 0,
+					DirPaths: []string{"E01-infra"},
+				},
+				OnlyHere: map[string]rules.SchemaField{
+					"id": {Type: "sequence", Prefix: "E", Digits: 2},
+				},
+			},
+			{
+				Level: infer.Level{
+					Prefix: "F", Digits: 2, Depth: 1,
+					DirPaths: []string{"E01-infra/F01-net"},
+				},
+				OnlyHere: map[string]rules.SchemaField{
+					"id": {Type: "sequence", Prefix: "F", Digits: 2},
+				},
+			},
+			{
+				Level: infer.Level{
+					Prefix: "S", Digits: 3, Depth: 2,
+					DirPaths: []string{"E01-infra/F01-net/S001-dns"},
+				},
+				OnlyHere: map[string]rules.SchemaField{
+					"id": {Type: "sequence", Prefix: "S", Digits: 3},
+				},
+			},
+		},
+	)
+
+	result := BuildSplitStems(project, existing, hierarchy)
+	for _, sf := range result.Stems {
+		if err := os.MkdirAll(filepath.Dir(sf.Path), 0o755); err != nil {
+			t.Fatalf("creating %s: %v", filepath.Dir(sf.Path), err)
+		}
+		if err := os.WriteFile(sf.Path, []byte(sf.Content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", sf.Path, err)
+		}
+	}
+
+	record := filepath.Join(nested, "README.md")
+	if err := os.WriteFile(record, []byte("---\nestado: Pending\n---\n# F01\n"), 0o644); err != nil {
+		t.Fatalf("writing record: %v", err)
+	}
+
+	entries, err := rules.WalkUp(record)
+	if err != nil {
+		t.Fatalf("WalkUp failed: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one stem entry")
+	}
+
+	ancestorStem := filepath.Join(ancestor, ".stem")
+	for _, e := range entries {
+		if e.Path == ancestorStem {
+			t.Errorf("walk-up escaped the project root and included %s", e.Path)
+		}
+		rel, relErr := filepath.Rel(project, e.Path)
+		if relErr != nil || strings.HasPrefix(rel, "..") {
+			t.Errorf("stem %s lies outside the project root %s", e.Path, project)
+		}
+	}
+
+	// The outermost entry must be the project root stem carrying the marker.
+	if entries[0].Path != filepath.Join(project, ".stem") {
+		t.Errorf("expected project root .stem first, got %s", entries[0].Path)
+	}
+	if !entries[0].Stem.Root {
+		t.Error("expected project root .stem to carry root: true after split")
 	}
 }
 

--- a/internal/migrate/split_test.go
+++ b/internal/migrate/split_test.go
@@ -340,5 +340,62 @@ func TestBuildSplitStems_NoScopeOmitted(t *testing.T) {
 	}
 }
 
+func TestBuildSplitStems_ChildVersionEmitted(t *testing.T) {
+	existing := &rules.StemFile{
+		Version: 2,
+		Scope:   rules.Scope{Match: "*.md"},
+		Schema: map[string]rules.SchemaField{
+			"id":     {Type: "sequence", Prefix: "E", Digits: 2},
+			"estado": {Type: "enum", Values: []string{"Pending", "Done"}, Required: true},
+			"tipo":   {Type: "enum", Values: []string{"feature", "historia"}},
+		},
+	}
+
+	hierarchy := makeHierarchy(
+		map[string]rules.SchemaField{
+			"estado": {Type: "enum", Values: []string{"Pending", "Done"}, Required: true},
+		},
+		[]infer.LevelSchema{
+			{
+				Level: infer.Level{
+					Prefix: "E", Digits: 2, Depth: 0,
+					DirPaths: []string{"E01-infra"},
+				},
+				OnlyHere: map[string]rules.SchemaField{
+					"id": {Type: "sequence", Prefix: "E", Digits: 2},
+				},
+			},
+			{
+				Level: infer.Level{
+					Prefix: "F", Digits: 2, Depth: 1,
+					DirPaths: []string{"E01-infra/F01-net"},
+				},
+				OnlyHere: map[string]rules.SchemaField{
+					"id":   {Type: "sequence", Prefix: "F", Digits: 2},
+					"tipo": {Type: "enum", Values: []string{"feature", "historia"}},
+				},
+			},
+		},
+	)
+
+	result := BuildSplitStems("/proj", existing, hierarchy)
+	if len(result.Stems) < 2 {
+		t.Fatalf("expected root plus at least one child stem, got %d", len(result.Stems))
+	}
+
+	for _, sf := range result.Stems {
+		parsed, err := rules.ParseStem(sf.Path, []byte(sf.Content))
+		if err != nil {
+			t.Fatalf("ParseStem(%s) failed: %v\ncontent:\n%s", sf.Path, err, sf.Content)
+		}
+		if parsed.Version != 2 {
+			t.Errorf("%s: expected Version 2, got %d\ncontent:\n%s", sf.Path, parsed.Version, sf.Content)
+		}
+		if !strings.HasPrefix(sf.Content, "version: 2\n") {
+			t.Errorf("%s: expected version on first line, got:\n%s", sf.Path, sf.Content)
+		}
+	}
+}
+
 // Ensure the extract.Record import is used (needed for infer.InferredSchema).
 var _ = (*extract.Record)(nil)


### PR DESCRIPTION
## What

Fixes the three integrity defects in `rootline migrate --split` reported in #58, as three reviewable commits:

| Commit | Fix |
|---|---|
| `c655400` | `fix(migrate): emit version in child .stem files` |
| `13240f9` | `fix(migrate): preserve root marker in split operation` |
| `62e9d2b` | `feat(migrate): add --force guard and dry-run collision annotation` |

Closes #58

## Why

Reproduced end-to-end against master @ `1fc8a92` and against this branch, same fixture (a `root: true` project with `E##/F##` levels).

**Before (master `1fc8a92`)**

```
$ rootline migrate . --split
Split .stem into 3 files across 2 levels (derive/aggregate/links preserved at root)

$ head -2 E01-infra/.stem          # child stem — no version key
schema:
  id:

$ head -2 .stem                    # root marker gone
version: 2
scope:

$ rootline validate E01-infra/F01-a/README.md
Error: parsing .../E01-infra/.stem: stem version 0 is no longer supported — upgrade with rootline v0.x migrate --to-v2 first

$ rootline migrate . --split       # re-run silently clobbers the child stems
Split .stem into 3 files across 2 levels (...)
EXIT=0
```

**After (this branch)**

```
$ rootline migrate . --split
Split .stem into 3 files across 2 levels (derive/aggregate/links preserved at root)

$ head -2 E01-infra/.stem
version: 2
schema:

$ head -2 .stem
version: 2
root: true

$ rootline validate E01-infra/F01-a/README.md -o table
File                       Valid  Errors
E01-infra/F01-a/README.md  yes

$ rootline migrate . --split
Error: cannot split: E01-infra/.stem, E02-platform/.stem already exist (use --force to overwrite)
EXIT=1

$ rootline migrate . --split --dry-run
# --- .stem ---
...
# --- E01-infra/.stem ---
# (existing file will be overwritten)
...

$ rootline migrate . --split --force
Split .stem into 3 files across 2 levels (...)
EXIT=0
```

Concretely: every split produced unloadable child schemas, silently deleted the project's governance boundary, and destroyed pre-existing child stems with no warning and no recovery.

## How

**1. Child stem version** — `internal/migrate/split.go:231`

`buildSplitChildYAML` now writes `version: 2` as its first line, matching `buildSplitRootYAML` (`split.go:95`). Hardcoded literal rather than a new constant, because the root render already hardcodes it and `internal/rules` has no version constant to share.

**2. Root marker** — `internal/migrate/split.go:95-98`

`buildSplitRootYAML` already receives the `existing *rules.StemFile` pointer (it reads `existing.Scope.Match`), so it now reads `existing.Root` from the same pointer — no signature churn. Emits `root: true` only when truthy; a project without a boundary does not gain one. Ordered `version` → `root` → `scope`.

**3. Pre-flight guard** — `cmd/rootline/migrate.go:44,438-462,585-620`

`splitCollisions` stats every child target before anything is written; `runMigrateSplit` refuses atomically when any exists and `--force` is not set. Two decisions worth flagging:

- **The root `.stem` is matched by path, not by index.** It is the input being rewritten in place and must never trigger the guard. `splitCollisions` compares each `sf.Path` against `filepath.Join(absTarget, ".stem")` rather than skipping `result.Stems[0]`, so the check stays correct if `BuildSplitStems` ever reorders its output.
- **All collisions are collected before failing**, and named in one sorted error, so the user sees the full blast radius instead of discovering targets one re-run at a time. Message format follows the sibling idiom in `internal/templates/fetch.go:142` and `cmd/rootline/init.go:94`.

`--dry-run` reuses the same collision set to annotate `# (existing file will be overwritten)` directly under each affected header — a preview that cannot tell you what it would destroy is not a preview.

**Breaking change**: invocations that previously succeeded by silently clobbering child stems now fail and require `--force`. Documented in `CHANGELOG.md` under Unreleased → Changed.

### Tests

Written test-first; each failed for the intended reason before implementation (`stem version 0 is no longer supported`, missing `root: true`, `unknown flag: --force`, no annotation).

| Test | Proves |
|---|---|
| `TestBuildSplitStems_ChildVersionEmitted` | every rendered stem round-trips through `rules.ParseStem` with `Version == 2` |
| `TestBuildSplitStems_RootPreservation` | table-driven: `root: true` preserved when present, **not invented** when absent; children never carry it |
| `TestBuildSplitStems_NestedAncestorBoundary` | real nested-ancestor tree — `rules.WalkUp` from a 3-level-deep record stops at the project root and never reaches the ancestor `.stem` |
| `TestRunMigrateSplit_PreFlightGuardCollisionsRefused` | error + non-zero exit, sentinel child `.stem` **byte-identical** to its pre-invocation state, and no other child written (zero partial writes) |
| `TestRunMigrateSplit_PreFlightGuardForceBypass` | `--force` succeeds and rewrites the child |
| `TestRunMigrateSplit_DryRunAnnotatesCollisions` | annotation lands directly under the right header, root is **not** annotated, non-colliding child is **not** annotated, nothing written to disk |

The existing `TestMigrateSplit` already covers the "root `.stem` rewrite does not trigger the guard" scenario: its fixture has no pre-existing child stems and it still passes without `--force`.

## Checklist

- [x] Tests pass (`go test ./... -race`) — all 13 packages `ok`
- [x] Code is clean (`go vet ./...`) — `just check`: gofmt clean, golangci-lint `0 issues`, build ok
- [x] Changes are documented if user-facing — `CHANGELOG.md` (Added / **BREAKING** Changed / Fixed)
- [x] Coverage gate — `just coverage-check` passes, TOTAL 89.2%; `cmd/rootline` 86.4%, `internal/migrate` 86.2% (floor 85%)
