### PR TITLE
fix(schema): confine schema apply targets to the scan root

### DIFF
--- a/.claude/skills/rootline/ref-schema.md
+++ b/.claude/skills/rootline/ref-schema.md
@@ -158,6 +158,23 @@ Use these instead of hand-rolling `WalkUp` + `entries[0]` indexing in new comman
 - Post-apply: runs `rootline validate --all` and includes results in output
 - Emits JSON: version 1, kind `"rootline/schema-apply"` with applied/skipped/errors/validation_summary
 
+**Path containment.** Each `create_stem` target is validated with
+`fix.ContainPath(scanRoot, target, fix.PolicyAcceptAbsolute)` before `ScaffoldSchema` runs, and
+`ScaffoldSchema` receives the directory of the *validated* target, not the raw one.
+
+Two deliberate differences from `repair apply`:
+- **Absolute targets are accepted, then confined** (`PolicyAcceptAbsolute`). `schema propose`
+  emits absolute `.stem` targets, so the propose→apply contract needs them to keep working.
+  `repair apply` uses `PolicyRejectAbsolute` because its report paths are root-relative by
+  construction.
+- **Refusals go to `errors[]`, not `rejected[]`.** `schema apply` has no `rejected[]`, so a
+  target outside the root is a validation failure rather than a semantic rejection.
+
+`--dry-run` adds the same additive `resolved_targets: {accepted, rejected}` envelope that
+`repair apply` emits (`fix.ResolvedTargetsBreakdown`); omitted otherwise, contract stays
+version 1. `fix.ContainmentReason(err)` is exported so both apply commands unwrap
+`ContainmentError` through one implementation.
+
 ## Fix All Schema Safety
 
 `fix --all` now applies **data-only repairs** only (correct_value, add_field, migrate_value):

--- a/cmd/rootline/schema.go
+++ b/cmd/rootline/schema.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pablontiv/rootline/internal/derive"
 	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/fix"
 	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/infer"
 	"github.com/pablontiv/rootline/internal/rules"
@@ -55,6 +56,10 @@ type SchemaApplyResult struct {
 	DryRun            bool               `json:"dry_run,omitempty"`
 	Errors            []string           `json:"errors,omitempty"`
 	ValidationSummary *ValidationSummary `json:"validation_summary,omitempty"`
+
+	// ResolvedTargets is populated in dry-run only, where the caller cannot
+	// inspect the outcome on disk and needs to see where each .stem would land.
+	ResolvedTargets *fix.ResolvedTargetsBreakdown `json:"resolved_targets,omitempty"`
 }
 
 // ValidationSummary contains validation results after schema apply.
@@ -257,6 +262,11 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 		scanRoot = absRoot
 	}
 
+	resolved := &fix.ResolvedTargetsBreakdown{
+		Accepted: map[string]string{},
+		Rejected: map[string]string{},
+	}
+
 	// Process each proposal.
 	for _, proposal := range report.Proposals {
 		// Skip proposals that require agent intervention.
@@ -267,13 +277,30 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 
 		// Process based on operation type.
 		if proposal.Operation == "create_stem" {
+			// `schema propose` emits absolute targets under the scan root, so the
+			// propose->apply contract depends on absolute paths staying valid —
+			// they are accepted, then confined.
+			target, err := fix.ContainPath(scanRoot, proposal.Target, fix.PolicyAcceptAbsolute)
+			if err != nil {
+				// A refused target is a validation failure, not a feature gap:
+				// schema apply has no rejected[], so it belongs in errors[].
+				result.Errors = append(result.Errors, err.Error())
+				resolved.Rejected[proposal.Target] = fix.ContainmentReason(err)
+				continue
+			}
+			resolved.Accepted[proposal.Target] = target
+
 			// Create a new .stem file at target.
-			if err := infer.ScaffoldSchema(filepath.Dir(proposal.Target), schemaApplyDryRun); err != nil {
+			if err := infer.ScaffoldSchema(filepath.Dir(target), schemaApplyDryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("scaffold %s: %v", proposal.Target, err))
 			} else {
-				result.Applied = append(result.Applied, fmt.Sprintf("create_stem: %s", proposal.Target))
+				result.Applied = append(result.Applied, fmt.Sprintf("create_stem: %s", target))
 			}
 		}
+	}
+
+	if schemaApplyDryRun {
+		result.ResolvedTargets = resolved
 	}
 
 	// If not dry-run, run validation.

