### PR TITLE
fix(schema)!: refuse create_stem against an existing .stem without --force

### DIFF
--- a/.claude/skills/rootline/ref-schema.md
+++ b/.claude/skills/rootline/ref-schema.md
@@ -149,14 +149,15 @@ Use these instead of hand-rolling `WalkUp` + `entries[0]` indexing in new comman
 
 ### schema apply
 
-`rootline schema apply --report <proposals.json> [--dry-run]` applies schema proposals to `.stem` files:
+`rootline schema apply --report <proposals.json> [--dry-run] [--force]` applies schema proposals to `.stem` files:
 - Input kind must be `"rootline/schema-proposals"`, version must be 1 (else structured error)
 - Skips proposals with `requires_agent: true`
-- `create_stem` operation: calls `ScaffoldSchema` to create the target `.stem` file
-- `update_stem` operation: calls `ApplySchemaInferences` on the target `.stem` file
+- `create_stem` operation: creates the target `.stem` file with the proposed schema
+- Unknown operations: rejected with message in `rejected[]` (policy refusal, not error)
+- **Flag: `--force`** — Overwrites existing `.stem` files when applying `create_stem` proposals. Without `--force`, proposals targeting existing files are rejected (policy refusal).
 - `--dry-run`: no files written; reports what would be done
 - Post-apply: runs `rootline validate --all` and includes results in output
-- Emits JSON: version 1, kind `"rootline/schema-apply"` with applied/skipped/errors/validation_summary
+- Emits JSON: version 1, kind `"rootline/schema-apply"` with applied/skipped/rejected/errors/validation_summary
 
 **Path containment.** Each `create_stem` target is validated with
 `fix.ContainPath(scanRoot, target, fix.PolicyAcceptAbsolute)` before `ScaffoldSchema` runs, and
@@ -167,8 +168,8 @@ Two deliberate differences from `repair apply`:
   emits absolute `.stem` targets, so the propose→apply contract needs them to keep working.
   `repair apply` uses `PolicyRejectAbsolute` because its report paths are root-relative by
   construction.
-- **Refusals go to `errors[]`, not `rejected[]`.** `schema apply` has no `rejected[]`, so a
-  target outside the root is a validation failure rather than a semantic rejection.
+- **Policy refusals go to `rejected[]`** (overwrite without `--force`, unknown operations).
+  Containment violations go to `errors[]` (operational failures).
 
 `--dry-run` adds the same additive `resolved_targets: {accepted, rejected}` envelope that
 `repair apply` emits (`fix.ResolvedTargetsBreakdown`); omitted otherwise, contract stays

