### PR TITLE
fix(repair): confine repair apply writes to the scan root

### DIFF
--- a/cmd/rootline/repair_test.go
+++ b/cmd/rootline/repair_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pablontiv/rootline/internal/fix"
 	"github.com/pablontiv/rootline/internal/proposal"
 )
 
@@ -468,4 +469,298 @@ schema:
 			}
 		})
 	}
+}
+
+// --- path containment (issue #69) ---
+
+// containmentFixture builds a scan root holding the report and a governed
+// record, plus a sibling file one level above the root that must stay untouched.
+func containmentFixture(t *testing.T) (root, outside string) {
+	t.Helper()
+
+	base := t.TempDir()
+	root = filepath.Join(base, "scan")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mustWriteFile(t, filepath.Join(root, ".stem"), []byte(`version: 2
+scope:
+  match: "*.md"
+schema:
+  estado:
+    type: enum
+    required: true
+    values: [Pending, Completed]
+`), 0644)
+	declareTestBoundary(t, root)
+
+	mustWriteFile(t, filepath.Join(root, "task.md"),
+		[]byte("---\nestado: Pending\n---\n# Task\n\n## Status\n\noriginal\n"), 0644)
+
+	outside = filepath.Join(base, "outside.md")
+	mustWriteFile(t, outside,
+		[]byte("---\nestado: Pending\n---\n# Outside\n\n## Status\n\nuntouched\n"), 0644)
+
+	return root, outside
+}
+
+// writeContainmentReport writes a repair report into root and returns its path.
+// The report directory is what repair apply resolves as the scan root.
+func writeContainmentReport(t *testing.T, root string, proposals []proposal.Proposal) string {
+	t.Helper()
+
+	data, err := json.Marshal(proposal.Report{
+		Version:   1,
+		Kind:      "rootline/proposals",
+		Proposals: proposals,
+	})
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	reportFile := filepath.Join(root, "report.json")
+	mustWriteFile(t, reportFile, data, 0644)
+	return reportFile
+}
+
+func decodeRepairResult(t *testing.T, out string) *fix.RepairResult {
+	t.Helper()
+
+	var result fix.RepairResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decoding repair result: %v\noutput: %s", err, out)
+	}
+	return &result
+}
+
+// assertRejected requires exactly one rejection naming both the offending path
+// and the reason, with nothing recorded as changed and nothing reported as an
+// I/O error — a containment violation is a policy rejection, not a failed write.
+func assertRejected(t *testing.T, result *fix.RepairResult, path, reason string) {
+	t.Helper()
+
+	if len(result.Rejected) != 1 {
+		t.Fatalf("rejected = %v, want exactly one entry", result.Rejected)
+	}
+	if !strings.Contains(result.Rejected[0], path) {
+		t.Errorf("rejection %q does not name the path %q", result.Rejected[0], path)
+	}
+	if !strings.Contains(result.Rejected[0], reason) {
+		t.Errorf("rejection %q does not give the reason %q", result.Rejected[0], reason)
+	}
+	if len(result.Changed) != 0 {
+		t.Errorf("changed = %v, want empty", result.Changed)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("errors = %v, want empty (containment violations are not I/O errors)", result.Errors)
+	}
+}
+
+func TestRunRepairApply_PathContainment(t *testing.T) {
+	// Scenario 1: a relative path climbing above the scan root is rejected and
+	// the file it named is never opened for writing.
+	t.Run("RelativeEscapeRejected", func(t *testing.T) {
+		root, outside := containmentFixture(t)
+		before := mustReadFile(t, outside)
+
+		reportFile := writeContainmentReport(t, root, []proposal.Proposal{{
+			Type:        proposal.CorrectValue,
+			Field:       "estado",
+			From:        "Pending",
+			To:          "Completed",
+			Paths:       []string{"../outside.md"},
+			Description: "correct estado",
+		}})
+
+		resetFlags()
+		out, err := runCmd(t, "repair", "apply", "--report", reportFile, "-o", "json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		assertRejected(t, decodeRepairResult(t, out), "../outside.md", "escapes root")
+
+		if after := mustReadFile(t, outside); !bytes.Equal(before, after) {
+			t.Error("file outside the scan root was modified")
+		}
+	})
+
+	// Scenario 2: set_section reaches the filesystem through applySetSection
+	// rather than the frontmatter rewriters, so it needs its own guard.
+	t.Run("SetSectionEscapeRejected", func(t *testing.T) {
+		root, outside := containmentFixture(t)
+		before := mustReadFile(t, outside)
+
+		reportFile := writeContainmentReport(t, root, []proposal.Proposal{{
+			Type:        proposal.SetSection,
+			Heading:     "## Status",
+			Value:       "injected",
+			Mode:        "replace",
+			Paths:       []string{"../outside.md"},
+			Description: "rewrite status section",
+		}})
+
+		resetFlags()
+		out, err := runCmd(t, "repair", "apply", "--report", reportFile, "-o", "json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		assertRejected(t, decodeRepairResult(t, out), "../outside.md", "escapes root")
+
+		if after := mustReadFile(t, outside); !bytes.Equal(before, after) {
+			t.Error("file outside the scan root was modified via set_section")
+		}
+	})
+
+	// Scenario 3: an absolute path is refused on policy. Before this change it
+	// was joined onto the root and failed as a "no such file" I/O error, which
+	// hid the traversal attempt among ordinary failures.
+	t.Run("AbsolutePathRejected", func(t *testing.T) {
+		root, outside := containmentFixture(t)
+		before := mustReadFile(t, outside)
+
+		reportFile := writeContainmentReport(t, root, []proposal.Proposal{{
+			Type:        proposal.AddField,
+			Field:       "tampered",
+			Value:       "true",
+			Paths:       []string{outside},
+			Description: "add tampered field",
+		}})
+
+		resetFlags()
+		out, err := runCmd(t, "repair", "apply", "--report", reportFile, "-o", "json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		assertRejected(t, decodeRepairResult(t, out), outside, "absolute paths are not allowed")
+
+		if after := mustReadFile(t, outside); !bytes.Equal(before, after) {
+			t.Error("file named by an absolute path was modified")
+		}
+	})
+
+	// Scenario 4: --dry-run performs the same check and additionally reports the
+	// resolved destinations so a caller can see where writes would have landed.
+	t.Run("DryRunRejectsAndReportsResolvedTargets", func(t *testing.T) {
+		root, outside := containmentFixture(t)
+		before := mustReadFile(t, outside)
+
+		reportFile := writeContainmentReport(t, root, []proposal.Proposal{
+			{
+				Type:        proposal.CorrectValue,
+				Field:       "estado",
+				From:        "Pending",
+				To:          "Completed",
+				Paths:       []string{"../outside.md"},
+				Description: "correct estado outside root",
+			},
+			{
+				Type:        proposal.CorrectValue,
+				Field:       "estado",
+				From:        "Pending",
+				To:          "Completed",
+				Paths:       []string{"task.md"},
+				Description: "correct estado inside root",
+			},
+		})
+
+		resetFlags()
+		out, err := runCmd(t, "repair", "apply", "--report", reportFile, "--dry-run", "-o", "json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		result := decodeRepairResult(t, out)
+		if !result.DryRun {
+			t.Error("dry_run = false, want true")
+		}
+		if result.ResolvedTargets == nil {
+			t.Fatal("resolved_targets is absent, want it populated in dry-run")
+		}
+
+		wantAccepted := filepath.Join(root, "task.md")
+		if got := result.ResolvedTargets.Accepted["task.md"]; got != wantAccepted {
+			t.Errorf("resolved_targets.accepted[task.md] = %q, want %q", got, wantAccepted)
+		}
+		if got := result.ResolvedTargets.Rejected["../outside.md"]; got != "escapes root" {
+			t.Errorf("resolved_targets.rejected[../outside.md] = %q, want %q", got, "escapes root")
+		}
+
+		if after := mustReadFile(t, outside); !bytes.Equal(before, after) {
+			t.Error("dry-run modified a file outside the scan root")
+		}
+		if !strings.Contains(strings.Join(result.Changed, "\n"), "task.md") {
+			t.Errorf("changed = %v, want the contained proposal previewed", result.Changed)
+		}
+	})
+
+	// resolved_targets is dry-run only: an applied run already says what it did
+	// in changed[], so repeating the destinations would be noise.
+	t.Run("ResolvedTargetsOmittedOutsideDryRun", func(t *testing.T) {
+		root, _ := containmentFixture(t)
+
+		reportFile := writeContainmentReport(t, root, []proposal.Proposal{{
+			Type:        proposal.CorrectValue,
+			Field:       "estado",
+			From:        "Pending",
+			To:          "Completed",
+			Paths:       []string{"task.md"},
+			Description: "correct estado",
+		}})
+
+		resetFlags()
+		out, err := runCmd(t, "repair", "apply", "--report", reportFile, "-o", "json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		if result := decodeRepairResult(t, out); result.ResolvedTargets != nil {
+			t.Errorf("resolved_targets = %+v, want absent outside dry-run", result.ResolvedTargets)
+		}
+		if strings.Contains(out, "resolved_targets") {
+			t.Error("resolved_targets key present in JSON, want it omitted")
+		}
+	})
+
+	// Scenario 12: a contained set_section write is applied and recorded. It
+	// used to write the file but report nothing outside dry-run.
+	t.Run("ContainedSetSectionIsAppliedAndRecorded", func(t *testing.T) {
+		root, _ := containmentFixture(t)
+		taskFile := filepath.Join(root, "task.md")
+
+		reportFile := writeContainmentReport(t, root, []proposal.Proposal{{
+			Type:        proposal.SetSection,
+			Heading:     "## Status",
+			Value:       "rewritten",
+			Mode:        "replace",
+			Paths:       []string{"task.md"},
+			Description: "rewrite status section",
+		}})
+
+		resetFlags()
+		out, err := runCmd(t, "repair", "apply", "--report", reportFile, "-o", "json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		result := decodeRepairResult(t, out)
+		if len(result.Errors) != 0 {
+			t.Fatalf("errors = %v, want empty", result.Errors)
+		}
+		if len(result.Rejected) != 0 {
+			t.Fatalf("rejected = %v, want empty", result.Rejected)
+		}
+
+		changed := strings.Join(result.Changed, "\n")
+		if !strings.Contains(changed, "task.md") || !strings.Contains(changed, "## Status") {
+			t.Errorf("changed = %v, want an entry naming the file and the section", result.Changed)
+		}
+
+		if content := string(mustReadFile(t, taskFile)); !strings.Contains(content, "rewritten") {
+			t.Errorf("task.md was not rewritten:\n%s", content)
+		}
+	})
 }

--- a/internal/fix/coverage_gaps_test.go
+++ b/internal/fix/coverage_gaps_test.go
@@ -100,7 +100,7 @@ func TestApplySetSection_CreateWithoutNewline(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -150,7 +150,7 @@ More stuff.
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestApplySetSection_AppendWithoutNewline(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestApplySetSection_ReplaceAtEOF(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestApplySetSection_ReplaceDefaultMode(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -52,7 +52,9 @@ func ApplyProposals(_ context.Context, report *proposal.Report, root string, rec
 			}
 			applied = append(applied, p)
 		case proposal.SetSection:
-			if err := applySetSection(p, root, recordMap); err != nil {
+			// fix --all builds proposals from scanned record paths, which are
+			// already root-relative; absolute input is tolerated but still confined.
+			if err := applySetSection(p, root, recordMap, PolicyAcceptAbsolute); err != nil {
 				return fmt.Errorf("set_section %s: %w", p.Heading, err)
 			}
 			applied = append(applied, p)
@@ -318,7 +320,7 @@ func applyMigrateValue(p proposal.Proposal, root string, recordMap map[string]*e
 			newContent = InsertWikiLinksBeforeHeading(newContent, p.WikiLinks)
 		}
 
-		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // path comes from a filesystem scan of root, never from a report
 			return err
 		}
 	}
@@ -364,12 +366,20 @@ func rewriteRecordFile(root, path string, fm map[string]any) error {
 		return err
 	}
 	newContent := RewriteFrontmatter(string(content), fm)
-	return os.WriteFile(absPath, []byte(newContent), 0644) //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+	return os.WriteFile(absPath, []byte(newContent), 0644) //nolint:gosec // path comes from a filesystem scan of root, never from a report
 }
 
-func applySetSection(p proposal.Proposal, root string, _ map[string]*extract.Record) error {
+// applySetSection rewrites a named section of each target document. Both the
+// repair-apply path and the fix --all path reach it, so it validates containment
+// itself rather than trusting the caller to have done so; policy carries the
+// caller's trust model for absolute paths.
+func applySetSection(p proposal.Proposal, root string, _ map[string]*extract.Record, policy ContainmentPolicy) error {
 	for _, relPath := range p.Paths {
-		absPath := filepath.Join(root, relPath)
+		absPath, err := ContainPath(root, relPath, policy)
+		if err != nil {
+			return err
+		}
+
 		data, err := os.ReadFile(absPath)
 		if err != nil {
 			return err
@@ -401,7 +411,7 @@ func applySetSection(p proposal.Proposal, root string, _ map[string]*extract.Rec
 					content += "\n"
 				}
 				content += "\n" + heading + "\n\n" + newValue + "\n"
-				if err := os.WriteFile(absPath, []byte(content), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+				if err := os.WriteFile(absPath, []byte(content), 0644); err != nil { //nolint:gosec // absPath is the path ContainPath validated and confined to root
 					return err
 				}
 				continue
@@ -470,7 +480,7 @@ func applySetSection(p proposal.Proposal, root string, _ map[string]*extract.Rec
 			return fmt.Errorf("unknown mode %q for set_section", p.Mode)
 		}
 
-		if err := os.WriteFile(absPath, []byte(content), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		if err := os.WriteFile(absPath, []byte(content), 0644); err != nil { //nolint:gosec // absPath is the path ContainPath validated and confined to root
 			return err
 		}
 	}
@@ -485,7 +495,7 @@ func applyCorrectLink(p proposal.Proposal, root string) error {
 			return err
 		}
 		newContent := strings.Replace(string(content), p.From, p.To, 1)
-		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // path comes from a filesystem scan of root, never from a report
 			return err
 		}
 	}

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1202,7 +1202,7 @@ func TestApplySetSection_Replace(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1243,7 +1243,7 @@ func TestApplySetSection_Append(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1278,7 +1278,7 @@ func TestApplySetSection_Create(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1320,7 +1320,7 @@ func TestApplySetSection_UnknownMode(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err == nil {
 		t.Fatal("expected error for unknown mode")
 	}
@@ -1344,7 +1344,7 @@ func TestApplySetSection_HeadingNotFoundNoCreate(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err == nil {
 		t.Fatal("expected error for heading not found in replace mode")
 	}
@@ -1364,7 +1364,7 @@ func TestApplySetSection_FileNotFound(t *testing.T) {
 		Paths:   []string{"nonexistent.md"},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err == nil {
 		t.Fatal("expected error for nonexistent file")
 	}
@@ -1386,7 +1386,7 @@ func TestApplySetSection_HeadingAtStart(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1417,7 +1417,7 @@ func TestApplySetSection_CreateWhenFoundActsLikeAppend(t *testing.T) {
 		Paths:   []string{relPath},
 	}
 
-	err := applySetSection(p, dir, nil)
+	err := applySetSection(p, dir, nil, PolicyRejectAbsolute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -3,6 +3,7 @@ package fix
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,8 +20,28 @@ type RepairResult struct {
 	DryRun   bool     `json:"dry_run"`
 	Changed  []string `json:"changed"`
 	Skipped  []string `json:"skipped"`
-	Rejected []string `json:"rejected"` // schema proposals silently rejected
+	Rejected []string `json:"rejected"` // schema proposals and containment violations
 	Errors   []string `json:"errors"`
+
+	// ResolvedTargets is populated in dry-run only, where the caller cannot
+	// inspect the outcome on disk and needs to see where each write would land.
+	ResolvedTargets *ResolvedTargetsBreakdown `json:"resolved_targets,omitempty"`
+}
+
+// ResolvedTargetsBreakdown reports where each report-supplied path resolved to,
+// and why any of them were refused. Keys are the paths exactly as the report
+// spelled them, so a caller can match entries back against its own input.
+type ResolvedTargetsBreakdown struct {
+	Accepted map[string]string `json:"accepted"` // report path -> validated absolute path
+	Rejected map[string]string `json:"rejected"` // report path -> reason for refusal
+}
+
+// repairTarget pairs a record with the containment-validated absolute path it
+// was read from. Handlers write to that path instead of re-deriving it, which
+// keeps the containment invariant local to the check that established it.
+type repairTarget struct {
+	abs    string
+	record *extract.Record
 }
 
 // ApplyRepair applies repair proposals (data-only corrections) to the filesystem.
@@ -29,6 +50,10 @@ type RepairResult struct {
 // Modifies Markdown frontmatter only — never touches .stem files.
 // Supports dryRun for preview mode. Post-validates modified files and rolls
 // back if validation fails.
+//
+// Reports are untrusted input, so every path they name is checked against root
+// before the filesystem is touched at all. Paths that escape are recorded in
+// Rejected, not Errors: they are a policy refusal rather than a failed write.
 func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*RepairResult, error) {
 	result := &RepairResult{
 		Version: 1,
@@ -40,20 +65,17 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*Repa
 		return result, nil
 	}
 
-	// Build record map for efficient lookup.
-	recordMap := make(map[string]*extract.Record)
-	reg := extract.NewRegistry()
-
-	// First pass: extract all affected records.
-	affectedPaths := make(map[string]bool)
-	for _, p := range proposals {
-		for _, path := range p.Paths {
-			affectedPaths[path] = true
-		}
+	// First pass: gate every proposal path on containment, before any read.
+	accepted, rejected := containProposalPaths(proposals, root, result)
+	if dryRun {
+		result.ResolvedTargets = &ResolvedTargetsBreakdown{Accepted: accepted, Rejected: rejected}
 	}
 
-	for path := range affectedPaths {
-		absPath := filepath.Join(root, path)
+	// Second pass: extract the records behind the paths that survived the gate.
+	targets := make(map[string]*repairTarget)
+	reg := extract.NewRegistry()
+
+	for path, absPath := range accepted {
 		content, err := os.ReadFile(absPath)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("read %s: %v", path, err))
@@ -72,11 +94,16 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*Repa
 			continue
 		}
 
-		recordMap[path] = record
+		targets[path] = &repairTarget{abs: absPath, record: record}
 	}
 
-	// Second pass: classify and apply proposals.
+	// Third pass: classify and apply proposals.
 	for _, p := range proposals {
+		// A proposal is applied whole or not at all, so one bad path discards it.
+		if hasRejectedPath(p, rejected) {
+			continue
+		}
+
 		// Classify by surface.
 		surf := p.Surface()
 		if surf != proposal.SurfaceRepair {
@@ -87,37 +114,37 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*Repa
 		// Apply based on proposal type.
 		switch p.Type {
 		case proposal.CorrectValue, proposal.MigrateValue:
-			if err := applyRepairCorrectValue(&p, root, recordMap, result, dryRun); err != nil {
+			if err := applyRepairCorrectValue(&p, targets, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("%s %s: %v", p.Type, p.Paths, err))
 			}
 
 		case proposal.AddField, proposal.ExtractBody, proposal.InferFromChildren, proposal.InferFromSiblings:
-			if err := applyRepairAddField(&p, root, recordMap, result, dryRun); err != nil {
+			if err := applyRepairAddField(&p, targets, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("%s %s: %v", p.Type, p.Paths, err))
 			}
 
 		case proposal.SetField:
-			if err := applyRepairSetField(&p, root, recordMap, result, dryRun); err != nil {
+			if err := applyRepairSetField(&p, targets, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("set_field %s: %v", p.Paths, err))
 			}
 
 		case proposal.SetSection:
-			if err := applyRepairSetSection(&p, root, recordMap, result, dryRun); err != nil {
+			if err := applyRepairSetSection(&p, root, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("set_section %s: %v", p.Heading, err))
 			}
 
 		case proposal.CorrectOutlier:
-			if err := applyRepairCorrectValue(&p, root, recordMap, result, dryRun); err != nil {
+			if err := applyRepairCorrectValue(&p, targets, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("correct_outlier %s: %v", p.Paths, err))
 			}
 
 		case proposal.PropagateAggregate:
-			if err := applyRepairCorrectValue(&p, root, recordMap, result, dryRun); err != nil {
+			if err := applyRepairCorrectValue(&p, targets, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("propagate_aggregate %s: %v", p.Paths, err))
 			}
 
 		case proposal.CorrectLink:
-			if err := applyRepairCorrectLink(&p, root, result, dryRun); err != nil {
+			if err := applyRepairCorrectLink(&p, targets, result, dryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("correct_link %s: %v", p.Paths, err))
 			}
 
@@ -127,18 +154,16 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*Repa
 		}
 	}
 
-	// Third pass: post-validate and rollback on failure.
+	// Fourth pass: post-validate and rollback on failure.
 	if !dryRun && len(result.Errors) == 0 {
-		for path, rec := range recordMap {
-			absPath := filepath.Join(root, path)
-
+		for path, tgt := range targets {
 			// Re-resolve effective stem.
-			dir := filepath.Dir(absPath)
-			effective, _ := rules.ResolveForRecord(dir, absPath)
+			dir := filepath.Dir(tgt.abs)
+			effective, _ := rules.ResolveForRecord(dir, tgt.abs)
 
 			// Validate.
 			ctx := context.Background()
-			errs := rules.Validate(ctx, rec, effective)
+			errs := rules.Validate(ctx, tgt.record, effective)
 			if len(errs) > 0 {
 				// Validation failed — rollback.
 				// Note: Since we've modified rec in-memory and written to file,
@@ -157,16 +182,67 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*Repa
 	return result, nil
 }
 
-// applyRepairCorrectValue updates a field value in a record's frontmatter.
-func applyRepairCorrectValue(p *proposal.Proposal, root string, recordMap map[string]*extract.Record, result *RepairResult, dryRun bool) error {
+// containProposalPaths validates every distinct path named by the proposals and
+// splits them into the accepted paths (mapped to their validated absolute form)
+// and the refused ones (mapped to the reason). Refusals are also appended to
+// result.Rejected so they surface in the command output.
+func containProposalPaths(proposals []proposal.Proposal, root string, result *RepairResult) (accepted, rejected map[string]string) {
+	accepted = make(map[string]string)
+	rejected = make(map[string]string)
+
+	for _, p := range proposals {
+		for _, path := range p.Paths {
+			if _, seen := accepted[path]; seen {
+				continue
+			}
+			if _, seen := rejected[path]; seen {
+				continue
+			}
+
+			// Repair reports carry root-relative record paths by construction,
+			// so an absolute path is malformed input rather than a real target.
+			absPath, err := ContainPath(root, path, PolicyRejectAbsolute)
+			if err != nil {
+				rejected[path] = containmentReason(err)
+				result.Rejected = append(result.Rejected, err.Error())
+				continue
+			}
+			accepted[path] = absPath
+		}
+	}
+
+	return accepted, rejected
+}
+
+// containmentReason extracts the bare reason from a containment failure, for
+// the resolved-targets breakdown where the path is already the map key.
+func containmentReason(err error) string {
+	var cerr *ContainmentError
+	if errors.As(err, &cerr) {
+		return cerr.Message
+	}
+	return err.Error()
+}
+
+// hasRejectedPath reports whether any path of the proposal failed containment.
+func hasRejectedPath(p proposal.Proposal, rejected map[string]string) bool {
 	for _, path := range p.Paths {
-		rec, ok := recordMap[path]
+		if _, bad := rejected[path]; bad {
+			return true
+		}
+	}
+	return false
+}
+
+// applyRepairCorrectValue updates a field value in a record's frontmatter.
+func applyRepairCorrectValue(p *proposal.Proposal, targets map[string]*repairTarget, result *RepairResult, dryRun bool) error {
+	for _, path := range p.Paths {
+		tgt, ok := targets[path]
 		if !ok {
 			continue
 		}
 
-		rec.Frontmatter[p.Field] = p.To
-		absPath := filepath.Join(root, path)
+		tgt.record.Frontmatter[p.Field] = p.To
 
 		if dryRun {
 			result.Changed = append(result.Changed,
@@ -175,13 +251,13 @@ func applyRepairCorrectValue(p *proposal.Proposal, root string, recordMap map[st
 		}
 
 		// Read file, update frontmatter, write back.
-		content, err := os.ReadFile(absPath)
+		content, err := os.ReadFile(tgt.abs)
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		newContent := RewriteFrontmatter(string(content), rec.Frontmatter)
-		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		newContent := RewriteFrontmatter(string(content), tgt.record.Frontmatter)
+		if err := os.WriteFile(tgt.abs, []byte(newContent), 0644); err != nil { //nolint:gosec // tgt.abs is the path ContainPath validated and confined to root
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
 
@@ -192,20 +268,19 @@ func applyRepairCorrectValue(p *proposal.Proposal, root string, recordMap map[st
 }
 
 // applyRepairAddField adds a missing field to a record's frontmatter.
-func applyRepairAddField(p *proposal.Proposal, root string, recordMap map[string]*extract.Record, result *RepairResult, dryRun bool) error {
+func applyRepairAddField(p *proposal.Proposal, targets map[string]*repairTarget, result *RepairResult, dryRun bool) error {
 	value := p.Value
 	if value == "" {
 		value = p.To
 	}
 
 	for _, path := range p.Paths {
-		rec, ok := recordMap[path]
+		tgt, ok := targets[path]
 		if !ok {
 			continue
 		}
 
-		rec.Frontmatter[p.Field] = value
-		absPath := filepath.Join(root, path)
+		tgt.record.Frontmatter[p.Field] = value
 
 		if dryRun {
 			result.Changed = append(result.Changed,
@@ -214,13 +289,13 @@ func applyRepairAddField(p *proposal.Proposal, root string, recordMap map[string
 		}
 
 		// Read file, update frontmatter, write back.
-		content, err := os.ReadFile(absPath)
+		content, err := os.ReadFile(tgt.abs)
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		newContent := RewriteFrontmatter(string(content), rec.Frontmatter)
-		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		newContent := RewriteFrontmatter(string(content), tgt.record.Frontmatter)
+		if err := os.WriteFile(tgt.abs, []byte(newContent), 0644); err != nil { //nolint:gosec // tgt.abs is the path ContainPath validated and confined to root
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
 
@@ -231,15 +306,14 @@ func applyRepairAddField(p *proposal.Proposal, root string, recordMap map[string
 }
 
 // applyRepairSetField sets a field via SetField proposal.
-func applyRepairSetField(p *proposal.Proposal, root string, recordMap map[string]*extract.Record, result *RepairResult, dryRun bool) error {
+func applyRepairSetField(p *proposal.Proposal, targets map[string]*repairTarget, result *RepairResult, dryRun bool) error {
 	for _, path := range p.Paths {
-		rec, ok := recordMap[path]
+		tgt, ok := targets[path]
 		if !ok {
 			continue
 		}
 
-		rec.Frontmatter[p.Field] = p.Value
-		absPath := filepath.Join(root, path)
+		tgt.record.Frontmatter[p.Field] = p.Value
 
 		if dryRun {
 			result.Changed = append(result.Changed,
@@ -248,13 +322,13 @@ func applyRepairSetField(p *proposal.Proposal, root string, recordMap map[string
 		}
 
 		// Read file, update frontmatter, write back.
-		content, err := os.ReadFile(absPath)
+		content, err := os.ReadFile(tgt.abs)
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		newContent := RewriteFrontmatter(string(content), rec.Frontmatter)
-		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		newContent := RewriteFrontmatter(string(content), tgt.record.Frontmatter)
+		if err := os.WriteFile(tgt.abs, []byte(newContent), 0644); err != nil { //nolint:gosec // tgt.abs is the path ContainPath validated and confined to root
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
 
@@ -264,38 +338,46 @@ func applyRepairSetField(p *proposal.Proposal, root string, recordMap map[string
 	return nil
 }
 
-// applyRepairSetSection applies a SetSection proposal.
-func applyRepairSetSection(p *proposal.Proposal, root string, recordMap map[string]*extract.Record, result *RepairResult, dryRun bool) error {
-	// Use the existing applySetSection logic from fix.go.
-	// We delegate to the same implementation.
-	if dryRun {
-		mode := p.Mode
-		if mode == "" {
-			mode = "replace"
-		}
-		for _, path := range p.Paths {
-			result.Changed = append(result.Changed,
-				fmt.Sprintf("%s section %s in %s", mode, p.Heading, path))
-		}
-		return nil
+// applyRepairSetSection applies a SetSection proposal by delegating to the
+// shared applySetSection, which re-checks containment because it is also
+// reachable from the fix --all pipeline.
+func applyRepairSetSection(p *proposal.Proposal, root string, result *RepairResult, dryRun bool) error {
+	mode := p.Mode
+	if mode == "" {
+		mode = "replace"
 	}
 
-	return applySetSection(*p, root, recordMap)
+	if !dryRun {
+		if err := applySetSection(*p, root, nil, PolicyRejectAbsolute); err != nil {
+			return err
+		}
+	}
+
+	// Recorded in both modes: an applied section write used to be invisible in
+	// the result even though dry-run previewed it.
+	for _, path := range p.Paths {
+		result.Changed = append(result.Changed,
+			fmt.Sprintf("%s section %s in %s", mode, p.Heading, path))
+	}
+	return nil
 }
 
 // applyRepairCorrectLink applies a CorrectLink proposal.
-func applyRepairCorrectLink(p *proposal.Proposal, root string, result *RepairResult, dryRun bool) error {
+func applyRepairCorrectLink(p *proposal.Proposal, targets map[string]*repairTarget, result *RepairResult, dryRun bool) error {
 	for _, path := range p.Paths {
-		absPath := filepath.Join(root, path)
-
 		if dryRun {
 			result.Changed = append(result.Changed,
 				fmt.Sprintf("correct link: %s -> %s in %s", p.From, p.To, path))
 			continue
 		}
 
+		tgt, ok := targets[path]
+		if !ok {
+			continue
+		}
+
 		// Read file, replace link, write back.
-		content, err := os.ReadFile(absPath)
+		content, err := os.ReadFile(tgt.abs)
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
@@ -306,7 +388,7 @@ func applyRepairCorrectLink(p *proposal.Proposal, root string, result *RepairRes
 			newContent = replaceOnce(newContent, p.From, p.To)
 		}
 
-		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // repair intentionally rewrites proposal-selected paths under the caller-provided root
+		if err := os.WriteFile(tgt.abs, []byte(newContent), 0644); err != nil { //nolint:gosec // tgt.abs is the path ContainPath validated and confined to root
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
 

--- a/internal/fix/repair_test.go
+++ b/internal/fix/repair_test.go
@@ -3,6 +3,7 @@ package fix
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pablontiv/rootline/internal/proposal"
@@ -295,4 +296,147 @@ func contains(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// --- path containment (issue #69) ---
+
+// escapeFixture returns a scan root and a sibling file one level above it, so a
+// "../outside.md" proposal path names a real file that must stay untouched.
+func escapeFixture(t *testing.T) (root, outside string) {
+	t.Helper()
+
+	base := t.TempDir()
+	root = filepath.Join(base, "scan")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	outside = filepath.Join(base, "outside.md")
+	body := "---\nestado: Pending\n---\n# Outside\n\n## Status\n\nuntouched\n"
+	if err := os.WriteFile(outside, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return root, outside
+}
+
+func TestApplyRepair_RejectsEscapingPath(t *testing.T) {
+	root, outside := escapeFixture(t)
+	before, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ApplyRepair([]proposal.Proposal{{
+		Type:        proposal.CorrectValue,
+		Field:       "estado",
+		Description: "correct estado",
+		Paths:       []string{"../outside.md"},
+		From:        "Pending",
+		To:          "Completed",
+	}}, false, root)
+	if err != nil {
+		t.Fatalf("ApplyRepair failed: %v", err)
+	}
+
+	if len(result.Rejected) != 1 {
+		t.Fatalf("Rejected = %v, want exactly one containment violation", result.Rejected)
+	}
+	if len(result.Changed) != 0 {
+		t.Errorf("Changed = %v, want empty", result.Changed)
+	}
+	// The escaping path must never be opened, so it cannot produce a read error.
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors = %v, want empty", result.Errors)
+	}
+
+	after, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Error("file outside the root was modified")
+	}
+}
+
+func TestApplyRepair_RejectsAbsolutePath(t *testing.T) {
+	root, outside := escapeFixture(t)
+
+	result, err := ApplyRepair([]proposal.Proposal{{
+		Type:        proposal.AddField,
+		Field:       "tampered",
+		Description: "add tampered field",
+		Paths:       []string{outside},
+		Value:       "true",
+	}}, false, root)
+	if err != nil {
+		t.Fatalf("ApplyRepair failed: %v", err)
+	}
+
+	if len(result.Rejected) != 1 {
+		t.Fatalf("Rejected = %v, want exactly one containment violation", result.Rejected)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors = %v, want empty (a policy refusal is not an I/O error)", result.Errors)
+	}
+}
+
+func TestApplySetSection_ContainmentPolicy(t *testing.T) {
+	// applySetSection is reached from both repair apply and fix --all, so it
+	// carries its own guard rather than trusting the caller.
+	t.Run("rejects escaping path", func(t *testing.T) {
+		root, outside := escapeFixture(t)
+		before, err := os.ReadFile(outside)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		p := proposal.Proposal{
+			Type:    proposal.SetSection,
+			Heading: "## Status",
+			Value:   "injected",
+			Mode:    "replace",
+			Paths:   []string{"../outside.md"},
+		}
+		if err := applySetSection(p, root, nil, PolicyRejectAbsolute); err == nil {
+			t.Fatal("expected a containment error")
+		}
+
+		after, err := os.ReadFile(outside)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(before) != string(after) {
+			t.Error("file outside the root was modified")
+		}
+	})
+
+	// The fix --all path supplies scan-derived relative paths; the check must
+	// pass them through so that pipeline keeps behaving exactly as before.
+	t.Run("passes through a contained relative path", func(t *testing.T) {
+		root, _ := escapeFixture(t)
+		target := filepath.Join(root, "task.md")
+		if err := os.WriteFile(target, []byte("# Task\n\n## Status\n\noriginal\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		p := proposal.Proposal{
+			Type:    proposal.SetSection,
+			Heading: "## Status",
+			Value:   "rewritten",
+			Mode:    "replace",
+			Paths:   []string{"task.md"},
+		}
+		if err := applySetSection(p, root, nil, PolicyAcceptAbsolute); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		content, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := "rewritten"; !strings.Contains(string(content), want) {
+			t.Errorf("task.md does not contain %q:\n%s", want, content)
+		}
+	})
 }


### PR DESCRIPTION
## What

Enforces path containment in `repair apply`. PR 2 of 3 for #69 — **stacked on `feat/report-path-containment-helper` (#70), review that first.**

- `ApplyRepair` gates every report-supplied path through `ContainPath` before the filesystem is touched (`internal/fix/repair.go:68-70`, `containProposalPaths` at `:180`)
- Violations go to `rejected[]`, not `errors[]`
- `applySetSection` takes a `ContainmentPolicy` and checks containment itself (`internal/fix/fix.go:372-382`)
- `set_section` writes now recorded in `changed[]`
- `--dry-run` reports `resolved_targets` (additive, omitted otherwise)
- Six of the nine `//nolint:gosec` comments rewritten to name the guard

## Why

Repro from #69 — before this change, with the report at `<root>/report.json`:

```json
{"version":1,"kind":"rootline/proposals","proposals":[
  {"type":"correct_value","field":"estado","from":"Pending","to":"Completed",
   "paths":["../../../etc/shadow"]}]}
```

`ApplyRepair` did `filepath.Join(root, path)` (old `repair.go:56`) and read, rewrote and wrote the result — outside the declared root. An absolute path like `/etc/passwd` was *also* joined, producing `<root>/etc/passwd`, which failed as a `no such file` entry in `errors[]`: a traversal attempt was indistinguishable from an ordinary missing file.

After: both land in `rejected[]` with a reason, `errors[]` stays empty, and the target file is never opened.

Refs #69

## How

**The gate runs before any read, not before each write.** A report is untrusted input, so a path that escapes the root must not even be opened — reading it is already a disclosure. `containProposalPaths` (`repair.go:180-207`) validates each distinct path once and splits them into accepted (mapped to the validated absolute path) and rejected (mapped to the reason). The record-extraction pass then iterates only the accepted set.

A proposal is applied whole or not at all (`hasRejectedPath`, `repair.go:222`), so a proposal naming three files where one escapes writes none of them — a partial repair from a tampered report is worse than no repair.

**Handlers write the path `ContainPath` returned.** The design called for a second `ContainPath` call inside each write handler as defense-in-depth. I did something different, and want this flagged for review: those handlers are unexported and reachable only through `ApplyRepair`, so a second call with identical inputs is dead code that can never fire — it adds an unreachable branch per handler, not a layer. Instead the new `repairTarget` (`repair.go:41-44`) carries the validated absolute path alongside the record, and every `os.WriteFile` writes `tgt.abs`. The path that reaches the syscall *is* the `ContainPath` output rather than a `filepath.Join` recomputation that merely agrees with it. Structural, not asserted.

**`applySetSection` is the exception and does keep its own check** (`fix.go:372-382`) — it is genuinely reachable from two callers: `applyRepairSetSection` (report-driven, `PolicyRejectAbsolute`) and `ApplyProposals` for `fix --all` (scan-driven, `PolicyAcceptAbsolute`). Here the check is load-bearing, so it takes the policy from the caller's trust model.

**`fix --all` is unaffected.** Its paths are `record.Path` from a filesystem scan, already root-relative, so `ContainPath` passes them through. `TestApplySetSection_ContainmentPolicy/passes_through_a_contained_relative_path` pins that, and the pre-existing `internal/fix` suite covers the rest.

**nolint comments** (`repair.go:260,298,331,391`, `fix.go:414,483`) now read `absPath is the path ContainPath validated and confined to root`. The remaining three (`fix.go:323,369,498`) sit on the `fix --all` path and say so: `path comes from a filesystem scan of root, never from a report`. All nine now describe a guard that exists.

### Tests

`cmd/rootline/repair_test.go` — `TestRunRepairApply_PathContainment`, end-to-end through the cobra command:

| Subtest | Spec scenario |
|---|---|
| `RelativeEscapeRejected` | 1 |
| `SetSectionEscapeRejected` | 2 |
| `AbsolutePathRejected` | 3 |
| `DryRunRejectsAndReportsResolvedTargets` | 4 |
| `ContainedSetSectionIsAppliedAndRecorded` | 12 |
| `ResolvedTargetsOmittedOutsideDryRun` | contract check |

Each asserts the JSON result *and* byte-compares the out-of-root file before/after — a rejection that still wrote would pass a result-only assertion.

Scenario 3 uses an absolute path to a temp file rather than the spec's literal `/etc/passwd`; the assertion is about policy refusal of absolute input, and pointing a test at a real system file to prove it was not written is not a trade worth making.

`internal/fix/repair_test.go` — `TestApplyRepair_RejectsEscapingPath`, `TestApplyRepair_RejectsAbsolutePath`, `TestApplySetSection_ContainmentPolicy` at package level.

Eight existing `applySetSection(p, dir, nil)` call sites in `fix_test.go` / `coverage_gaps_test.go` gained the policy argument; no assertions changed.

## Checklist

- [x] Tests pass (`go test ./... -race`) — all 13 packages ok
- [x] Code is clean (`go vet ./...`) — `just check`: gofmt clean, golangci-lint 0 issues, build ok. `just coverage-check`: all packages above the 85% floor, `internal/fix` 88.1%, total 89.1%
- [x] Changes are documented if user-facing — `resolved_targets` is new in dry-run JSON and `rejected[]` now carries containment violations; both explained above. `CLAUDE.md` describes `repair apply` at a level this does not change