--- a/cmd/rootline/schema_test.go
+++ b/cmd/rootline/schema_test.go
@@ -732,3 +732,200 @@ func TestAnalyzeWorksWithoutSchema(t *testing.T) {
 		t.Errorf("expected kind rootline/analyze, got %v", report["kind"])
 	}
 }
+
+// --- target containment (issue #69) ---
+
+// writeSchemaProposalsReport writes a one-proposal report into root and returns
+// its path. scanRoot is what schema apply confines targets to.
+func writeSchemaProposalsReport(t *testing.T, root, scanRoot, target string) string {
+	t.Helper()
+
+	report := SchemaProposalsReport{
+		Version: 1,
+		Kind:    "rootline/schema-proposals",
+		Path:    scanRoot,
+		Proposals: []SchemaProposal{
+			{
+				ID:           "bootstrap-flat",
+				Operation:    "create_stem",
+				Target:       target,
+				Confidence:   0.85,
+				PatchPreview: "version: 2\nschema:\n  title:\n    type: string\n",
+			},
+		},
+	}
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	reportFile := filepath.Join(root, "report.json")
+	if err := os.WriteFile(reportFile, data, 0o644); err != nil {
+		t.Fatalf("writing report: %v", err)
+	}
+	return reportFile
+}
+
+func decodeSchemaApplyResult(t *testing.T, out string) *SchemaApplyResult {
+	t.Helper()
+
+	var result SchemaApplyResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decoding schema apply result: %v\noutput: %s", err, out)
+	}
+	return &result
+}
+
+func TestSchemaApply_TargetContainment(t *testing.T) {
+	// Scenario 6: schema propose emits absolute targets, so an absolute target
+	// inside the scan root has to keep working — this is the regression guard on
+	// the propose->apply loop, not an edge case.
+	t.Run("AbsoluteTargetInsideRootIsApplied", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		target := filepath.Join(docsDir, ".stem")
+
+		reportFile := writeSchemaProposalsReport(t, root, docsDir, target)
+
+		out, err := executeSchemaApply(t, "--report", reportFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Errors) != 0 {
+			t.Fatalf("errors = %v, want empty", result.Errors)
+		}
+		if len(result.Applied) == 0 {
+			t.Fatal("applied is empty, want the create_stem recorded")
+		}
+		if _, err := os.Stat(target); err != nil {
+			t.Errorf(".stem was not created: %v", err)
+		}
+	})
+
+	// Scenario 7: an absolute target above the scan root.
+	t.Run("AbsoluteTargetOutsideRootIsRejected", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		// One level above the declared scan root.
+		target := filepath.Join(root, "escaped.stem")
+
+		reportFile := writeSchemaProposalsReport(t, root, docsDir, target)
+
+		out, err := executeSchemaApply(t, "--report", reportFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 0 {
+			t.Errorf("applied = %v, want empty", result.Applied)
+		}
+		if len(result.Errors) != 1 {
+			t.Fatalf("errors = %v, want exactly one containment violation", result.Errors)
+		}
+		if !strings.Contains(result.Errors[0], "escapes root") {
+			t.Errorf("error %q does not give the containment reason", result.Errors[0])
+		}
+		if _, err := os.Stat(target); err == nil {
+			t.Error("a .stem was created outside the scan root")
+		}
+	})
+
+	// Scenario 5: the target only escapes once cleaned. filepath.Join(root,
+	// target) would have folded it back inside and reported it as contained.
+	t.Run("TargetEscapingAfterCleanIsRejected", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		target := filepath.Join(docsDir, "..", "..", "outside", ".stem")
+
+		reportFile := writeSchemaProposalsReport(t, root, docsDir, target)
+
+		out, err := executeSchemaApply(t, "--report", reportFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 0 {
+			t.Errorf("applied = %v, want empty", result.Applied)
+		}
+		if len(result.Errors) != 1 {
+			t.Fatalf("errors = %v, want exactly one containment violation", result.Errors)
+		}
+		if _, err := os.Stat(filepath.Clean(target)); err == nil {
+			t.Error("a .stem was created outside the scan root")
+		}
+	})
+
+	t.Run("DryRunReportsResolvedTargets", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		accepted := filepath.Join(docsDir, ".stem")
+		rejected := filepath.Join(root, "escaped.stem")
+
+		report := SchemaProposalsReport{
+			Version: 1,
+			Kind:    "rootline/schema-proposals",
+			Path:    docsDir,
+			Proposals: []SchemaProposal{
+				{ID: "inside", Operation: "create_stem", Target: accepted},
+				{ID: "outside", Operation: "create_stem", Target: rejected},
+			},
+		}
+		data, err := json.Marshal(report)
+		if err != nil {
+			t.Fatalf("marshal report: %v", err)
+		}
+		reportFile := filepath.Join(root, "report.json")
+		if err := os.WriteFile(reportFile, data, 0o644); err != nil {
+			t.Fatalf("writing report: %v", err)
+		}
+
+		out, err := executeSchemaApply(t, "--report", reportFile, "--dry-run")
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		result := decodeSchemaApplyResult(t, out)
+		if result.ResolvedTargets == nil {
+			t.Fatal("resolved_targets is absent, want it populated in dry-run")
+		}
+		if got := result.ResolvedTargets.Accepted[accepted]; got != accepted {
+			t.Errorf("resolved_targets.accepted[%s] = %q, want %q", accepted, got, accepted)
+		}
+		if got := result.ResolvedTargets.Rejected[rejected]; got != "escapes root" {
+			t.Errorf("resolved_targets.rejected[%s] = %q, want %q", rejected, got, "escapes root")
+		}
+		if _, err := os.Stat(rejected); err == nil {
+			t.Error("dry-run created a .stem outside the scan root")
+		}
+	})
+
+	t.Run("ResolvedTargetsOmittedOutsideDryRun", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		reportFile := writeSchemaProposalsReport(t, root, docsDir, filepath.Join(docsDir, ".stem"))
+
+		out, err := executeSchemaApply(t, "--report", reportFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+		}
+
+		if result := decodeSchemaApplyResult(t, out); result.ResolvedTargets != nil {
+			t.Errorf("resolved_targets = %+v, want absent outside dry-run", result.ResolvedTargets)
+		}
+	})
+}

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -163,6 +163,36 @@ rootline schema apply --report proposals.json
 
 Data-only repairs (correct_value, add_field, etc.) are **ignored** — use `rootline repair apply` instead.
 