--- a/cmd/rootline/commands_test.go
+++ b/cmd/rootline/commands_test.go
@@ -100,6 +100,7 @@ func resetFlags() {
 	schemaProposeIncremental = false
 	schemaApplyReport = ""
 	schemaApplyDryRun = false
+	schemaApplyForce = false
 	reportPath = ""
 	repairDryRun = false
 

--- a/cmd/rootline/schema.go
+++ b/cmd/rootline/schema.go
@@ -53,6 +53,7 @@ type SchemaApplyResult struct {
 	Kind              string             `json:"kind"`
 	Applied           []string           `json:"applied"`
 	Skipped           []string           `json:"skipped"`
+	Rejected          []string           `json:"rejected,omitempty"`
 	DryRun            bool               `json:"dry_run,omitempty"`
 	Errors            []string           `json:"errors,omitempty"`
 	ValidationSummary *ValidationSummary `json:"validation_summary,omitempty"`
@@ -88,6 +89,7 @@ Use --incremental to only show proposals not already covered by existing .stem f
 var (
 	schemaApplyReport string
 	schemaApplyDryRun bool
+	schemaApplyForce  bool
 )
 
 var schemaApplyCmd = &cobra.Command{
@@ -107,6 +109,7 @@ func init() {
 	schemaApplyCmd.Flags().StringVar(&schemaApplyReport, "report", "", "path to schema proposals report JSON file (required)")
 	_ = schemaApplyCmd.MarkFlagRequired("report")
 	schemaApplyCmd.Flags().BoolVar(&schemaApplyDryRun, "dry-run", false, "show changes without applying them")
+	schemaApplyCmd.Flags().BoolVar(&schemaApplyForce, "force", false, "overwrite existing .stem files")
 	schemaCmd.AddCommand(schemaApplyCmd)
 
 	rootCmd.AddCommand(schemaCmd)
@@ -244,12 +247,13 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 	}
 
 	result := &SchemaApplyResult{
-		Version: 1,
-		Kind:    "rootline/schema-apply",
-		DryRun:  schemaApplyDryRun,
-		Applied: []string{},
-		Skipped: []string{},
-		Errors:  []string{},
+		Version:  1,
+		Kind:     "rootline/schema-apply",
+		DryRun:   schemaApplyDryRun,
+		Applied:  []string{},
+		Skipped:  []string{},
+		Rejected: []string{},
+		Errors:   []string{},
 	}
 
 	// Resolve absolute path from report.
@@ -290,12 +294,32 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 			}
 			resolved.Accepted[proposal.Target] = target
 
-			// Create a new .stem file at target.
+			// Overwrite guard: replacing a governed .stem discards root, scope,
+			// enum values, required markers, derive and aggregate in one write,
+			// so it is a policy refusal unless the caller opted in with --force.
+			_, statErr := os.Stat(target)
+			targetExists := statErr == nil
+			if targetExists && !schemaApplyForce {
+				result.Rejected = append(result.Rejected,
+					fmt.Sprintf(".stem already exists in %s (use --force to overwrite)", filepath.Dir(target)))
+				continue
+			}
+
+			// Name the action after what it actually does. A dry run is the only
+			// chance the caller has to notice that "create" means "replace".
+			action := "create_stem"
+			if targetExists {
+				action = "overwrite_stem"
+			}
+
 			if err := infer.ScaffoldSchema(filepath.Dir(target), schemaApplyDryRun); err != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("scaffold %s: %v", proposal.Target, err))
 			} else {
-				result.Applied = append(result.Applied, fmt.Sprintf("create_stem: %s", target))
+				result.Applied = append(result.Applied, fmt.Sprintf("%s: %s", action, target))
 			}
+		} else {
+			// Unknown operation: reject with descriptive message
+			result.Rejected = append(result.Rejected, fmt.Sprintf("%s: unknown operation \"%s\"", proposal.ID, proposal.Operation))
 		}
 	}
 
@@ -360,6 +384,7 @@ func runSchemaApplyFromAnalyze(cmd *cobra.Command, data []byte) error {
 	// Separate schema-modifying inferences from data-correction inferences.
 	// Schema-modifying: enum_values, required_field, constant_field, field_type, untyped_field, sequence_incomplete
 	// Data-correction: migrate_value, correct_value, add_field (these go to repair apply, not here)
+	// Routing filter: emits only schema-modifying types. Drift guard in apply.go:default catches divergence.
 	var schemaInferences []infer.ReportInference
 	for _, cat := range report.Categories {
 		for _, inf := range cat.Inferences {
@@ -378,12 +403,13 @@ func runSchemaApplyFromAnalyze(cmd *cobra.Command, data []byte) error {
 
 	// Format result as SchemaApplyResult
 	result := &SchemaApplyResult{
-		Version: 1,
-		Kind:    "rootline/schema-apply",
-		DryRun:  schemaApplyDryRun,
-		Applied: schemaResult.Applied,
-		Skipped: schemaResult.Skipped,
-		Errors:  []string{},
+		Version:  1,
+		Kind:     "rootline/schema-apply",
+		DryRun:   schemaApplyDryRun,
+		Applied:  schemaResult.Applied,
+		Skipped:  schemaResult.Skipped,
+		Rejected: schemaResult.Rejected,
+		Errors:   []string{},
 	}
 
 	// If not dry-run, run validation.
@@ -607,6 +633,13 @@ func renderSchemaApplyTable(cmd *cobra.Command, result *SchemaApplyResult) error
 		}
 	}
 
+	if len(result.Rejected) > 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Rejected (policy):")
+		for _, r := range result.Rejected {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  - %s\n", r)
+		}
+	}
+
 	if len(result.Errors) > 0 {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Errors:")
 		for _, e := range result.Errors {
@@ -622,7 +655,7 @@ func renderSchemaApplyTable(cmd *cobra.Command, result *SchemaApplyResult) error
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Total errors: %d\n", result.ValidationSummary.TotalErrors)
 	}
 
-	if len(result.Applied) == 0 && len(result.Skipped) == 0 && len(result.Errors) == 0 {
+	if len(result.Applied) == 0 && len(result.Skipped) == 0 && len(result.Rejected) == 0 && len(result.Errors) == 0 {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No modifications to apply.")
 	}
 

--- a/cmd/rootline/schema_test.go
+++ b/cmd/rootline/schema_test.go
@@ -929,3 +929,220 @@ func TestSchemaApply_TargetContainment(t *testing.T) {
 		}
 	})
 }
