### PR TITLE
fix(extract): parse wikilink anchors

### DIFF
--- a/internal/extract/links.go
+++ b/internal/extract/links.go
@@ -62,6 +62,27 @@ func parseMarkdownDestination(dest string) (Link, bool) {
 	return link, true
 }
 
+// parseWikilinkInner converts the text between [[ and ]] into a Link.
+// The optional "type:" prefix selects the link type; the optional "#anchor"
+// suffix is split off into Link.Anchor exactly as parseMarkdownDestination
+// does for markdown destinations, so anchor-aware checks fire on both styles.
+// Returns false for a pure fragment ([[#heading]]), which names no target.
+func parseWikilinkInner(inner string) (Link, bool) {
+	link := Link{Type: "reference", Target: inner, Style: StyleWikilink}
+	if idx := strings.Index(inner, ":"); idx > 0 {
+		link.Type = inner[:idx]
+		link.Target = inner[idx+1:]
+	}
+	if target, anchor, found := strings.Cut(link.Target, "#"); found {
+		if target == "" {
+			return Link{}, false
+		}
+		link.Target = target
+		link.Anchor = anchor
+	}
+	return link, true
+}
+
 // ParseLinks extracts wiki-links and markdown links from body text.
 // Wiki-links: [[target]] (type "reference") and [[type:target]] (typed).
 // Markdown links: [text](target) with optional fragment (#anchor).
@@ -88,15 +109,12 @@ func ParseLinks(body string) []Link {
 		cleaned := removeInlineCode(line)
 
 		for _, match := range wikilinkRe.FindAllStringSubmatch(cleaned, -1) {
-			inner := match[1]
-			link := Link{Line: lineNum, Source: "body", Style: StyleWikilink}
-			if idx := strings.Index(inner, ":"); idx > 0 {
-				link.Type = inner[:idx]
-				link.Target = inner[idx+1:]
-			} else {
-				link.Type = "reference"
-				link.Target = inner
+			link, ok := parseWikilinkInner(match[1])
+			if !ok {
+				continue
 			}
+			link.Line = lineNum
+			link.Source = "body"
 			links = append(links, link)
 		}
 
@@ -153,14 +171,9 @@ func ParseFrontmatterLinks(frontmatter map[string]any) []Link {
 func parseWikilinksFromString(s string) []Link {
 	var links []Link
 	for _, match := range wikilinkRe.FindAllStringSubmatch(s, -1) {
-		inner := match[1]
-		link := Link{Line: 0, Style: StyleWikilink}
-		if idx := strings.Index(inner, ":"); idx > 0 {
-			link.Type = inner[:idx]
-			link.Target = inner[idx+1:]
-		} else {
-			link.Type = "reference"
-			link.Target = inner
+		link, ok := parseWikilinkInner(match[1])
+		if !ok {
+			continue
 		}
 		links = append(links, link)
 	}

--- a/internal/extract/links_test.go
+++ b/internal/extract/links_test.go
@@ -358,3 +358,57 @@ func TestParseLinks_MarkdownParenInTarget(t *testing.T) {
 		t.Errorf("got %+v", links[1])
 	}
 }
+
+func TestParseLinks_WikilinkAnchor(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantTarget string
+		wantAnchor string
+		wantType   string
+	}{
+		{"bare anchor", "see [[b#heading-one]]", "b", "heading-one", "reference"},
+		{"path-qualified anchor", "see [[sub/file#section]]", "sub/file", "section", "reference"},
+		{"extension and anchor", "see [[b.md#intro]]", "b.md", "intro", "reference"},
+		{"typed link with anchor", "see [[blocks:T003#done]]", "T003", "done", "blocks"},
+		{"no anchor", "see [[file]]", "file", "", "reference"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			links := ParseLinks(tc.body)
+			if len(links) != 1 {
+				t.Fatalf("expected 1 link, got %d: %+v", len(links), links)
+			}
+			if links[0].Target != tc.wantTarget {
+				t.Errorf("Target = %q, want %q", links[0].Target, tc.wantTarget)
+			}
+			if links[0].Anchor != tc.wantAnchor {
+				t.Errorf("Anchor = %q, want %q", links[0].Anchor, tc.wantAnchor)
+			}
+			if links[0].Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", links[0].Type, tc.wantType)
+			}
+			if strings.Contains(links[0].Target, "#") {
+				t.Errorf("Target %q still carries the anchor separator", links[0].Target)
+			}
+		})
+	}
+}
+
+// A wikilink that is nothing but an anchor has no target to resolve; it is a
+// same-document reference and must not become a link to the empty path.
+func TestParseLinks_WikilinkPureFragmentIsSkipped(t *testing.T) {
+	if links := ParseLinks("see [[#heading-one]]"); len(links) != 0 {
+		t.Errorf("expected pure-fragment wikilink to be skipped, got %+v", links)
+	}
+}
+
+func TestParseFrontmatterLinks_WikilinkAnchor(t *testing.T) {
+	links := ParseFrontmatterLinks(map[string]any{"ref": "[[b#heading-one]]"})
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+	if links[0].Target != "b" || links[0].Anchor != "heading-one" {
+		t.Errorf("got Target=%q Anchor=%q, want b/heading-one", links[0].Target, links[0].Anchor)
+	}
+}


### PR DESCRIPTION
## What

Wikilink parsing took the whole inner text as the target, so `[[b#heading-one]]` became a
filename containing `#`. No resolver could ever match it, and both `validate` and
`graph --check` reported such links as broken.

Markdown destinations already split the fragment into `Link.Anchor`
(`internal/extract/links.go:54-61`); the wikilink branch never did. The practical effect is
that `links.checks.anchors` could **never** fire on a wikilink corpus — and `[wikilink]` is
the default when `links.styles` is omitted.

This is the first unit of the unified link engine for issue #62.

## How

- Split the `#anchor` suffix off the target for wikilinks, matching `parseMarkdownDestination`.
- Skip pure-fragment wikilinks (`[[#heading]]`) — they name no target, exactly as the markdown
  path already treats a bare `#fragment`.
- The wikilink branch was duplicated across `ParseLinks` and `parseWikilinksFromString`, so the
  frontmatter path would have drifted from the body path. Both now share one
  `parseWikilinkInner` helper.

Ordering matters and is covered: the `type:` prefix is extracted before the `#` split, so
`[[blocks:T003#done]]` yields `Type=blocks`, `Target=T003`, `Anchor=done`.

## Parity matrix rows changed

| Feature | Before | After |
|---|---|---|
| Wikilink anchors parsed (`[[b#heading]]`) | never — anchor folded into the target | parsed into `Link.Anchor` |
| Anchor check reachable on a wikilink corpus | impossible | now reachable (the check itself lands in a later unit) |

Closes **sub-defect 9** of #62. Behavior change **B4**, classified `fix`: it makes a
previously-unmatchable link matchable and adds no new failure mode.

## Testing

- `TestParseLinks_WikilinkAnchor` — 5 cases: bare anchor, path-qualified, explicit `.md`,
  typed link, and no anchor. Asserts the target no longer carries `#`.
- `TestParseLinks_WikilinkPureFragmentIsSkipped`
- `TestParseFrontmatterLinks_WikilinkAnchor` — pins the frontmatter path to the body path.

`just check`, `just test` and `just coverage-check` all green (`internal/extract` 94.6%,
total 89.3%).

## Size

99 changed lines (83 added / 16 removed), against a 90-line forecast.

Refs #62