+**Path containment.** As with `repair apply`, a report is untrusted input: every `create_stem`
+target is checked against the scan root before a `.stem` is written, so a report naming
+`<root>/../../outside/.stem` no longer scaffolds outside the tree the command was pointed at.
+
+`schema propose` emits **absolute** targets, so the propose→apply loop depends on absolute paths
+staying valid — they are accepted and then confined, not refused outright. That is the one
+difference from `repair apply`, which rejects absolute paths as malformed input.
+
+The second difference is where refusals land. `schema apply` has no `rejected[]`, so a target
+outside the root is a validation failure and appears in `errors[]`:
+
+```bash
+rootline schema apply --report proposals.json
+# errors: containment violation: path "/tmp/outside/.stem" escapes root (root "/abs/scan")
+```
+
+With `--dry-run`, the output carries the same additive `resolved_targets` envelope that
+`repair apply` emits, so you can see where each `.stem` would land before writing:
+
+```json
+{
+  "resolved_targets": {
+    "accepted": { "/abs/scan/tasks/.stem": "/abs/scan/tasks/.stem" },
+    "rejected": { "/tmp/outside/.stem": "escapes root" }
+  }
+}
+```
+
+`resolved_targets` is omitted outside dry-run; the contract stays `version: 1`.
+
 Flags:
 - `--dry-run` — Preview changes without modifying files
 - `--report <file>` — Path to proposals JSON file (required)

