### PR TITLE
feat(preflight)!: make schema-boundary discovery answer the same way from every directory

### DIFF
--- a/cmd/rootline/describe.go
+++ b/cmd/rootline/describe.go
@@ -26,6 +26,31 @@ func init() {
 	rootCmd.AddCommand(describeCmd)
 }
 
+// noSchemaGovernsError restates ErrNoSchemaFound as the condition the user hit
+// rather than the step that was running, while staying the same error to code
+// that tests for it with errors.Is.
+type noSchemaGovernsError struct{ cause error }
+
+func (e *noSchemaGovernsError) Error() string {
+	return "no schema governs this path; run 'rootline init <path>' to create one"
+}
+
+func (e *noSchemaGovernsError) Unwrap() error { return e.cause }
+
+// describeSchemaError turns a discovery failure into the answer describe owes
+// the user.
+//
+// describe prints a resolved schema, so it must still fail when there is none —
+// but "discovering .stem files: ..." named the internal step instead of the
+// condition, which reads as a fault in rootline rather than an answer about the
+// tree. A real IO or parse failure is a different answer and keeps its cause.
+func describeSchemaError(err error) error {
+	if rules.IsRealSchemaError(err) {
+		return fmt.Errorf("resolving .stem: %w", err)
+	}
+	return &noSchemaGovernsError{cause: err}
+}
+
 func runDescribe(cmd *cobra.Command, args []string) error {
 	targetPath, err := filepath.Abs(args[0])
 	if err != nil {
@@ -42,7 +67,7 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 		dir := filepath.Dir(targetPath)
 		entries, err = rules.WalkUp(dir)
 		if err != nil {
-			return fmt.Errorf("discovering .stem files: %w", err)
+			return describeSchemaError(err)
 		}
 		effective, err = rules.ResolveForRecord(dir, args[0])
 		if err != nil {
@@ -52,7 +77,7 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 		// Directory (or non-existent path): use existing merge without levels.
 		entries, err = rules.WalkUp(targetPath)
 		if err != nil {
-			return fmt.Errorf("discovering .stem files: %w", err)
+			return describeSchemaError(err)
 		}
 		effective = rules.MergeStemFiles(entries)
 	}

--- a/cmd/rootline/describe_test.go
+++ b/cmd/rootline/describe_test.go
@@ -307,3 +307,29 @@ func TestDescribeErrorPropagation_NoSchema(t *testing.T) {
 		t.Fatalf("describe should fail when no schema is found, but got nil error (silent degradation)")
 	}
 }
+
+// TestDescribe_SchemaMissingMessage keeps the failure but fixes what it says.
+//
+// describe prints a resolved schema, so it must still fail when there is none.
+// The old text ("discovering .stem files: ...") named the step that was running
+// rather than the condition the user hit, which reads as an internal fault
+// instead of an answer.
+func TestDescribe_SchemaMissingMessage(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("---\n---\n# A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, target := range []string{dir, filepath.Join(dir, "a.md")} {
+		_, err := executeDescribe(t, target)
+		if err == nil {
+			t.Fatalf("describe(%s) must fail without a schema", target)
+		}
+		if !strings.Contains(err.Error(), "no schema governs this path") {
+			t.Errorf("describe(%s): expected the schema-governance message, got: %v", target, err)
+		}
+		if strings.Contains(err.Error(), "discovering .stem files") {
+			t.Errorf("describe(%s): the internal discovery step leaked into the message: %v", target, err)
+		}
+	}
+}

--- a/cmd/rootline/explain.go
+++ b/cmd/rootline/explain.go
@@ -34,8 +34,16 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolving path: %w", err)
 	}
 
-	if _, err := os.Stat(absPath); err != nil {
+	// A directory otherwise reaches the extractor registry as an unrecognised
+	// file type and comes back as "no extractor for <dir>". explain traces one
+	// document and has no --all to offer, so the message names the argument
+	// shape it does accept.
+	info, err := os.Stat(absPath)
+	if err != nil {
 		return fmt.Errorf("file not found: %s", file)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory; use 'rootline explain <file>'", file)
 	}
 
 	// Extract record.

--- a/cmd/rootline/explain_unit_test.go
+++ b/cmd/rootline/explain_unit_test.go
@@ -97,3 +97,24 @@ func TestExplainErrorPropagation_NoSchema(t *testing.T) {
 		t.Fatalf("explain should fail when no schema is found, but got nil error (silent degradation)")
 	}
 }
+
+// TestExplain_DirectoryArgumentError mirrors validate's directory message.
+//
+// explain traces one document, and has no --all to point at, so the message
+// names the argument shape it does accept rather than a flag.
+func TestExplain_DirectoryArgumentError(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":     "version: 2\nscope:\n  match: \"*.md\"\n",
+		"docs/a.md": "---\ntitulo: x\n---\n# x\n",
+	})
+	target := filepath.Join(root, "docs")
+
+	_, err := runCmd(t, "explain", target)
+	if err == nil {
+		t.Fatal("explain must reject a directory argument")
+	}
+	want := target + " is a directory; use 'rootline explain <file>'"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}

--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -79,9 +79,14 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load .stem schema: filter links and read the cycle-failure opt-in.
+	//
+	// A missing .stem is not a missing graph. The schema only decides which
+	// link styles are governed and whether cycles fail a check, so without one
+	// the links stay unfiltered and cycles stay informational — the nil stem
+	// below already expresses exactly that.
 	failCycles := false
 	entries, err := rules.WalkUp(absRoot)
-	if err != nil {
+	if rules.IsRealSchemaError(err) {
 		return fmt.Errorf("discovering schema for link filtering: %w", err)
 	}
 	stem := rules.MergeStemFiles(entries)

--- a/cmd/rootline/graph_test.go
+++ b/cmd/rootline/graph_test.go
@@ -662,27 +662,41 @@ func TestGraphJSON_QuietCycles_CyclesPopulated(t *testing.T) {
 	}
 }
 