+
+// --- Slice A Tests: Force Flag, Rejected Field, Unrecognized Operations ---
+
+// TestSchemaApplyForceFlag tests that --force flag gates overwrite of existing .stem files.
+// RED: test that:
+// 1. force flag is recognized
+// 2. without force: existing .stem is refused
+// 3. with force: existing .stem is overwritten
+func TestSchemaApplyForceFlag(t *testing.T) {
+	t.Run("ForceFlagIsRecognized", func(t *testing.T) {
+		// Use setupValidateProject to create proper project structure
+		root := setupValidateProject(t, map[string]string{
+			"doc1.md": "---\ntitle: Test\nauthor: Someone\n---\nContent",
+		})
+
+		// Create existing .stem
+		existingStem := "version: 2\nschema:\n  old_field:\n    type: string\n"
+		stemPath := filepath.Join(root, ".stem")
+		if err := os.WriteFile(stemPath, []byte(existingStem), 0o644); err != nil {
+			t.Fatalf("writing existing .stem: %v", err)
+		}
+
+		// Create proposals report targeting the existing .stem
+		report := SchemaProposalsReport{
+			Version: 1,
+			Kind:    "rootline/schema-proposals",
+			Path:    root,
+			Proposals: []SchemaProposal{
+				{
+					ID:            "test-force",
+					Operation:     "create_stem",
+					Target:        stemPath,
+					RequiresAgent: false,
+					PatchPreview:  "version: 2\nschema:\n  new_field:\n    type: string\n",
+				},
+			},
+		}
+		reportData, _ := json.Marshal(report)
+		reportFile := filepath.Join(root, "report.json")
+		if err := os.WriteFile(reportFile, reportData, 0o644); err != nil {
+			t.Fatalf("writing report: %v", err)
+		}
+
+		// Test 1: Without --force, existing .stem should be rejected
+		out, err := executeSchemaApply(t, "--report", reportFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Rejected) == 0 {
+			t.Error("expected rejected[]to contain entry for overwrite attempt without --force, got empty")
+		}
+		if len(result.Applied) > 0 {
+			t.Error("expected applied[] to be empty when overwrite is refused")
+		}
+
+		// Verify .stem was not modified
+		stillExisting := string(mustReadFile(t, stemPath))
+		if stillExisting != existingStem {
+			t.Error(".stem was modified despite --force not being passed")
+		}
+
+		// Test 2: With --force, existing .stem should be overwritten
+		out2, err := executeSchemaApply(t, "--report", reportFile, "--force")
+		if err != nil {
+			t.Fatalf("unexpected error with --force: %v", err)
+		}
+		result2 := decodeSchemaApplyResult(t, out2)
+		if len(result2.Applied) == 0 {
+			t.Error("expected applied[] to contain entry when --force is passed")
+		}
+		if len(result2.Rejected) > 0 {
+			t.Errorf("expected no rejections with --force, got: %v", result2.Rejected)
+		}
+	})
+
+}
+
+// TestSchemaApplyUnrecognizedOperation tests that unknown operations are rejected.
+func TestSchemaApplyUnrecognizedOperation(t *testing.T) {
+	root := t.TempDir()
+
+	// Create proposals report with unknown operation
+	report := SchemaProposalsReport{
+		Version: 1,
+		Kind:    "rootline/schema-proposals",
+		Path:    root,
+		Proposals: []SchemaProposal{
+			{
+				ID:            "unknown-op-1",
+				Operation:     "update_stem", // This is not a valid proposal-path operation
+				Target:        filepath.Join(root, ".stem"),
+				RequiresAgent: false,
+			},
+		},
+	}
+	reportData, _ := json.Marshal(report)
+	reportFile := filepath.Join(root, "report.json")
+	if err := os.WriteFile(reportFile, reportData, 0o644); err != nil {
+		t.Fatalf("writing report: %v", err)
+	}
+
+	out, err := executeSchemaApply(t, "--report", reportFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := decodeSchemaApplyResult(t, out)
+
+	// Verify unknown operation is in rejected[], not errors[] or applied[]
+	if len(result.Rejected) == 0 {
+		t.Error("expected rejected[] to contain unknown operation, got empty")
+	}
+	if len(result.Applied) > 0 {
+		t.Error("expected applied[] to be empty for unknown operation")
+	}
+
+	// Check that the rejection message names the operation
+	found := false
+	for _, msg := range result.Rejected {
+		if strings.Contains(msg, "update_stem") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("rejection message should mention 'update_stem', got: %v", result.Rejected)
+	}
+}
+
+// TestSchemaApplyDryRunDistinction asserts that a dry run names the action it
+// would take. Reporting "create_stem" for a target that already exists is the
+// exact blind spot issue #59 describes: the caller approves a create and gets a
+// replacement.
+func TestSchemaApplyDryRunDistinction(t *testing.T) {
+	writeReport := func(t *testing.T, root, name, target string) string {
+		t.Helper()
+		report := SchemaProposalsReport{
+			Version: 1,
+			Kind:    "rootline/schema-proposals",
+			Path:    filepath.Dir(target),
+			Proposals: []SchemaProposal{{
+				ID:        name,
+				Operation: "create_stem",
+				Target:    target,
+			}},
+		}
+		data, err := json.Marshal(report)
+		if err != nil {
+			t.Fatalf("marshaling report: %v", err)
+		}
+		path := filepath.Join(root, name+".json")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("writing report: %v", err)
+		}
+		return path
+	}
+
+	t.Run("absent target reports create", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+		})
+		target := filepath.Join(root, "docs", ".stem")
+		out, err := executeSchemaApply(t, "--report", writeReport(t, root, "create", target), "--dry-run")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 1 {
+			t.Fatalf("applied = %v, want exactly one entry", result.Applied)
+		}
+		if !strings.HasPrefix(result.Applied[0], "create_stem: ") {
+			t.Errorf("applied[0] = %q, want a create_stem action", result.Applied[0])
+		}
+		if len(result.Rejected) != 0 {
+			t.Errorf("rejected = %v, want empty for a fresh target", result.Rejected)
+		}
+	})
+
+	t.Run("existing target without force is rejected, not applied", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+			"docs/.stem":   "version: 2\nschema:\n  old:\n    type: string\n",
+		})
+		target := filepath.Join(root, "docs", ".stem")
+		out, err := executeSchemaApply(t, "--report", writeReport(t, root, "reject", target), "--dry-run")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 0 {
+			t.Errorf("applied = %v, want empty when the target exists and --force is absent", result.Applied)
+		}
+		if len(result.Rejected) != 1 || !strings.Contains(result.Rejected[0], "use --force to overwrite") {
+			t.Errorf("rejected = %v, want the already-exists refusal", result.Rejected)
+		}
+	})
+
+	t.Run("existing target with force reports overwrite, not create", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/doc1.md": "---\ntitle: Test\n---\nContent",
+			"docs/.stem":   "version: 2\nschema:\n  old:\n    type: string\n",
+		})
+		target := filepath.Join(root, "docs", ".stem")
+		out, err := executeSchemaApply(t, "--report", writeReport(t, root, "force", target), "--dry-run", "--force")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 1 {
+			t.Fatalf("applied = %v, want exactly one entry", result.Applied)
+		}
+		if !strings.HasPrefix(result.Applied[0], "overwrite_stem: ") {
+			t.Errorf("applied[0] = %q, want an overwrite_stem action so the caller can tell a replacement from a create", result.Applied[0])
+		}
+	})
+}

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -158,8 +158,7 @@ rootline schema apply --report proposals.json
 
 `schema apply` accepts a report from `rootline analyze` or `rootline schema propose` and applies only schema-surface proposals to `.stem` files:
 - create_stem