--- a/internal/fix/contain.go
+++ b/internal/fix/contain.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,16 @@ func (e *ContainmentError) Error() string {
 // single-line because they are embedded verbatim in JSON output.
 func containmentFailure(requested, root, message string) error {
 	return &ContainmentError{Requested: requested, Root: root, Message: message}
+}
+
+// ContainmentReason extracts the bare reason from a containment failure, for
+// output where the offending path is already carried alongside it.
+func ContainmentReason(err error) string {
+	var cerr *ContainmentError
+	if errors.As(err, &cerr) {
+		return cerr.Message
+	}
+	return err.Error()
 }
 
 // ContainPath checks that path resolves to a location inside root and returns

--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -3,7 +3,6 @@ package fix
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -211,7 +210,7 @@ func containProposalPaths(proposals []proposal.Proposal, root string, result *Re
 			// so an absolute path is malformed input rather than a real target.
 			absPath, err := ContainPath(root, path, PolicyRejectAbsolute)
 			if err != nil {
-				rejected[path] = containmentReason(err)
+				rejected[path] = ContainmentReason(err)
 				result.Rejected = append(result.Rejected, err.Error())
 				continue
 			}
@@ -220,16 +219,6 @@ func containProposalPaths(proposals []proposal.Proposal, root string, result *Re
 	}
 
 	return accepted, rejected
-}
-
-// containmentReason extracts the bare reason from a containment failure, for
-// the resolved-targets breakdown where the path is already the map key.
-func containmentReason(err error) string {
-	var cerr *ContainmentError
-	if errors.As(err, &cerr) {
-		return cerr.Message
-	}
-	return err.Error()
 }
 
 // hasRejectedPath reports whether any path of the proposal failed containment.


### PR DESCRIPTION
## What

Enforces target containment in `schema apply`. PR 3 of 3 for #69 — **the last of the chain, so this one carries `Closes #69`.**

Both prerequisites are now on master: the helper landed as #70, and the `repair apply` half landed as #79 (which superseded #74 after its base branch was deleted). This branch has been rebased onto master and retargeted from `feat/report-path-containment-repair` to `master`; it is now a single self-contained commit and can be reviewed on its own.

- `create_stem` targets validated with `ContainPath` under `PolicyAcceptAbsolute` (`cmd/rootline/schema.go:283`)
- Refusals go to `errors[]`
- `--dry-run` reports `resolved_targets`, matching `repair apply`
- `ContainmentReason` exported from `internal/fix` so both apply commands share one unwrapping helper

## Why

`runSchemaApply` passed `proposal.Target` straight to `infer.ScaffoldSchema(filepath.Dir(proposal.Target), ...)` (old `schema.go:271`) with no relation to `report.Path`, the scan root it had already resolved two lines above. A report naming a target above that root scaffolded a `.stem` there:

```json
{"version":1,"kind":"rootline/schema-proposals","path":"<root>/docs",
 "proposals":[{"id":"x","operation":"create_stem",
               "target":"<root>/docs/../../outside/.stem"}]}
```

After: `errors[]` carries the violation, nothing is written outside the root.

Closes #69

## How

**Absolute targets are accepted, then confined — not refused.** This is the one place the two apply commands legitimately differ. `schema propose` emits absolute `.stem` targets (`schema.go:452,472`), so `repair apply`'s `PolicyRejectAbsolute` would break the propose→apply loop outright. `PolicyAcceptAbsolute` cleans the target and requires it to land under `report.Path`. `TestSchemaApply_TargetContainment/AbsoluteTargetInsideRootIsApplied` is the regression guard on that loop and is deliberately the first subtest.

This is also where the naive check fails hardest, and why PR 1 branches on `filepath.IsAbs` before joining. `filepath.Rel(root, filepath.Join(root, "/tmp/.stem"))` returns `tmp/.stem` — contained — for a target naming `/tmp`. Every target here is absolute, so a `Join`-first implementation would have validated nothing at all while looking correct.

**Refusals go to `errors[]`, not a new field.** `SchemaApplyResult` has no `rejected[]`. Adding one to carry a single case would widen the contract for no consumer; a target outside the root is a validation failure and sits naturally beside the `scaffold %s: %v` entries already there. `repair apply` routes to `rejected[]` because that field exists and already means "refused on policy" — the asymmetry follows the two result shapes rather than fighting them.

**`ScaffoldSchema` receives the validated path.** `filepath.Dir(target)` where `target` is `ContainPath`'s return, not `filepath.Dir(proposal.Target)`. The path that passed the check is the path that gets written, same discipline as PR 2's handlers.

**`ContainmentReason` exported** (`internal/fix/contain.go:46`). PR 2 introduced an unexported version for the repair breakdown; `schema.go` needs the same unwrapping, and two copies of an `errors.As` on the same error type is one too many. Moved to `contain.go` next to the error it unwraps.

### Tests

`cmd/rootline/schema_test.go` — `TestSchemaApply_TargetContainment`:

| Subtest | Spec scenario |
|---|---|
| `AbsoluteTargetInsideRootIsApplied` | 6 — propose→apply loop preserved |
| `AbsoluteTargetOutsideRootIsRejected` | 7 |
| `TargetEscapingAfterCleanIsRejected` | 5 |
| `DryRunReportsResolvedTargets` | dry-run contract |
| `ResolvedTargetsOmittedOutsideDryRun` | dry-run contract |

Each rejection subtest `os.Stat`s the would-be target: asserting `errors[]` alone would pass even if the `.stem` had been written anyway.

Pre-existing `TestSchemaApplyCreateStem`, `TestSchemaApplyDryRun`, `TestSchemaApplySkipsRequiresAgent` and the `analyze`-report path pass unchanged.

## Deviations from the approved design, for the reviewer

Two, both in PR 2 and both flagged there — repeating so this stack can be judged as a whole:

1. Write handlers use the absolute path `ContainPath` returned instead of calling `ContainPath` a second time. The unexported handlers are reachable only through `ApplyRepair`, so a second identical call is an unreachable branch, not a layer. `applySetSection` *does* keep its own check because it genuinely has two callers.
2. Task T16 expected `fix.go:321,367,488` to be `fix --all`-only sites. Confirmed by tracing callers; their comments now say `path comes from a filesystem scan of root, never from a report`. All nine `nolint:gosec` sites are updated across PRs 2 and 3.

Actual sizes came in above the design's forecast: 439 / 621 / 238 changed lines against ~320 / ~125 / ~75. The overrun is almost entirely test tables.

## Checklist

- [x] Tests pass (`go test ./... -race`) — all 13 packages ok
- [x] Code is clean (`go vet ./...`) — `just check`: gofmt clean, golangci-lint 0 issues, build ok. `just coverage-check`: all packages above the 85% floor, `cmd/rootline` 86.5%, total 89.1%
- [x] Changes are documented if user-facing — `resolved_targets` is new in dry-run JSON and `errors[]` now carries containment violations. Documented in `docs/fix.md` (containment section under *Schema Mutation*, with the real refusal string and a `resolved_targets` example) and `.claude/skills/rootline/ref-schema.md` (the same contract plus the two deliberate asymmetries against `repair apply`: `PolicyAcceptAbsolute` vs. `PolicyRejectAbsolute`, and `errors[]` vs. `rejected[]`)

## Rebase notes

Rebased onto master with `--onto origin/master 6023aec`, dropping the two commits that already landed (#70 helper, #79 repair). **No conflicts** — the `internal/fix/repair.go` and `internal/fix/contain.go` hunks applied cleanly on top of the squashed #79. `just check` and `just test` both pass; the pre-push coverage gate passed without `--no-verify`.
