### PR TITLE
fix(schema): apply the proposed patch and validate honestly

### DIFF
--- a/.claude/skills/rootline/ref-schema.md
+++ b/.claude/skills/rootline/ref-schema.md
@@ -143,7 +143,9 @@ Use these instead of hand-rolling `WalkUp` + `entries[0]` indexing in new comman
 
 `rootline schema propose <dir> [--incremental] [--output json|table]` generates read-only schema proposals:
 - Detects whether the directory has a hierarchical structure (E##/F##/S###/T### patterns) and calls `GenerateHierarchicalSchema` or `GenerateFlatSchema`
-- Emits JSON: version 1, kind `"rootline/schema-proposals"`, with `proposals` array (id, operation, target, confidence, requires_agent, patch_preview) and summary
+- Emits JSON: version 1, kind `"rootline/schema-proposals"`, with `proposals` array (id, operation, target, confidence, requires_agent, `patch`, `patch_preview`) and summary
+- `patch` carries the **full** inferred YAML and is what `schema apply` writes. `patch_preview` is the same YAML truncated to 200 chars, for display only — never apply from it
+- `root` carries the **absolute** scan root, so the report stays applicable from any working directory
 - `--incremental`: skips proposals covered by existing `.stem` files
 - Never creates, modifies, or deletes any file
 
@@ -152,16 +154,18 @@ Use these instead of hand-rolling `WalkUp` + `entries[0]` indexing in new comman
 `rootline schema apply --report <proposals.json> [--dry-run] [--force]` applies schema proposals to `.stem` files:
 - Input kind must be `"rootline/schema-proposals"`, version must be 1 (else structured error)
 - Skips proposals with `requires_agent: true`
-- `create_stem` operation: creates the target `.stem` file with the proposed schema
+- `create_stem` operation: writes `proposal.patch` **byte-identical** to the target `.stem`. Apply never re-derives the schema, so what a reviewer approved is what lands on disk
+- A proposal with an empty or missing `patch` is refused into `errors[]` with an instruction to re-run `schema propose`; it is never silently scaffolded into untyped `type: string` shells
 - Unknown operations: rejected with message in `rejected[]` (policy refusal, not error)
 - **Flag: `--force`** — Overwrites existing `.stem` files when applying `create_stem` proposals. Without `--force`, proposals targeting existing files are rejected (policy refusal).
 - `--dry-run`: no files written; reports what would be done
-- Post-apply: runs `rootline validate --all` and includes results in output
+- Scan root: `report.root` when present, else `report.path` resolved against the caller's CWD (legacy reports)
+- Post-apply: runs `rootline validate --all` against that scan root. A failed scan surfaces in `errors[]` — it is never reported as an all-zero `validation_summary`, which would be indistinguishable from a clean run
 - Emits JSON: version 1, kind `"rootline/schema-apply"` with applied/skipped/rejected/errors/validation_summary
 
 **Path containment.** Each `create_stem` target is validated with
-`fix.ContainPath(scanRoot, target, fix.PolicyAcceptAbsolute)` before `ScaffoldSchema` runs, and
-`ScaffoldSchema` receives the directory of the *validated* target, not the raw one.
+`fix.ContainPath(scanRoot, target, fix.PolicyAcceptAbsolute)` before anything is written, and the
+write targets the *validated* path, not the raw one.
 
 Two deliberate differences from `repair apply`:
 - **Absolute targets are accepted, then confined** (`PolicyAcceptAbsolute`). `schema propose`

--- a/cmd/rootline/schema.go
+++ b/cmd/rootline/schema.go
@@ -27,6 +27,7 @@ type SchemaProposal struct {
 	Target        string  `json:"target"`    // path to .stem file
 	Confidence    float64 `json:"confidence"`
 	RequiresAgent bool    `json:"requires_agent"`
+	Patch         string  `json:"patch,omitempty"` // full YAML markup to be written
 	PatchPreview  string  `json:"patch_preview"`
 }
 
@@ -35,6 +36,7 @@ type SchemaProposalsReport struct {
 	Version     int              `json:"version"`
 	Kind        string           `json:"kind"`
 	Path        string           `json:"path"`
+	Root        string           `json:"root,omitempty"` // absolute path to scan root
 	Incremental bool             `json:"incremental"`
 	Proposals   []SchemaProposal `json:"proposals"`
 	Summary     ProposalsSummary `json:"summary"`
@@ -151,6 +153,7 @@ func runSchemaPropose(cmd *cobra.Command, args []string) error {
 			Version:     1,
 			Kind:        "rootline/schema-proposals",
 			Path:        scanRoot,
+			Root:        root,
 			Incremental: schemaProposeIncremental,
 			Proposals:   []SchemaProposal{},
 			Summary:     ProposalsSummary{},
@@ -191,6 +194,7 @@ func runSchemaPropose(cmd *cobra.Command, args []string) error {
 		Version:     1,
 		Kind:        "rootline/schema-proposals",
 		Path:        scanRoot,
+		Root:        root,
 		Incremental: schemaProposeIncremental,
 		Proposals:   proposals,
 	}
@@ -257,13 +261,17 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve absolute path from report.
-	scanRoot := report.Path
-	if !filepath.IsAbs(scanRoot) {
-		absRoot, err := filepath.Abs(scanRoot)
-		if err != nil {
-			return fmt.Errorf("resolving path: %w", err)
+	// Prefer report.Root if set (absolute path); otherwise fall back to report.Path (CWD-relative)
+	scanRoot := report.Root
+	if scanRoot == "" {
+		scanRoot = report.Path
+		if !filepath.IsAbs(scanRoot) {
+			absRoot, err := filepath.Abs(scanRoot)
+			if err != nil {
+				return fmt.Errorf("resolving path: %w", err)
+			}
+			scanRoot = absRoot
 		}
-		scanRoot = absRoot
 	}
 
 	resolved := &fix.ResolvedTargetsBreakdown{
@@ -294,6 +302,12 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 			}
 			resolved.Accepted[proposal.Target] = target
 
+			// Check for empty patch before write attempt
+			if proposal.Patch == "" {
+				result.Errors = append(result.Errors, fmt.Sprintf("create_stem: %s: patch content required; re-run 'schema propose' to generate it", proposal.Target))
+				continue
+			}
+
 			// Overwrite guard: replacing a governed .stem discards root, scope,
 			// enum values, required markers, derive and aggregate in one write,
 			// so it is a policy refusal unless the caller opted in with --force.
@@ -312,9 +326,15 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 				action = "overwrite_stem"
 			}
 
-			if err := infer.ScaffoldSchema(filepath.Dir(target), schemaApplyDryRun); err != nil {
-				result.Errors = append(result.Errors, fmt.Sprintf("scaffold %s: %v", proposal.Target, err))
+			// Write the patch content byte-identical to what was proposed (not regenerated)
+			if !schemaApplyDryRun {
+				if err := os.WriteFile(target, []byte(proposal.Patch), 0o644); err != nil {
+					result.Errors = append(result.Errors, fmt.Sprintf("write %s: %v", proposal.Target, err))
+				} else {
+					result.Applied = append(result.Applied, fmt.Sprintf("%s: %s", action, target))
+				}
 			} else {
+				// In dry-run, just record the action without writing
 				result.Applied = append(result.Applied, fmt.Sprintf("%s: %s", action, target))
 			}
 		} else {
@@ -329,8 +349,12 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 
 	// If not dry-run, run validation.
 	if !schemaApplyDryRun {
-		validationResult := runPostApplyValidation(ctx, scanRoot)
-		result.ValidationSummary = validationResult
+		validationResult, validationErr := runPostApplyValidation(ctx, scanRoot)
+		if validationErr != nil {
+			result.Errors = append(result.Errors, validationErr.Error())
+		} else {
+			result.ValidationSummary = validationResult
+		}
 	}
 
 	// Output result.
@@ -414,8 +438,12 @@ func runSchemaApplyFromAnalyze(cmd *cobra.Command, data []byte) error {
 
 	// If not dry-run, run validation.
 	if !schemaApplyDryRun {
-		validationResult := runPostApplyValidation(ctx, root)
-		result.ValidationSummary = validationResult
+		validationResult, validationErr := runPostApplyValidation(ctx, root)
+		if validationErr != nil {
+			result.Errors = append(result.Errors, validationErr.Error())
+		} else {
+			result.ValidationSummary = validationResult
+		}
 	}
 
 	// Output result.
@@ -426,7 +454,11 @@ func runSchemaApplyFromAnalyze(cmd *cobra.Command, data []byte) error {
 }
 
 // runPostApplyValidation runs validate --all on the root and returns a summary.
-func runPostApplyValidation(ctx context.Context, root string) *ValidationSummary {
+//
+// A failed scan returns an error rather than an empty summary. An all-zero
+// ValidationSummary is indistinguishable from a clean run, so swallowing the
+// scan error here would report a green result for a root that was never read.
+func runPostApplyValidation(ctx context.Context, root string) (*ValidationSummary, error) {
 	reg := extract.NewRegistry()
 	resolver := func(dir string) (*rules.StemFile, error) {
 		entries, err := rules.WalkUp(dir)
@@ -440,7 +472,7 @@ func runPostApplyValidation(ctx context.Context, root string) *ValidationSummary
 	// not have one yet, so a missing schema must not stop it.
 	records, err := index.Scan(ctx, root, reg, index.WithScopeResolver(resolver), index.AllowUngoverned())
 	if err != nil {
-		return &ValidationSummary{}
+		return nil, fmt.Errorf("post-apply validation scan of %s: %w", root, err)
 	}
 
 	derive.DeriveAllSimple(ctx, records, root)
@@ -473,7 +505,7 @@ func runPostApplyValidation(ctx context.Context, root string) *ValidationSummary
 		ValidFiles:   validCount,
 		InvalidFiles: invalidCount,
 		TotalErrors:  totalErrors,
-	}
+	}, nil
 }
 
 // generateSchemaProposals analyzes records and generates schema proposals.
@@ -505,6 +537,7 @@ func generateSchemaProposals(ctx context.Context, root string, records []*extrac
 				Target:        stemPath,
 				Confidence:    0.9,
 				RequiresAgent: false,
+				Patch:         yaml,
 				PatchPreview:  truncatePreview(yaml, 200),
 			}
 			proposals = append(proposals, proposal)
@@ -525,6 +558,7 @@ func generateSchemaProposals(ctx context.Context, root string, records []*extrac
 			Target:        stemPath,
 			Confidence:    0.85,
 			RequiresAgent: false,
+			Patch:         yaml,
 			PatchPreview:  truncatePreview(yaml, 200),
 		}
 		proposals = append(proposals, proposal)

--- a/cmd/rootline/schema_test.go
+++ b/cmd/rootline/schema_test.go
@@ -491,10 +491,12 @@ func TestSchemaApplyCreateStem(t *testing.T) {
 	docsDir := filepath.Join(root, "docs")
 
 	// Create a schema proposals report with create_stem
+	patchContent := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  title:\n    type: string\n  author:\n    type: string\n"
 	report := SchemaProposalsReport{
 		Version: 1,
 		Kind:    "rootline/schema-proposals",
 		Path:    docsDir,
+		Root:    root,
 		Proposals: []SchemaProposal{
 			{
 				ID:            "bootstrap-flat",
@@ -502,6 +504,7 @@ func TestSchemaApplyCreateStem(t *testing.T) {
 				Target:        filepath.Join(docsDir, ".stem"),
 				Confidence:    0.85,
 				RequiresAgent: false,
+				Patch:         patchContent,
 				PatchPreview:  "version: 2\nschema:\n  title:\n    type: string\n  author:\n    type: string\n",
 			},
 		},
@@ -740,16 +743,21 @@ func TestAnalyzeWorksWithoutSchema(t *testing.T) {
 func writeSchemaProposalsReport(t *testing.T, root, scanRoot, target string) string {
 	t.Helper()
 
+	patchContent := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  title:\n    type: string\n"
+	// Root should be the absolute version of the scan root
+	absRoot, _ := filepath.Abs(scanRoot)
 	report := SchemaProposalsReport{
 		Version: 1,
 		Kind:    "rootline/schema-proposals",
 		Path:    scanRoot,
+		Root:    absRoot,
 		Proposals: []SchemaProposal{
 			{
 				ID:           "bootstrap-flat",
 				Operation:    "create_stem",
 				Target:       target,
 				Confidence:   0.85,
+				Patch:        patchContent,
 				PatchPreview: "version: 2\nschema:\n  title:\n    type: string\n",
 			},
 		},
@@ -952,16 +960,19 @@ func TestSchemaApplyForceFlag(t *testing.T) {
 		}
 
 		// Create proposals report targeting the existing .stem
+		patchContent := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  new_field:\n    type: string\n"
 		report := SchemaProposalsReport{
 			Version: 1,
 			Kind:    "rootline/schema-proposals",
 			Path:    root,
+			Root:    root,
 			Proposals: []SchemaProposal{
 				{
 					ID:            "test-force",
 					Operation:     "create_stem",
 					Target:        stemPath,
 					RequiresAgent: false,
+					Patch:         patchContent,
 					PatchPreview:  "version: 2\nschema:\n  new_field:\n    type: string\n",
 				},
 			},
@@ -1066,14 +1077,17 @@ func TestSchemaApplyUnrecognizedOperation(t *testing.T) {
 func TestSchemaApplyDryRunDistinction(t *testing.T) {
 	writeReport := func(t *testing.T, root, name, target string) string {
 		t.Helper()
+		patchContent := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  title:\n    type: string\n"
 		report := SchemaProposalsReport{
 			Version: 1,
 			Kind:    "rootline/schema-proposals",
 			Path:    filepath.Dir(target),
+			Root:    root,
 			Proposals: []SchemaProposal{{
 				ID:        name,
 				Operation: "create_stem",
 				Target:    target,
+				Patch:     patchContent,
 			}},
 		}
 		data, err := json.Marshal(report)
@@ -1143,6 +1157,285 @@ func TestSchemaApplyDryRunDistinction(t *testing.T) {
 		}
 		if !strings.HasPrefix(result.Applied[0], "overwrite_stem: ") {
 			t.Errorf("applied[0] = %q, want an overwrite_stem action so the caller can tell a replacement from a create", result.Applied[0])
+		}
+	})
+}
+
+// writeProposalsReport builds a single-proposal report on disk. Shared by the
+// patch-fidelity and root-resolution tests, which differ only in the fields
+// they exercise.
+func writeProposalsReport(t *testing.T, scanPath, scanRoot, target, patch string) string {
+	t.Helper()
+	report := SchemaProposalsReport{
+		Version: 1,
+		Kind:    "rootline/schema-proposals",
+		Path:    scanPath,
+		Root:    scanRoot,
+		Proposals: []SchemaProposal{{
+			ID:        "p1",
+			Operation: "create_stem",
+			Target:    target,
+			Patch:     patch,
+		}},
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshaling report: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "proposals.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("writing report: %v", err)
+	}
+	return path
+}
+
+// TestSchemaProposePopulatesFullPatch asserts that propose records the whole
+// inferred schema, not just the 200-char display preview. Without the full
+// patch there is nothing for apply to write except a re-derivation.
+func TestSchemaProposePopulatesFullPatch(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		"task1.md": "---\nstatus: done\ntype: feature\n---\n# Task 1\n",
+		"task2.md": "---\nstatus: pending\ntype: bug\n---\n# Task 2\n",
+	})
+
+	stdout, err := executeSchemaPropose(t, root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var report SchemaProposalsReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, stdout)
+	}
+	if len(report.Proposals) == 0 {
+		t.Fatal("expected at least one proposal")
+	}
+
+	p := report.Proposals[0]
+	if p.Patch == "" {
+		t.Fatal("patch is empty; propose must record the full YAML it inferred")
+	}
+	for _, want := range []string{"version: 2", "schema:", "status", "type"} {
+		if !strings.Contains(p.Patch, want) {
+			t.Errorf("patch is missing %q; got:\n%s", want, p.Patch)
+		}
+	}
+	if p.PatchPreview == "" {
+		t.Error("patch_preview must stay populated for display")
+	}
+	if len(p.PatchPreview) > 203 {
+		t.Errorf("patch_preview is %d chars; it must stay truncated for display", len(p.PatchPreview))
+	}
+}
+
+// TestSchemaApplyWritesProposedPatchVerbatim is the propose->apply contract:
+// the bytes a reviewer approved are the bytes that land on disk. Before this
+// change apply ignored the proposal body and re-derived an untyped schema, so
+// approving a proposal approved something the tool would never produce.
+func TestSchemaApplyWritesProposedPatchVerbatim(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		"task1.md": "---\nstatus: done\n---\n# Task 1\n",
+		"task2.md": "---\nstatus: pending\n---\n# Task 2\n",
+	})
+
+	stdout, err := executeSchemaPropose(t, root)
+	if err != nil {
+		t.Fatalf("propose: %v", err)
+	}
+	var report SchemaProposalsReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(report.Proposals) == 0 {
+		t.Fatal("expected at least one proposal")
+	}
+	proposed := report.Proposals[0].Patch
+
+	reportPath := filepath.Join(t.TempDir(), "proposals.json")
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshaling report: %v", err)
+	}
+	if err := os.WriteFile(reportPath, data, 0o644); err != nil {
+		t.Fatalf("writing report: %v", err)
+	}
+
+	if _, err := executeSchemaApply(t, "--report", reportPath); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	written := string(mustReadFile(t, report.Proposals[0].Target))
+	if written != proposed {
+		t.Errorf("written .stem does not match the proposed patch.\nproposed:\n%s\nwritten:\n%s", proposed, written)
+	}
+	// The regression this guards: the old path emitted untyped shells.
+	if strings.Contains(written, "type: string") && !strings.Contains(proposed, "type: string") {
+		t.Error("written schema was re-derived rather than taken from the proposal")
+	}
+}
+
+// TestSchemaApplyEmptyPatchRejected covers legacy reports that predate the
+// patch field. Refusing is the point: the old fallback silently wrote untyped
+// shells over whatever was there.
+func TestSchemaApplyEmptyPatchRejected(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		"test.md": "---\ntitle: Test\n---\nContent",
+	})
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("resolving root: %v", err)
+	}
+	stemPath := filepath.Join(absRoot, ".stem")
+
+	reportPath := writeProposalsReport(t, absRoot, absRoot, stemPath, "")
+
+	out, err := executeSchemaApply(t, "--report", reportPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := decodeSchemaApplyResult(t, out)
+
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "patch content required") && strings.Contains(e, "schema propose") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("errors = %v, want one telling the caller to re-run schema propose", result.Errors)
+	}
+	if len(result.Applied) != 0 {
+		t.Errorf("applied = %v, want empty for a proposal with no patch", result.Applied)
+	}
+	if _, statErr := os.Stat(stemPath); statErr == nil {
+		t.Error("a .stem was written despite the proposal carrying no patch")
+	}
+}
+
+// TestSchemaApplyRootResolution covers the scan root the post-apply validation
+// runs against. report.Root is absolute, so a report stays applicable from any
+// working directory; reports without it keep the old CWD-relative behaviour.
+func TestSchemaApplyRootResolution(t *testing.T) {
+	const patch = "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  title:\n    type: string\n"
+
+	t.Run("propose records an absolute root", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"test.md": "---\ntitle: Test\n---\nContent",
+		})
+		stdout, err := executeSchemaPropose(t, root)
+		if err != nil {
+			t.Fatalf("propose: %v", err)
+		}
+		var report SchemaProposalsReport
+		if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if !filepath.IsAbs(report.Root) {
+			t.Errorf("root = %q, want an absolute path so the report survives a change of directory", report.Root)
+		}
+	})
+
+	t.Run("root wins over a path that would resolve elsewhere", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/test.md": "---\ntitle: Test\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		// Path is a bare relative name that would resolve against the test
+		// process CWD; Root is the real location.
+		reportPath := writeProposalsReport(t, "docs", docsDir, filepath.Join(docsDir, ".stem"), patch)
+
+		out, err := executeSchemaApply(t, "--report", reportPath)
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 1 {
+			t.Fatalf("applied = %v (errors %v), want the proposal applied via report.Root", result.Applied, result.Errors)
+		}
+		if _, statErr := os.Stat(filepath.Join(docsDir, ".stem")); statErr != nil {
+			t.Errorf("no .stem at the root-resolved location: %v", statErr)
+		}
+	})
+
+	t.Run("legacy report without root keeps path-based resolution", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"test.md": "---\ntitle: Test\n---\nContent",
+		})
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			t.Fatalf("resolving root: %v", err)
+		}
+		reportPath := writeProposalsReport(t, absRoot, "", filepath.Join(absRoot, ".stem"), patch)
+
+		out, err := executeSchemaApply(t, "--report", reportPath)
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+		if len(result.Applied) != 1 {
+			t.Errorf("applied = %v (errors %v), want legacy path resolution to still work", result.Applied, result.Errors)
+		}
+	})
+}
+
+// TestPostApplyValidationErrorPropagation tests that validation errors surface in results.
+func TestPostApplyValidationErrorPropagation(t *testing.T) {
+	// A scan root that does not exist must surface as an error. This is issue
+	// #59 sub-defect 4b: applying a report from another directory resolved the
+	// scan root to a path that was never there, and the swallowed scan error
+	// was reported as total_files: 0 — indistinguishable from a clean run.
+	t.Run("unscannable root surfaces an error instead of an all-zero summary", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		reportPath := writeProposalsReport(t, missing, missing,
+			filepath.Join(missing, ".stem"), "version: 2\nschema:\n  title:\n    type: string\n")
+
+		out, err := executeSchemaApply(t, "--report", reportPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+
+		foundScanError := false
+		for _, e := range result.Errors {
+			if strings.Contains(e, "post-apply validation scan") {
+				foundScanError = true
+			}
+		}
+		if !foundScanError {
+			t.Errorf("errors = %v, want one naming the failed post-apply validation scan", result.Errors)
+		}
+		if result.ValidationSummary != nil {
+			t.Errorf("validation_summary = %+v, want it omitted when the scan failed", result.ValidationSummary)
+		}
+	})
+
+	// The complement: a scan that succeeds must report the real numbers,
+	// including failures caused by the schema that was just written.
+	t.Run("successful scan reports real counts for the freshly written schema", func(t *testing.T) {
+		root := setupValidateProject(t, map[string]string{
+			"docs/a.md": "---\nestado: Pending\n---\nContent",
+			"docs/b.md": "---\nestado: Bogus\n---\nContent",
+		})
+		docsDir := filepath.Join(root, "docs")
+		target := filepath.Join(docsDir, ".stem")
+		patch := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  estado:\n    type: enum\n    required: true\n    values: [Pending, Done]\n"
+		reportPath := writeProposalsReport(t, docsDir, docsDir, target, patch)
+
+		out, err := executeSchemaApply(t, "--report", reportPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		result := decodeSchemaApplyResult(t, out)
+
+		if result.ValidationSummary == nil {
+			t.Fatalf("validation_summary is nil; a successful scan must report one. errors=%v", result.Errors)
+		}
+		if result.ValidationSummary.TotalFiles != 2 {
+			t.Errorf("total_files = %d, want 2", result.ValidationSummary.TotalFiles)
+		}
+		// b.md violates the enum the patch just introduced, so a green summary
+		// here would mean validation ran against something that cannot fail.
+		if result.ValidationSummary.InvalidFiles == 0 || result.ValidationSummary.TotalErrors == 0 {
+			t.Errorf("summary = %+v, want the enum violation in b.md counted", result.ValidationSummary)
 		}
 	})
 }

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -162,6 +162,21 @@ rootline schema apply --report proposals.json
 
 Data-only repairs (correct_value, add_field, etc.) are **ignored** — use `rootline repair apply` instead.
 
+**What propose proposes is what apply writes.** Each `create_stem` proposal carries a `patch`
+field holding the complete inferred YAML, and `schema apply` writes those bytes verbatim. It does
+not re-derive the schema at apply time, so the artifact a reviewer approved is the artifact that
+lands on disk. The neighbouring `patch_preview` is the same YAML truncated to 200 characters for
+display; it is not the write source. A proposal with no `patch` — a report generated before this
+field existed — is refused with an instruction to re-run `schema propose`, rather than falling
+back to a generator that emits untyped `type: string` shells.
+
+**Where the scan root comes from.** `schema propose` records an absolute `root`, so a report
+applies from any working directory — the usual CI shape, where proposals are written into an
+`artifacts/` directory and applied from elsewhere. Reports without `root` keep the older behaviour
+of resolving `path` against the caller's working directory. Post-apply validation runs against
+that root, and a scan that fails surfaces in `errors[]` rather than as an all-zero
+`validation_summary`, which reads identically to a clean run.
+
 **Path containment.** As with `repair apply`, a report is untrusted input: every `create_stem`
 target is checked against the scan root before a `.stem` is written, so a report naming
 `<root>/../../outside/.stem` no longer scaffolds outside the tree the command was pointed at.


### PR DESCRIPTION
## What

`schema apply` now writes what `schema propose` proposed, and its post-apply validation can no longer report a false green. Slice 2 of 2 for issue #59, stacked on #82.

- `SchemaProposal.patch` carries the **full** inferred YAML; `schema apply` writes those bytes verbatim instead of re-deriving the schema. `patch_preview` keeps its 200-char truncation for display only.
- A proposal with no `patch` is refused with "re-run `schema propose`" rather than falling back to the untyped-shell generator.
- `SchemaProposalsReport.root` carries the absolute scan root, so a report applies from any working directory.
- `runPostApplyValidation` returns `(*ValidationSummary, error)`; a failed scan surfaces in `errors[]` instead of an all-zero summary.

Both envelope fields are additive and optional — the `rootline/schema-proposals` and `rootline/schema-apply` contracts stay at `version: 1`.

## Related issue

Fixes #59

<!-- Closing keyword belongs on this PR: it is the last of the two-PR chain. #82 carries the
     safety guard and is deliberately unlinked. -->

## Why

`runSchemaApply`'s `create_stem` branch called `infer.ScaffoldSchema`, which re-derived a schema from the documents and can only emit `type: string` (`internal/infer/scaffold.go:62`). The proposal body was never read, so **the artifact reviewed was not the artifact written** — which is the entire point of splitting propose from apply.

**Before** — propose offers a typed schema, apply writes untyped shells:

```console
$ jq -r '.proposals[0].patch_preview' prop.json
version: 2
scope:
  match: "*.md"
schema:
  estado:
    type: enum
    required: true
    values: [Bogus, Pending]

$ rootline schema apply --report prop.json && cat docs/.stem
version: 2
schema:
  estado:
    type: string
  titulo:
    type: string
```

**After** — byte-identical round trip, verified by hash:

```console
$ jq -j '.proposals[0].patch' prop.json | shasum -a256
c9979ff0cf7f2e08b0ff1f0c68fc6ae8e5a3c74adabe41f41fc383b6eb930043
$ shasum -a256 < docs/.stem
c9979ff0cf7f2e08b0ff1f0c68fc6ae8e5a3c74adabe41f41fc383b6eb930043
```

**Sub-defect 4b — applying from another directory.** `schema propose` wrote `path` relative to its own invocation directory while `apply` resolved it against the caller's. The normal CI shape — proposals in `artifacts/`, applied from elsewhere — pointed the validator at a directory that never existed:

```console
# before (on master, after PR #75 added containment)
$ cd artifacts && rootline schema apply --report prop.json -o json
{"applied":[],"errors":["containment violation: ... escapes root (root \".../artifacts/docs\")"],
 "validation_summary":{"total_files":0,"valid_files":0,"invalid_files":0,"total_errors":0}}

# after
$ cd artifacts && rootline schema apply --report prop.json -o json | jq -c '{applied,errors}'
{"applied":["create_stem: .../proj/docs/.stem"],"errors":null}
```

**Legacy report with no patch** is refused rather than silently degrading a governed schema:

```console
$ rootline schema apply --report legacy.json -o json | jq -c '{applied,errors}'
{"applied":[],"errors":["create_stem: .../docs/.stem: patch content required; re-run 'schema propose' to generate it"]}
```

**Unreadable scan root** now says so instead of reporting zeros:

```console
$ rootline schema apply --report bad.json -o json | jq -c '{errors,validation_summary}'
{"errors":[...,"post-apply validation scan of /…/nope: lstat /…/nope: no such file or directory"],
 "validation_summary":null}
```

## How

**Guard ordering in the `create_stem` branch** is deliberate: containment (`fix.ContainPath`) → empty-patch refusal → overwrite guard (`--force`, from #82) → write. The empty-patch check sits after containment so a refused target never reaches it, and before the overwrite guard so an incomplete proposal cannot consume the force decision.

**Empty patch goes to `errors[]`, not `rejected[]`.** It is a pre-write validation failure — the proposal is incomplete — rather than a policy refusal of a write that could have succeeded. That is the distinction `internal/fix/repair.go:55` draws, and the same reason the overwrite guard in #82 goes the other way.

**The legacy scan-root fallback is preserved unchanged.** `report.root` wins when present; otherwise `filepath.Abs(report.path)` behaves exactly as before. `cmd/rootline/repair.go` is untouched, so issue #61 item 3 remains free to pick either convention for both commands.

**`infer.ScaffoldSchema` is left in place** even though it now has no production caller. Removing it belongs to #66's dead-code cluster, not here.

## Scope boundaries with other open issues

- **#61 (exit codes / atomicity)** — untouched. `schema apply` still exits 0 on every path, and no test asserts otherwise. The write is still a single `os.WriteFile`; atomicity is #61's item 2.
- **#66 (dead code)** — `infer.ScaffoldSchema` becomes caller-less here; flagged for that cluster.

## Checklist

- [x] Tests pass (`just test` — 13 packages, 0 failures)
- [x] Code is clean (`just check` — gofmt + golangci-lint 0 issues + build)
- [x] Coverage gate (`just coverage-check` — TOTAL 89.3%; `cmd/rootline` 87.0%, floor 85%)
- [x] Changes are documented (`.claude/skills/rootline/ref-schema.md`, `docs/fix.md`)
- [x] Linked to its issue with a closing keyword (final PR of the chain)
