### PR TITLE
fix(hooks): clear inherited git env before the pre-push coverage run

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -56,7 +56,14 @@ while read local_ref local_sha remote_ref remote_sha; do
   # Requires just coverage-check to be available (added by T006).
   if git diff --name-only "$range" -- '*.go' 2>/dev/null | grep -q .; then
     echo "Checking coverage..."
-    if ! just coverage-check > /tmp/rootline-cov.log 2>&1; then
+    # git exports GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/GIT_OBJECT_DIRECTORY into
+    # hook processes. Tests that shell out to git inherit them: internal/templates
+    # clones a template repo, and the inherited GIT_DIR makes the nested clone fail
+    # with "does not appear to be a git repository". That collapses coverage and
+    # blocks every push touching Go. Worse, a nested `git commit` under an inherited
+    # GIT_DIR writes into the real repository. Clear them for the test run only.
+    if ! env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
+        just coverage-check > /tmp/rootline-cov.log 2>&1; then
       cat /tmp/rootline-cov.log
       echo "Coverage below threshold. Run: just coverage-check"
       exit 1


### PR DESCRIPTION
## What

Wrap the pre-push coverage run in `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY`.

## Why

`git push` exports `GIT_DIR` and friends into hook processes. `.githooks/pre-push` runs
`just coverage-check` -> `go test ./...`, and `internal/templates` shells out to `git clone`.
The nested clone inherits `GIT_DIR` and dies:

```
fatal: /var/folders/.../TestFetchFromURL_EmptyRepo.../001 does not appear to be a git repository
fatal: Could not read from remote repository.
FAIL  github.com/pablontiv/rootline/internal/templates  1.601s
```

A failing package collapses total coverage to 47.3%, so the gate reports
"Coverage below threshold" and **every push touching a `.go` file is blocked**. The
misleading message sends you hunting for a coverage regression that does not exist.

Reproduction (passes standalone, fails with the env git exports):

```
go test ./internal/templates/ -count=1                                  # ok, 87.1%
GIT_DIR=/path/to/repo/.git go test ./internal/templates/ -count=1       # FAIL
```

Worse than a broken gate: a nested `git commit` under an inherited `GIT_DIR` writes into the
real repository. Running the reproduction above landed a stray commit authored
`Test <test@example.com>` plus four `.stem` files on the local branch of this very repo.

## How

Clear the four git env vars for the test invocation only. The hook keeps using them everywhere
else, so range detection and the other gates are unaffected.

Follow-up, not in this PR: `internal/templates` should isolate its own git environment rather
than relying on callers to sanitize it.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [ ] Changes are documented if user-facing (hook-internal, no user-facing surface)