-// TEST-FIRST: Graph command should fail (non-zero exit) when schema resolution fails
-// This test will FAIL under current behavior because graph silently degrades
-// when WalkUp returns an error (line 83-89 in graph.go checks err == nil).
-func TestGraphErrorPropagation_NoSchema(t *testing.T) {
+// schemalessLinkTree builds a tree of linked documents with no .stem anywhere.
+func schemalessLinkTree(t *testing.T, target string) string {
+	t.Helper()
 	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a.md"), []byte("---\n---\n# A\n[["+target+"]]\n"), 0644)
+	mustWriteFile(t, filepath.Join(dir, "b.md"), []byte("---\n---\n# B\n"), 0644)
+	return dir
+}
 
-	// Create a markdown file with links WITHOUT a .stem anywhere in the tree
-	// This will cause WalkUp to return ErrNoSchemaFound
-	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("---\n---\n# A\n[[b.md]]\n"), 0644); err != nil {
-		t.Fatal(err)
+// TestGraph_SchemalessEmitsGraph replaces TestGraphErrorPropagation_NoSchema,
+// which asserted the opposite.
+//
+// A .stem governs which link styles graph reads and whether cycles fail a
+// check. Its absence removes those restrictions; it does not remove the links.
+// Refusing to draw the graph withheld the one view that helps someone decide
+// where the schema should go, so a tree with no .stem now yields the whole
+// extracted graph rather than a discovery error.
+func TestGraph_SchemalessEmitsGraph(t *testing.T) {
+	dir := schemalessLinkTree(t, "b.md")
+
+	out, err := runCmd(t, "graph", dir)
+	if err != nil {
+		t.Fatalf("graph must tolerate a tree with no .stem, got: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "b.md"), []byte("---\n---\n# B\n"), 0644); err != nil {
-		t.Fatal(err)
+
+	var result map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", jsonErr, out)
 	}
-
-	// Run graph on a directory with no schema
-	_, err := runCmd(t, "graph", dir)
-
-	// EXPECTATION: graph should exit with an error, not silently produce a graph without link schema
-	if err == nil {
-		t.Fatalf("graph should fail when no schema is found, but got nil error (silent degradation)")
+	if result["kind"] != "rootline/graph" {
+		t.Errorf("kind = %v, want rootline/graph", result["kind"])
+	}
+	edges, _ := result["edges"].([]any)
+	if len(edges) != 1 {
+		t.Errorf("edges = %d, want 1 (the a.md -> b.md link is still there)", len(edges))
 	}
 }
 
@@ -846,4 +860,32 @@ func TestGraphEdgeOrder(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestGraph_CheckOnSchemalessReportsIntegrity keeps --check answering the
+// question it was asked. Link integrity does not depend on a schema, so on a
+// tree with no .stem the exit code must report broken links and nothing else.
+func TestGraph_CheckOnSchemalessReportsIntegrity(t *testing.T) {
+	t.Run("broken link fails the check", func(t *testing.T) {
+		dir := schemalessLinkTree(t, "no-such-file")
+
+		out, err := runCmd(t, "graph", dir, "--check")
+		if err == nil {
+			t.Fatalf("--check must fail on a broken link\noutput: %s", out)
+		}
+		if !strings.Contains(out, "Broken links: 1") {
+			t.Errorf("expected the broken-link report, got: %s", out)
+		}
+		if strings.Contains(err.Error(), "schema") {
+			t.Errorf("the failure must be about links, not schema discovery: %v", err)
+		}
+	})
+
+	t.Run("valid links pass the check", func(t *testing.T) {
+		dir := schemalessLinkTree(t, "b.md")
+
+		if _, err := runCmd(t, "graph", dir, "--check"); err != nil {
+			t.Fatalf("--check must pass when every link resolves, got: %v", err)
+		}
+	})
 }

--- a/cmd/rootline/preflight.go
+++ b/cmd/rootline/preflight.go
@@ -74,20 +74,31 @@ func boundaryPreflight(cmd *cobra.Command, args []string) error {
 
 	entries, err := rules.WalkUp(target)
 	if err != nil {
-		// A tree with no .stem at all is not a broken project. Governed
-		// commands reject it in their own context and bootstrap commands are
-		// allowed to work on one, so pass that case through.
-		if errors.Is(err, rules.ErrNoSchemaFound) {
-			return nil
+		if !errors.Is(err, rules.ErrNoSchemaFound) {
+			// A real IO or parse failure, and this is the only place that sees
+			// every governed command. `query` and `stats` never resolve a
+			// schema on their own — query does so only under --sort and neither
+			// passes a scope resolver — so without failing here a corrupt .stem
+			// is invisible to them: they return records from a tree whose
+			// governance is broken and report success.
+			return err
 		}
 
-		// Anything else is a real IO or parse failure, and this is the only
-		// place that sees every governed command. `query` and `stats` never
-		// resolve a schema on their own — query does so only under --sort and
-		// neither passes a scope resolver — so without failing here a corrupt
-		// .stem is invisible to them: they return records from a tree whose
-		// governance is broken and report success.
-		return err
+		// Nothing governs the target from above, but the walk only looked one
+		// way. The same tree used to pass from one directory and fail from
+		// another that happened to sit above the only .stem, so ask the
+		// question downward too — whether a project declares where it starts is
+		// a property of the tree, not of the directory that was named.
+		entries, err = rules.DownwardScan(target)
+		if err != nil {
+			return err
+		}
+		// No .stem anywhere below either: the tree is ungoverned, not
+		// misgoverned. Governed commands reject it in their own context and
+		// bootstrap commands are allowed to work on one, so pass it through.
+		if len(entries) == 0 {
+			return nil
+		}
 	}
 
 	if !rules.ChainHasNoDeclaredBoundary(entries) {

--- a/cmd/rootline/preflight.go
+++ b/cmd/rootline/preflight.go
@@ -10,11 +10,20 @@ import (
 )
 
 // commandsExemptFromBoundaryPreflight lists commands that must run even when no
-// governance boundary is declared.
+// governance boundary is declared. They fall into two categories.
 //
-// `init` and `schema` create the very .stem files the preflight asks for, so
-// gating them on a declared boundary would be circular. The rest do not resolve
-// schemas at all.
+// Schema-creating — `init` and `schema` write the very .stem files the preflight
+// asks for, so gating them on a declared boundary would be circular.
+//
+// Schema-independent — `completion`, `hooks`, `help` and `migrate` resolve no
+// schema at all, and neither does `analyze`: it infers a schema from the
+// documents themselves. Gating it would block the one command that can tell an
+// ungoverned tree what its schema should be, and it is the entry point of the
+// `analyze --incremental` -> `schema apply` loop whose other end is already
+// exempt. This is not a general "read-only is safe" rule: `query` and `stats`
+// stay governed, because they skip schema resolution voluntarily and would
+// otherwise report records governed by .stem files collected from outside an
+// undeclared project.
 var commandsExemptFromBoundaryPreflight = map[string]bool{
 	"init":       true,
 	"schema":     true,
@@ -22,6 +31,7 @@ var commandsExemptFromBoundaryPreflight = map[string]bool{
 	"hooks":      true,
 	"help":       true,
 	"migrate":    true,
+	"analyze":    true,
 }
 
 // isExemptFromBoundaryPreflight reports whether cmd, or any command it hangs

--- a/cmd/rootline/preflight_test.go
+++ b/cmd/rootline/preflight_test.go
@@ -1,11 +1,32 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// unmarkedStemTree builds a project that has a .stem but never declares where
+// the project starts — the exact shape the boundary preflight rejects.
+func unmarkedStemTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	wiki := filepath.Join(root, "wiki")
+	if err := os.MkdirAll(wiki, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wiki, ".stem"),
+		[]byte("version: 2\nscope:\n  match: \"*.md\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wiki, "a.md"),
+		[]byte("---\nestado: Pending\n---\n# A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
 
 // brokenStemTree builds a project whose .stem cannot be parsed.
 func brokenStemTree(t *testing.T) string {
@@ -107,5 +128,51 @@ func TestPreflight_MissingSchemaIsLeftToTheCommand(t *testing.T) {
 	resetFlags()
 	if _, err := runCmd(t, "schema", "propose", root); err != nil {
 		t.Fatalf("schema propose must work without a .stem, got: %v", err)
+	}
+}
+
+// TestPreflight_AnalyzeExemptionWorks covers the second exemption category.
+//
+// `analyze` infers a schema from the documents themselves and resolves no
+// .stem at all, so gating it on a declared boundary blocks the one command
+// that could tell an ungoverned tree what its schema should be. It is the
+// entry point of the `analyze --incremental` -> `schema apply` loop, and
+// `schema propose` — its sibling on the same loop — is already exempt.
+func TestPreflight_AnalyzeExemptionWorks(t *testing.T) {
+	root := unmarkedStemTree(t)
+
+	out, err := runCmd(t, "analyze", filepath.Join(root, "wiki"))
+	if err != nil {
+		t.Fatalf("analyze must stay exempt on an unmarked .stem tree, got: %v", err)
+	}
+
+	var report map[string]any
+	if jsonErr := json.Unmarshal([]byte(out), &report); jsonErr != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", jsonErr, out)
+	}
+	if report["kind"] != "rootline/analyze" {
+		t.Errorf("kind = %v, want rootline/analyze", report["kind"])
+	}
+}
+
+// TestPreflight_QueryStatsNotExempt pins the boundary of the exemption.
+//
+// `query` and `stats` skip schema resolution voluntarily, not because they are
+// schema-independent: an unmarked chain may have collected .stem files from
+// outside the project, and both would happily report records governed by them.
+// Widening the exemption to cover them is the accident this test prevents.
+func TestPreflight_QueryStatsNotExempt(t *testing.T) {
+	for _, cmd := range []string{"query", "stats"} {
+		t.Run(cmd, func(t *testing.T) {
+			root := unmarkedStemTree(t)
+
+			out, err := runCmd(t, cmd, filepath.Join(root, "wiki"))
+			if err == nil {
+				t.Fatalf("%s must stay governed by the preflight\noutput: %s", cmd, out)
+			}
+			if !strings.Contains(err.Error(), "declared boundary") {
+				t.Errorf("expected the boundary error, got: %v", err)
+			}
+		})
 	}
 }

--- a/cmd/rootline/preflight_test.go
+++ b/cmd/rootline/preflight_test.go
@@ -176,3 +176,112 @@ func TestPreflight_QueryStatsNotExempt(t *testing.T) {
 		})
 	}
 }
+
+// writeTree materialises a fixture from relative path -> content.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		abs := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestPreflight_TreeScopedDownscan_FindsUnmarkedStem is the defect from #65.
+//
+// Whether a project declares where it starts is a property of the tree, but the
+// preflight only ever looked upward from the target, so the same tree answered
+// differently depending on which directory you named: `validate --all wiki`
+// walked up, found nothing, and passed, while `validate --all wiki/entities`
+// found the unmarked .stem and failed. Three commands, one tree, two verdicts.
+func TestPreflight_TreeScopedDownscan_FindsUnmarkedStem(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"wiki/.stem":          "version: 2\nscope:\n  match: \"*.md\"\n",
+		"wiki/entities/.stem": "version: 2\nscope:\n  match: \"*.md\"\n",
+		"wiki/entities/a.md":  "---\ntitulo: x\n---\n# x\n",
+	})
+
+	for _, target := range []string{root, filepath.Join(root, "wiki"), filepath.Join(root, "wiki", "entities")} {
+		out, err := runCmd(t, "validate", "--all", target)
+		if err == nil {
+			t.Fatalf("validate --all %s must report the undeclared boundary\noutput: %s", target, out)
+		}
+		if !strings.Contains(err.Error(), "declared boundary") {
+			t.Errorf("validate --all %s: expected the boundary error, got: %v", target, err)
+		}
+	}
+}
+
+// TestPreflight_TreeScopedDownscan_NoStemFound keeps the two conditions apart.
+// A tree with no .stem at all is ungoverned, not misgoverned: there is no
+// boundary to declare, so the preflight must pass it through and let the
+// command answer in its own terms.
+func TestPreflight_TreeScopedDownscan_NoStemFound(t *testing.T) {
+	root := writeTree(t, map[string]string{"a.md": "---\ntitulo: x\n---\n# x\n"})
+
+	_, err := runCmd(t, "validate", "--all", root)
+	if err == nil {
+		t.Fatal("validate --all must still fail on a tree it cannot validate")
+	}
+	if strings.Contains(err.Error(), "declared boundary") {
+		t.Errorf("an ungoverned tree must not be reported as an undeclared boundary: %v", err)
+	}
+}
+
+// TestPreflight_TreeScopedDownscan_RootMarkerBelowTargetPasses guards the scan
+// against over-reach. A .stem that declares root: true has said where its
+// project starts; scanning from a directory above it must not reopen that
+// question, and must not descend past it looking for one.
+func TestPreflight_TreeScopedDownscan_RootMarkerBelowTargetPasses(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"wiki/.stem":          "version: 2\nroot: true\nscope:\n  match: \"*.md\"\n",
+		"wiki/entities/.stem": "version: 2\nscope:\n  match: \"*.md\"\n",
+		"wiki/entities/a.md":  "---\ntitulo: x\n---\n# x\n",
+	})
+
+	if _, err := runCmd(t, "tree", root); err != nil &&
+		strings.Contains(err.Error(), "declared boundary") {
+		t.Fatalf("a declared boundary below the target must be honoured, got: %v", err)
+	}
+}
+
+// TestPreflight_TreeScopedDownscan_UnparseableStemFails extends the guarantee
+// the upward walk already gave. A .stem that cannot be parsed is broken
+// governance wherever it sits, and the scan must report it rather than collect
+// around it.
+func TestPreflight_TreeScopedDownscan_UnparseableStemFails(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"wiki/.stem": "version: 2\nscope:\n  match: [[[unclosed\n",
+		"wiki/a.md":  "---\ntitulo: x\n---\n# x\n",
+	})
+
+	_, err := runCmd(t, "tree", root)
+	if err == nil {
+		t.Fatal("an unparseable .stem below the target must fail the preflight")
+	}
+	if !strings.Contains(err.Error(), "parsing") {
+		t.Errorf("expected the parse failure to be reported, got: %v", err)
+	}
+}
+
+// TestPreflight_TreeScopedDownscan_StemignoreRespected keeps the scan inside
+// the same universe as every other traversal. A .stem the project has excluded
+// is not governing anything, so it cannot be the reason a command is refused.
+func TestPreflight_TreeScopedDownscan_StemignoreRespected(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"docs/.stemignore":  "nested/.stem\n",
+		"docs/nested/.stem": "version: 2\nscope:\n  match: \"*.md\"\n",
+		"docs/nested/a.md":  "---\ntitulo: x\n---\n# x\n",
+	})
+
+	_, err := runCmd(t, "tree", filepath.Join(root, "docs"))
+	if err != nil && strings.Contains(err.Error(), "declared boundary") {
+		t.Fatalf("an ignored .stem must not raise a boundary error: %v", err)
+	}
+}