-- update_stem
-- extend_enum
+- extend_enum (analyze path only)
 
 Data-only repairs (correct_value, add_field, etc.) are **ignored** — use `rootline repair apply` instead.
 
@@ -171,11 +170,12 @@ target is checked against the scan root before a `.stem` is written, so a report
 staying valid — they are accepted and then confined, not refused outright. That is the one
 difference from `repair apply`, which rejects absolute paths as malformed input.
 
-The second difference is where refusals land. `schema apply` has no `rejected[]`, so a target
-outside the root is a validation failure and appears in `errors[]`:
+The second difference is where refusals land. `schema apply` has a `rejected[]` field for policy refusals (overwrite without `--force`, unknown operations) and `errors[]` for operational failures (containment violations, scan errors):
 
 ```bash
 rootline schema apply --report proposals.json
+# rejected: ".stem already exists in /docs (use --force to overwrite)"
+# OR
 # errors: containment violation: path "/tmp/outside/.stem" escapes root (root "/abs/scan")
 ```
 

--- a/internal/infer/apply.go
+++ b/internal/infer/apply.go
@@ -12,9 +12,10 @@ import (
 
 // ApplyResult tracks what was modified during an apply operation.
 type ApplyResult struct {
-	Applied []string `json:"applied"`
-	Skipped []string `json:"skipped"`
-	DryRun  bool     `json:"dry_run,omitempty"`
+	Applied  []string `json:"applied"`
+	Skipped  []string `json:"skipped"`
+	Rejected []string `json:"rejected,omitempty"`
+	DryRun   bool     `json:"dry_run,omitempty"`
 }
 
 // ApplySchemaInferences applies schema-modifying inferences to a .stem file.
@@ -94,6 +95,10 @@ func ApplySchemaInferences(stemPath string, inferences []ReportInference, dryRun
 				result.Applied = append(result.Applied, fmt.Sprintf("sequence: %s completed", inf.Field))
 				modified = true
 			}
+
+		default:
+			// Drift guard: this fires only if schema.go's routing filter admits a type this switch doesn't handle (wiring bug).
+			result.Rejected = append(result.Rejected, fmt.Sprintf("%s: unknown inference type", inf.Type))
 		}
 	}
 

