### PR TITLE
docs(github): make issue linkage explicit in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,17 @@
 
 Brief description of the change.
 
+## Related issue
+
+Closes #<N>
+
+<!-- GitHub only auto-closes on "Closes/Fixes/Resolves #N". Leave this blank on the
+     intermediate PRs of a chain: the closing keyword belongs on the last PR only,
+     otherwise merging PR 1 closes the issue while the rest of the fix is still open. -->
+
 ## Why
 
-Why is this change needed? Link to a related issue if applicable.
+Why is this change needed?
 
 ## How
 
@@ -15,3 +23,4 @@ How was this implemented? Note any design decisions.
 - [ ] Tests pass (`go test ./... -race`)
 - [ ] Code is clean (`go vet ./...`)
 - [ ] Changes are documented if user-facing
+- [ ] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 
 ### Added
 
+- Pull request template now has a dedicated **Related issue** section with a `Closes #<N>` field and a checklist item, so issue linkage stops depending on the author remembering the keyword
 - `CHANGELOG.md` (this file) — ecosystem documentation baseline
 - GitHub Issues enabled on the repository
 - `docs/UPGRADE.md` — migration guide for the root marker requirement


### PR DESCRIPTION
## Related issue

<!-- none: this PR changes the template itself -->

## Why

The template only said, inside **Why**: "Link to a related issue if applicable." That is prose,
not a field. It never names `Closes`, `Fixes` or `Resolves` — the only keywords GitHub acts on —
and `if applicable` makes it skippable. The checklist had no linkage item either.

In the batch of seven PRs just opened against this repo, the linkage came from the authoring
instructions, not from the template. Without those instructions none of them would have closed
an issue on merge.

## How

Promote linkage to its own **Related issue** section with a `Closes #<N>` field, and add a
checklist item.

The comment in that section documents the one case where leaving it blank is correct: the
intermediate PRs of a chain. Three PRs resolved a single issue here, and putting the keyword on
the first would have closed the issue while two thirds of the fix were still unmerged.

## Checklist

- [x] Tests pass (`go test ./... -race`) — no code change
- [x] Code is clean (`go vet ./...`) — no code change
- [x] Changes are documented if user-facing (CHANGELOG entry added)
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (no issue: template change)