--- a/cmd/rootline/tree.go
+++ b/cmd/rootline/tree.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -102,6 +103,17 @@ func runTree(cmd *cobra.Command, args []string) error {
 		return rules.MergeStemFiles(entries), nil
 	}
 	records, err := index.Scan(ctx, absRoot, reg, index.WithScopeResolver(resolver))
+	if errors.Is(err, rules.ErrNoSchemaFound) {
+		// Nothing under absRoot resolved a schema. There is no scope to filter
+		// by and no governance to report, but the directory still has a shape,
+		// and tree describes structure rather than returning a verdict about
+		// it — so it renders what is there instead of refusing.
+		//
+		// This retry is deliberately narrower than passing AllowUngoverned
+		// outright: as soon as one record IS governed, the scan above keeps its
+		// scope filtering, and files outside every .stem's reach stay excluded.
+		records, err = index.Scan(ctx, absRoot, reg, index.WithScopeResolver(resolver), index.AllowUngoverned())
+	}
 	if err != nil {
 		return fmt.Errorf("scanning %s: %w", scanRoot, err)
 	}

--- a/cmd/rootline/tree_test.go
+++ b/cmd/rootline/tree_test.go
@@ -619,27 +619,35 @@ func TestTreeCmd_WhereMultiple(t *testing.T) {
 	}
 }
 