--- a/internal/infer/apply_test.go
+++ b/internal/infer/apply_test.go
@@ -855,3 +855,83 @@ func TestApplySchemaInferences_FieldTypeThenEnumSameNewField(t *testing.T) {
 		t.Errorf("expected 3 enum values, got %v", sf.Values)
 	}
 }
+
+// TestApplySchemaInferences_UnknownInferenceType tests that unknown inference types are rejected.
+func TestApplySchemaInferences_UnknownInferenceType(t *testing.T) {
+	dir := t.TempDir()
+	stemPath := filepath.Join(dir, ".stem")
+	if err := os.WriteFile(stemPath, []byte("version: 2\nschema:\n  estado:\n    type: string\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unknown inference type → should be rejected
+	inferences := []ReportInference{
+		{Type: "unknown_type", Field: "estado", Value: "test"},
+	}
+
+	result, err := ApplySchemaInferences(stemPath, inferences, false)
+	if err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	if len(result.Rejected) == 0 {
+		t.Error("expected rejected[] to contain unknown inference type")
+	}
+	if len(result.Applied) > 0 {
+		t.Errorf("expected no applied for unknown type, got %d", len(result.Applied))
+	}
+
+	// Verify the rejection message mentions the unknown type
+	found := false
+	for _, msg := range result.Rejected {
+		if strings.Contains(msg, "unknown_type") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("rejection message should mention 'unknown_type', got: %v", result.Rejected)
+	}
+}
+
+// TestApplySchemaInferences_MixedKnownAndUnknown tests that known types are applied and unknown types are rejected in one run.
+func TestApplySchemaInferences_MixedKnownAndUnknown(t *testing.T) {
+	dir := t.TempDir()
+	stemPath := filepath.Join(dir, ".stem")
+	if err := os.WriteFile(stemPath, []byte("version: 2\nschema:\n  estado:\n    type: string\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mix of known and unknown types
+	inferences := []ReportInference{
+		{Type: "required_field", Field: "estado"},
+		{Type: "unknown_op", Field: "estado", Value: "test"},
+		{Type: "field_type", Field: "nuevo", Value: "integer"},
+	}
+
+	result, err := ApplySchemaInferences(stemPath, inferences, false)
+	if err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	// Should have some applied (known types) and some rejected (unknown types)
+	if len(result.Applied) == 0 {
+		t.Error("expected some applied for known types")
+	}
+	if len(result.Rejected) == 0 {
+		t.Error("expected some rejected for unknown types")
+	}
+
+	// Verify the file was modified for the known types
+	data, _ := os.ReadFile(stemPath)
+	stem, err := rules.ParseStem(stemPath, data)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if !stem.Schema["estado"].Required {
+		t.Error("expected estado to be required (from known inference)")
+	}
+	if stem.Schema["nuevo"].Type != "integer" {
+		t.Error("expected nuevo field with type integer (from known inference)")
+	}
+}


### PR DESCRIPTION
## What

`schema apply` no longer overwrites an existing `.stem`. This is slice 1 of a 2-PR chain for issue #59.

- Adds `--force` to `schema apply`. Without it, a `create_stem` proposal aimed at a directory that already has a `.stem` is refused and the file is left untouched.
- Adds `rejected[]` to the `rootline/schema-apply` envelope for **policy refusals**, keeping `errors[]` for failed writes and operational failures — the rule already stated at `internal/fix/repair.go:55`.
- `--dry-run` now names the action it would take: `create_stem` for a fresh target, `overwrite_stem` when the target exists and `--force` was passed.
- Unrecognised `operation` values land in `rejected[]` instead of falling out of the loop unnoticed. `internal/infer/apply.go` gains a matching `default:` branch as a drift guard.
- Drops the `update_stem` claim from the proposals-path documentation, where that operation has never existed.

## Related issue

Part of #59.

<!-- Intentionally no closing keyword: this is slice 1 of 2. The keyword lands on the
     Slice B PR, which completes the fix. -->

## Why

Applying a `create_stem` proposal to an already-governed directory destroyed the schema and then reported success.

**Before** (master @ `99b649e`) — fixture with `root: true`, `scope`, two enums, two `required` markers and an `aggregate` block, plus one record that violates the enum:

```console
$ rootline validate --all docs -o json | jq -c .summary
{"total":2,"valid":1,"invalid":1,"errors_count":1,...}

$ rootline schema apply --report prop.json -o json
{"applied":["create_stem: .../docs/.stem"],"skipped":[],
 "validation_summary":{"total_files":2,"valid_files":2,"invalid_files":0,"total_errors":0}}
exit=0

$ cat docs/.stem
version: 2
schema:
  estado:
    type: string
  titulo:
    type: string
```

`root`, `scope`, both enums, both `required` markers and the whole `aggregate` block are gone. The summary flipped from `1 invalid` to `2 valid / 0 errors` — not because the bad record was fixed, but because the rule that flagged it was deleted. `--dry-run` printed `applied: ["create_stem: <path>"]` with no hint that a file was in the way.

**After** (this PR), same fixture:

```console
$ rootline schema apply --report prop.json --dry-run -o json | jq -c '{applied,rejected}'
{"applied":[],"rejected":[".stem already exists in .../docs (use --force to overwrite)"]}

$ rootline schema apply --report prop.json -o json | jq -c '{applied,rejected,validation_summary}'
{"applied":[],"rejected":[".stem already exists in .../docs (use --force to overwrite)"],
 "validation_summary":{"total_files":2,"valid_files":1,"invalid_files":1,"total_errors":1}}

$ diff docs/.stem stem.before && echo "PRESERVED byte-for-byte"
PRESERVED byte-for-byte

$ rootline schema apply --report prop.json --dry-run --force -o json | jq -c .applied
["overwrite_stem: .../docs/.stem"]
```

The schema survives, and the validation summary is honest again — `1 invalid / 1 error` — precisely because the constraints still exist.

## How

**The overwrite guard stats the resolved target, not its parent.** The check runs after `fix.ContainPath`, so it inspects the same path the write would touch. Message shape matches `cmd/rootline/init.go:94`, the CLI's existing precedent.

**`rejected[]` rather than `errors[]`.** `internal/fix/repair.go:55` states the rule outright: *"Rejected, not Errors: they are a policy refusal rather than a failed write."* An existing `.stem` is a refusal, not a failure. A prior draft of this change cited `repair apply` as precedent for putting unknown types in `errors[]`; that was verified false — `repair.go:160` sends unknown types to `Rejected`.

**Dry-run names the real action.** Reporting `create_stem` for what is actually a replacement is the blind spot that let the data loss through review in the first place, so the action string distinguishes the two.

**The analyze-path routing filter at `cmd/rootline/schema.go:366-369` is deliberately KEPT.** An earlier design proposed deleting it and letting the new `default:` branch be the single source of truth. That would have been a regression: `internal/infer` emits ~34 inference types and only six are schema-modifying, so every diagnostic and data-correction type would have been reported as `unknown inference type`. The `default:` branch is a drift guard that can only fire if the filter and the switch disagree.

## Scope boundaries with other open issues

- **#61 (exit codes / atomicity)** — untouched. `schema apply` still exits 0 in every path here, and no test asserts otherwise. `cmd/rootline/repair.go` is not modified, so #61 remains free to pick one report-path convention for both commands.
- **#66 (dead code)** — `infer.ScaffoldSchema` still has its production caller in this slice. It becomes caller-less in Slice B; deleting it belongs to #66's cluster.

## Follow-ups surfaced by review (pre-existing, not introduced here)

- `internal/infer/apply.go` `parseValueList` splits enum values on whitespace, so multi-word values like `In Progress` silently become two.
- `TestSchemaProposeIncremental` compares `ModTime()` for non-modification detection, which is filesystem-resolution dependent.

## Slice 2 (next PR in the chain)

`SchemaProposal.Patch` so apply writes what propose proposed; `SchemaProposalsReport.Root` so a report applies from any directory; and `runPostApplyValidation` returning an error instead of an all-zero summary.

## Breaking change — please confirm the release intent

Marked `fix(schema)!` with a `BREAKING CHANGE` footer, so the release workflow will cut a **major**. Invocations that previously replaced a governed schema now refuse. Issue #59 calls this out as intended ("previously-succeeding invocations against a governed directory now fail, which is the point"), and `--force` restores the old behaviour. If a patch release is preferred, drop the `!` and the footer before merging — but note that silently shipping this under a plain `fix` would land a breaking change as a patch.

## Checklist

- [x] Tests pass (`just test` — 13 packages, 0 failures)
- [x] Code is clean (`just check` — gofmt + golangci-lint 0 issues + build)
- [x] Coverage gate (`just coverage-check` — TOTAL 89.2%; `cmd/rootline` 86.8%, `internal/infer` 93.0%, floor 85%)
- [x] Changes are documented (`.claude/skills/rootline/ref-schema.md`, `docs/fix.md`)
- [x] Deliberately left unlinked by closing keyword (intermediate PR of a chain)