-// TEST-FIRST: Tree command should fail (non-zero exit) when schema resolution fails
-// This test will FAIL under current behavior if tree's resolver doesn't properly
-// propagate WalkUp errors to index.Scan
-func TestTreeErrorPropagation_NoSchema(t *testing.T) {
+// TestTree_SchemalessToleratesMissing replaces TestTreeErrorPropagation_NoSchema,
+// which asserted the opposite.
+//
+// tree renders a directory hierarchy and whatever frontmatter it finds. A .stem
+// only tells it which field to show as a status, so its absence narrows the
+// output rather than invalidating it — the same tolerance `query` already has
+// on the same tree.
+func TestTree_SchemalessToleratesMissing(t *testing.T) {
 	dir := t.TempDir()
-
-	// Create a markdown file WITHOUT a .stem anywhere in the tree
-	// This will cause WalkUp to return ErrNoSchemaFound
-	if err := os.WriteFile(filepath.Join(dir, "doc1.md"), []byte("---\nstatus: Pending\n---\n# Doc1\n"), 0644); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "doc2.md"), []byte("---\nstatus: Completed\n---\n# Doc2\n"), 0644); err != nil {
-		t.Fatal(err)
+	mustWriteFile(t, filepath.Join(dir, "doc1.md"), []byte("---\nstatus: Pending\n---\n# Doc1\n"), 0644)
+	mustWriteFile(t, filepath.Join(dir, "sub", "doc2.md"), []byte("---\nstatus: Completed\n---\n# Doc2\n"), 0644)
+
+	out, err := runCmd(t, "tree", dir)
+	if err != nil {
+		t.Fatalf("tree must tolerate a tree with no .stem, got: %v", err)
 	}
 
-	// Run tree on a directory with no schema
-	_, err := runCmd(t, "tree", dir)
-
-	// EXPECTATION: tree should fail when no schema is found, not silently build a tree
-	if err == nil {
-		t.Fatalf("tree should fail when no schema is found, but got nil error (silent degradation)")
+	var result TreeResult
+	if jsonErr := json.Unmarshal([]byte(out), &result); jsonErr != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", jsonErr, out)
+	}
+	if result.Root == nil {
+		t.Fatal("root node missing")
+	}
+	if result.Root.Total != 2 {
+		t.Errorf("total = %d, want 2 (both documents are still indexed)", result.Root.Total)
 	}
 }
 

--- a/cmd/rootline/validate.go
+++ b/cmd/rootline/validate.go
@@ -68,9 +68,16 @@ func runValidateFiles(cmd *cobra.Command, files []string) error {
 			return fmt.Errorf("resolving path %s: %w", file, err)
 		}
 
-		// Check file exists
-		if _, err := os.Stat(absPath); err != nil {
+		// Check the path exists and is a file. A directory otherwise reaches the
+		// extractor registry as an unrecognised file type and comes back as
+		// "no extractor for <dir>", which describes a missing file type and
+		// hides the flag that actually handles directories.
+		info, err := os.Stat(absPath)
+		if err != nil {
 			return fmt.Errorf("file not found: %s", file)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory; use 'rootline validate --all %s'", file, file)
 		}
 
 		// Check extractor exists

--- a/cmd/rootline/validate_test.go
+++ b/cmd/rootline/validate_test.go
@@ -629,3 +629,30 @@ func TestValidateAll_HardErrorDriftDetection(t *testing.T) {
 		t.Fatalf("expected error during drift detection when .stem is unparseable, got success\noutput: %s", stdout)
 	}
 }
+
+// TestValidate_DirectoryArgumentError names the mistake instead of its
+// consequence.
+//
+// `validate docs` is a plausible thing to type — `--all` is the flag that is
+// easy to forget — and the answer was "no extractor for docs", which describes
+// an extractor-registry miss and sends the reader looking for a missing file
+// type. The directory is the actual condition, and the flag that handles it is
+// one word away.
+func TestValidate_DirectoryArgumentError(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":        "version: 2\nscope:\n  match: \"*.md\"\n",
+		"docs/a.md":    "---\ntitulo: x\n---\n# x\n",
+		"docs/b.md":    "---\ntitulo: y\n---\n# y\n",
+		"CHANGELOG.md": "---\ntitulo: z\n---\n# z\n",
+	})
+	target := filepath.Join(root, "docs")
+
+	_, err := runCmd(t, "validate", target)
+	if err == nil {
+		t.Fatal("validate must reject a directory argument")
+	}
+	want := target + " is a directory; use 'rootline validate --all " + target + "'"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}

--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -54,6 +54,14 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string) (*Repa
 
 	for path := range affectedPaths {
 		absPath := filepath.Join(root, path)
+		// A directory otherwise reaches os.ReadFile and comes back as
+		// "read docs: is a directory" — the syscall that tripped over the path
+		// rather than an answer about the report. Repair takes document paths.
+		if info, statErr := os.Stat(absPath); statErr == nil && info.IsDir() {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("%s is a directory; use 'rootline repair apply --report <file>.json'", path))
+			continue
+		}
 		content, err := os.ReadFile(absPath)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("read %s: %v", path, err))

--- a/internal/fix/repair_test.go
+++ b/internal/fix/repair_test.go
@@ -296,3 +296,41 @@ func contains(s, substr string) bool {
 	}
 	return false
 }
+
+// TestApplyRepair_DirectoryPathReported keeps the message about the path rather
+// than the syscall that tripped over it.
+//
+// A proposal path that names a directory reached os.ReadFile and came back as
+// "read docs: is a directory" — an internal failure rather than an answer about
+// the report. The repair surface takes document paths, and the flag that takes
+// a file is worth naming.
+func TestApplyRepair_DirectoryPathReported(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	proposals := []proposal.Proposal{
+		{
+			Type:        proposal.CorrectValue,
+			Field:       "estado",
+			Description: "correct typo",
+			Paths:       []string{"docs"},
+			From:        "Inprogres",
+			To:          "In Progress",
+		},
+	}
+
+	result, err := ApplyRepair(proposals, false, tmpDir)
+	if err != nil {
+		t.Fatalf("ApplyRepair failed: %v", err)
+	}
+
+	want := "docs is a directory; use 'rootline repair apply --report <file>.json'"
+	if len(result.Errors) != 1 || result.Errors[0] != want {
+		t.Errorf("errors = %v, want [%q]", result.Errors, want)
+	}
+	if len(result.Changed) != 0 {
+		t.Errorf("changed = %v, want none", result.Changed)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -33,14 +33,19 @@ type scanConfig struct {
 
 // AllowUngoverned lets a scan read documents in a tree where no .stem resolves.
 //
-// It exists for the bootstrap commands only. `schema propose` and `analyze`
-// derive a schema FROM documents that do not have one yet, so demanding a
-// resolved schema before reading them would make them useless for their only
-// purpose — you cannot require a schema as the precondition for creating one.
+// Two kinds of command need it. The bootstrap commands — `schema propose` and
+// `analyze` — derive a schema FROM documents that do not have one yet, so
+// demanding a resolved schema before reading them would make them useless for
+// their only purpose: you cannot require a schema as the precondition for
+// creating one. `tree` needs it for a different reason — it reports the shape
+// of a directory rather than a verdict about it — but only once a governed scan
+// has already come back with nothing, so that a tree which does govern some of
+// its records keeps its scope filtering.
 //
 // It tolerates a MISSING schema, never a broken one: hard read and parse errors
-// still abort the scan. Governed commands must not use it, because succeeding
-// over zero governed records is exactly the false green this change removes.
+// still abort the scan. Commands that return a verdict must not use it, because
+// succeeding over zero governed records is exactly the false green this option
+// must never produce.
 func AllowUngoverned() ScanOption {
 	return func(c *scanConfig) { c.allowUngoverned = true }
 }

--- a/internal/rules/discovery.go
+++ b/internal/rules/discovery.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -120,6 +121,151 @@ func WalkUp(targetPath string) ([]StemEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// DownwardScan collects every .stem at or below targetPath that has not
+// declared, and is not covered by, a governance boundary.
+//
+// WalkUp answers "what governs this path", which is enough to resolve a schema
+// but not to judge one: it looks only upward, so the same tree could pass from
+// one directory and fail from another that happened to sit above the only
+// .stem. Whether a project declares where it starts is a property of the tree,
+// so the question has to be asked downward too.
+//
+// A .stem carrying root: true has already answered it. Its subtree is governed
+// and is skipped whole — reporting the stems below a declared boundary as
+// undeclared would be the same mistake in the other direction.
+//
+// Return semantics mirror the tree, not the walk:
+//   - entries (non-empty): every ungoverned .stem, root-most first
+//   - nil, nil: nothing left undeclared, including the tree with no .stem at
+//     all, which is ungoverned rather than misgoverned
+//   - error: a .stem that cannot be read or parsed, reported where it is found
+//     instead of collected around
+//
+// The traversal shares index.Scan's universe — it honours .stemignore and never
+// enters .git — because a file the project has excluded governs nothing and
+// cannot be the reason a command is refused. filepath.WalkDir orders entries
+// lexically and stats with Lstat, so the result is deterministic and symlinks
+// are not followed out of the subtree.
+func DownwardScan(targetPath string) ([]StemEntry, error) {
+	absTarget, err := filepath.Abs(targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	scanRoot := absTarget
+	if info, statErr := os.Lstat(absTarget); statErr == nil && !info.IsDir() {
+		scanRoot = filepath.Dir(absTarget)
+	}
+
+	var entries []StemEntry
+	var ignores []stemIgnoreScope
+
+	walkErr := filepath.WalkDir(scanRoot, func(dir string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// An unreadable directory is not a governance verdict. A target
+			// that does not exist belongs to the command that was given it.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil //nolint:nilerr // absence and unreadability are the caller's to report
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if d.Name() == ".git" && dir != scanRoot {
+			return fs.SkipDir
+		}
+
+		if patterns, loadErr := parseStemIgnore(filepath.Join(dir, ".stemignore")); loadErr == nil {
+			ignores = append(ignores, stemIgnoreScope{dir: dir, patterns: patterns})
+		}
+
+		stemPath := filepath.Join(dir, stemFileName)
+		info, statErr := os.Lstat(stemPath)
+		if statErr != nil || info.IsDir() {
+			return nil
+		}
+		if stemIsIgnored(stemPath, ignores) {
+			return nil
+		}
+
+		content, readErr := os.ReadFile(stemPath)
+		if readErr != nil {
+			return readErr
+		}
+		stem, parseErr := ParseStem(stemPath, content)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		if stem.Root {
+			return fs.SkipDir
+		}
+		entries = append(entries, StemEntry{Path: stemPath, Stem: stem})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	return entries, nil
+}
+
+// stemIgnoreScope holds the patterns of one .stemignore and the directory they
+// apply to.
+type stemIgnoreScope struct {
+	dir      string
+	patterns []string
+}
+
+// parseStemIgnore reads a .stemignore, dropping blanks and comments. A missing
+// file is reported as an error so callers simply skip it.
+func parseStemIgnore(path string) ([]string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var patterns []string
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+	return patterns, nil
+}
+
+// stemIsIgnored matches absPath against every .stemignore that covers it, by
+// base name and by path relative to the ignoring directory.
+//
+// This mirrors internal/index, which cannot be imported here: it already
+// depends on this package, and inverting that would make the schema domain
+// depend on the scanner that reads it.
+func stemIsIgnored(absPath string, scopes []stemIgnoreScope) bool {
+	name := filepath.Base(absPath)
+	for _, scope := range scopes {
+		// Compare with a separator so /sub never covers /sub-extra.
+		if absPath != scope.dir && !strings.HasPrefix(absPath, scope.dir+string(filepath.Separator)) {
+			continue
+		}
+		relFromIgnore, err := filepath.Rel(scope.dir, absPath)
+		if err != nil {
+			continue
+		}
+		for _, pattern := range scope.patterns {
+			if matched, _ := filepath.Match(pattern, name); matched {
+				return true
+			}
+			if matched, _ := filepath.Match(pattern, relFromIgnore); matched {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // IsRealSchemaError reports whether err is a genuine IO or parse failure rather

--- a/internal/rules/discovery.go
+++ b/internal/rules/discovery.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,6 +120,18 @@ func WalkUp(targetPath string) ([]StemEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// IsRealSchemaError reports whether err is a genuine IO or parse failure rather
+// than the absence of a schema.
+//
+// WalkUp reports ErrNoSchemaFound and a real failure through the same channel,
+// but they are not the same answer: a tree with no .stem is ungoverned, while
+// one whose .stem cannot be read or parsed is broken. Commands that can still
+// do useful work without a schema use this to tell the two apart instead of
+// treating every non-nil error as fatal.
+func IsRealSchemaError(err error) bool {
+	return err != nil && !errors.Is(err, ErrNoSchemaFound)
 }
 
 // ChainHasNoDeclaredBoundary checks if the walk terminated at the filesystem root

--- a/internal/rules/downward_test.go
+++ b/internal/rules/downward_test.go
@@ -1,0 +1,194 @@
+package rules
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// downwardTree materialises a fixture from relative path -> content.
+func downwardTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		abs := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// relStemDirs reduces entries to their directories relative to root, so the
+// assertions read as tree shapes rather than temp paths.
+func relStemDirs(t *testing.T, root string, entries []StemEntry) []string {
+	t.Helper()
+	dirs := make([]string, 0, len(entries))
+	for _, e := range entries {
+		rel, err := filepath.Rel(root, filepath.Dir(e.Path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		dirs = append(dirs, rel)
+	}
+	return dirs
+}
+
+func TestDownwardScan_CollectsEveryUnmarkedStemRootMostFirst(t *testing.T) {
+	root := downwardTree(t, map[string]string{
+		"wiki/.stem":          "version: 2\n",
+		"wiki/entities/.stem": "version: 2\n",
+		"zeta/.stem":          "version: 2\n",
+	})
+
+	entries, err := DownwardScan(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := relStemDirs(t, root, entries)
+	want := []string{"wiki", filepath.Join("wiki", "entities"), "zeta"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("dirs = %v, want %v (root-most first, then lexical)", got, want)
+	}
+}
+
+// A tree with no .stem is ungoverned, not broken: the absence is the answer,
+// so it must not surface as an error the caller has to special-case.
+func TestDownwardScan_NoStemIsNotAnError(t *testing.T) {
+	root := downwardTree(t, map[string]string{"a.md": "# a\n"})
+
+	entries, err := DownwardScan(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("entries = %v, want none", relStemDirs(t, root, entries))
+	}
+}
+
+// A .stem that declares root: true has already answered where its project
+// starts. The scan must stop there rather than reopening the question, and must
+// not report the stems it governs as undeclared.
+func TestDownwardScan_StopsAtADeclaredBoundary(t *testing.T) {
+	root := downwardTree(t, map[string]string{
+		"wiki/.stem":          "version: 2\nroot: true\n",
+		"wiki/entities/.stem": "version: 2\n",
+		"zeta/.stem":          "version: 2\n",
+	})
+
+	entries, err := DownwardScan(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := relStemDirs(t, root, entries)
+	if strings.Join(got, ",") != "zeta" {
+		t.Errorf("dirs = %v, want [zeta] (the wiki subtree declares its own boundary)", got)
+	}
+}
+
+func TestDownwardScan_ParseFailureStopsTheScan(t *testing.T) {
+	root := downwardTree(t, map[string]string{
+		"wiki/.stem":          "version: 2\nscope:\n  match: [[[unclosed\n",
+		"wiki/entities/.stem": "version: 2\n",
+	})
+
+	entries, err := DownwardScan(root)
+	if err == nil {
+		t.Fatalf("an unparseable .stem must fail the scan, got entries %v", relStemDirs(t, root, entries))
+	}
+	if entries != nil {
+		t.Errorf("entries = %v, want none on failure", relStemDirs(t, root, entries))
+	}
+	if !strings.Contains(err.Error(), "parsing") {
+		t.Errorf("expected the parse failure, got: %v", err)
+	}
+}
+
+func TestDownwardScan_RespectsStemignore(t *testing.T) {
+	root := downwardTree(t, map[string]string{
+		"docs/.stemignore":  "nested/.stem\n",
+		"docs/.stem":        "version: 2\n",
+		"docs/nested/.stem": "version: 2\n",
+	})
+
+	entries, err := DownwardScan(filepath.Join(root, "docs"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := relStemDirs(t, root, entries)
+	if strings.Join(got, ",") != "docs" {
+		t.Errorf("dirs = %v, want [docs] (docs/nested/.stem is ignored)", got)
+	}
+}
+
+// .git holds no records and is never governed, so scanning into it would only
+// find noise — the same exclusion index.Scan already makes.
+func TestDownwardScan_SkipsGitDirectory(t *testing.T) {
+	root := downwardTree(t, map[string]string{
+		".git/modules/x/.stem": "version: 2\n",
+		"wiki/.stem":           "version: 2\n",
+	})
+
+	entries, err := DownwardScan(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := relStemDirs(t, root, entries)
+	if strings.Join(got, ",") != "wiki" {
+		t.Errorf("dirs = %v, want [wiki]", got)
+	}
+}
+
+// The commands that run the scan are given whatever the user typed, which is
+// often a file. Its directory is the tree in question.
+func TestDownwardScan_FileTargetScansItsDirectory(t *testing.T) {
+	root := downwardTree(t, map[string]string{
+		"wiki/.stem": "version: 2\n",
+		"wiki/a.md":  "# a\n",
+	})
+
+	entries, err := DownwardScan(filepath.Join(root, "wiki", "a.md"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := relStemDirs(t, root, entries)
+	if strings.Join(got, ",") != "wiki" {
+		t.Errorf("dirs = %v, want [wiki]", got)
+	}
+}
+
+// A path that does not exist is the command's error to report, with the name
+// the user typed. The scan has nothing to say about it.
+func TestDownwardScan_MissingTargetIsNotTheScansError(t *testing.T) {
+	root := downwardTree(t, map[string]string{"a.md": "# a\n"})
+
+	entries, err := DownwardScan(filepath.Join(root, "nowhere"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("entries = %v, want none", relStemDirs(t, root, entries))
+	}
+}
+
+func TestIsRealSchemaError(t *testing.T) {
+	if IsRealSchemaError(nil) {
+		t.Error("nil is not an error at all")
+	}
+	if IsRealSchemaError(ErrNoSchemaFound) {
+		t.Error("a tree with no .stem is ungoverned, not broken")
+	}
+	if !IsRealSchemaError(errors.New("permission denied")) {
+		t.Error("an IO failure is a real schema error")
+	}
+}


### PR DESCRIPTION
## What

Five defects in how rootline decides whether a tree is governed, and in what it says when it decides no.

1. **Tree-scoped boundary preflight** (`cmd/rootline/preflight.go:75-105`) — the preflight only looked upward, so one tree gave two verdicts depending on which directory you named. **Behaviour-changing.**
2. **`graph` and `tree` on a tree with no `.stem`** (`cmd/rootline/graph.go:82-97`, `cmd/rootline/tree.go:71-92`) — both refused to answer.
3. **`describe`'s missing-schema message** (`cmd/rootline/describe.go:29-52`) — named the internal step instead of the condition.
4. **`analyze` blocked by the preflight** (`cmd/rootline/preflight.go:12-35`) — the one command that can tell an ungoverned tree what its schema should be was gated on having one.
5. **Directory arguments reported as extractor failures** (`cmd/rootline/validate.go:71-82`, `cmd/rootline/explain.go:37-48`, `internal/fix/repair.go:55-64`).

## Why

Closes #65.

Before / after, on the tree from the issue — `wiki/.stem` and `wiki/entities/.stem`, neither carrying `root: true`:

```
                                 master   this PR
validate --all .                 exit 0   exit 1     <- the wrong one passed
validate --all wiki              exit 1   exit 1
validate --all wiki/entities     exit 1   exit 1
analyze wiki                     exit 1   exit 0
graph <schemaless dir>           exit 1   exit 0
tree  <schemaless dir>           exit 1   exit 0
```

```
                master                                                    this PR
validate docs   Error: no extractor for docs                              Error: docs is a directory; use 'rootline validate --all docs'
explain  docs   Error: no extractor for docs                              Error: docs is a directory; use 'rootline explain <file>'
describe .      Error: discovering .stem files: no .stem file found ...   Error: no schema governs this path; run 'rootline init <path>' to create one
```

`validate --all .` returning exit 0 over three "valid" records is the defect that matters: those records are governed by a chain that reaches the filesystem root without a declared boundary, which is precisely the condition the preflight exists to catch. Which directory the user happened to type decided whether they were told.

## How

**Downward scan** (`internal/rules/discovery.go:124-212`). `WalkUp` answers "what governs this path", which resolves a schema but cannot judge one — it looks one way. `DownwardScan` collects every `.stem` at or below the target that has not declared, and is not covered by, a boundary. The preflight calls it only when the upward walk came back with `ErrNoSchemaFound`, so a rooted project never pays for it.

Three cases the scan is deliberate about:

- A `.stem` carrying `root: true` ends the scan for its subtree. The question is already answered there, and reporting the stems it governs as undeclared would be the same mistake pointing the other way (`internal/rules/downward_test.go:74-94`).
- A tree with no `.stem` anywhere is ungoverned rather than misgoverned: the scan returns nothing and the preflight passes it through, so the command still answers in its own terms (`cmd/rootline/preflight_test.go:221-236`).
- It shares `index.Scan`'s universe — honours `.stemignore`, never enters `.git` — because a file the project has excluded governs nothing and cannot be why a command is refused.

It carries its own `.stemignore` matcher rather than calling `internal/index`: that package already imports `internal/rules`, and inverting the dependency would make the schema domain depend on the scanner that reads it.

**Graph / tree tolerance.** A `.stem` decides which link styles `graph` reads, whether cycles fail a check, and which field `tree` shows as a status. Its absence removes those restrictions; it does not remove the links or the hierarchy. `graph` already had an `if stem != nil` guard expressing exactly that, so the fix is to stop turning `ErrNoSchemaFound` into a fatal error (`rules.IsRealSchemaError`).

`tree` needed more care. It renders the raw structure only after a *governed* scan comes back with nothing, rather than passing `index.AllowUngoverned()` outright — otherwise an ungoverned directory sitting inside a governed project would start appearing in the output, which `TestTreeCmd_ScopeFiltering_ExcludesOutOfScope` correctly forbids (`cmd/rootline/tree.go:79-90`).

**Describe** keeps failing — printing a schema is its whole job — but says what the user hit. It remains the same error to `errors.Is(err, rules.ErrNoSchemaFound)`, so `TestDescribeCmd_NoStemAncestors` and `TestDescribeCmd_NoStemTableHint` still hold (`cmd/rootline/describe.go:29-52`).

**Analyze exemption** is one map entry plus the rationale for the two exemption categories. `query` and `stats` stay governed and have a regression test pinning them there (`cmd/rootline/preflight_test.go:159-180`): they skip schema resolution voluntarily, not because they are schema-independent.

### Test inversions (intentional)

Two tests asserted the behaviour this PR reverses and are replaced, not deleted silently:

| Removed | Replaced by |
|---|---|
| `TestGraphErrorPropagation_NoSchema` | `TestGraph_SchemalessEmitsGraph`, `TestGraph_CheckOnSchemalessReportsIntegrity` |
| `TestTreeErrorPropagation_NoSchema` | `TestTree_SchemalessToleratesMissing` |

The `tree` inversion was not in the plan; it followed from the same decision the `graph` one did, and is called out here rather than quietly carried.

## Breaking change

`validate --all <dir>` — and any other governed command — now fails on a tree whose `.stem` files never declare `root: true`, where naming a directory **above** them used to pass. Only such trees are affected; a tree with a `root: true` marker, and a tree with no `.stem` at all, both behave as before.

On a terminal the existing `AttemptRootMarkerMigration` prompt offers to write the marker. Non-interactive callers (CI) get the error and must add `root: true` to the `.stem` that owns the project.

Verified unaffected: this repo's own `validate --all docs/roadmap/` and `tree docs/roadmap/` still exit 0, since the root `.stem` declares `root: true`.

## Verification

```
$ just check
gofmt -l .          (clean)
golangci-lint run   0 issues.
go build ./...      ok

$ just test
go test ./... -race
ok  github.com/pablontiv/rootline/cmd/rootline        3.899s
ok  github.com/pablontiv/rootline/internal/derive     1.977s
ok  github.com/pablontiv/rootline/internal/e2e        4.380s
ok  github.com/pablontiv/rootline/internal/extract    3.419s
ok  github.com/pablontiv/rootline/internal/fix        2.573s
ok  github.com/pablontiv/rootline/internal/graph      2.962s
ok  github.com/pablontiv/rootline/internal/index      1.755s
ok  github.com/pablontiv/rootline/internal/infer      3.259s
ok  github.com/pablontiv/rootline/internal/migrate    3.885s
ok  github.com/pablontiv/rootline/internal/proposal   3.630s
ok  github.com/pablontiv/rootline/internal/query      2.751s
ok  github.com/pablontiv/rootline/internal/rules      1.427s
ok  github.com/pablontiv/rootline/internal/templates  3.415s

$ just coverage-check
PASS: cmd/rootline = 86.4%     PASS: internal/index     = 90.3%
PASS: internal/derive = 93.7%  PASS: internal/infer     = 93.0%
PASS: internal/extract = 94.8% PASS: internal/migrate   = 86.2%
PASS: internal/fix = 88.6%     PASS: internal/proposal  = 88.6%
PASS: internal/graph = 95.4%   PASS: internal/query     = 88.8%
                               PASS: internal/rules     = 89.6%
                               PASS: internal/templates = 87.1%
TOTAL: 89.2%
```

The before/after tables above are real runs of two built binaries (`master` @ 1fc8a92 and this branch), not transcriptions.

## Size

+843 / -61 across 17 files, against a planning forecast of 201. The overrun is tests (+565/-33) and this repo's doc-comment density; non-test code is +278/-28, of which `DownwardScan` and its `.stemignore` matcher are +159. Flagged rather than hidden: this exceeds the 400-line review budget.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...` — `just check` runs `golangci-lint`, 0 issues)
- [x] Changes are documented if user-facing — behaviour change and every new message are documented above; `internal/index.AllowUngoverned` and the preflight exemption list carry updated rationale in-code
