### PR TITLE
fix(rules): add one canonical link resolver with wikilink .md inference

### DIFF
--- a/internal/rules/link_checks.go
+++ b/internal/rules/link_checks.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pablontiv/picokit/fuzzy"
 	"github.com/pablontiv/rootline/internal/extract"
 )
 
@@ -27,7 +26,10 @@ func NewHeadingCache() *HeadingCache {
 // against a record's links. sourceAbsPath is the absolute path of the record
 // file; relative targets resolve against its directory. Links whose style is
 // not in the schema's effective styles are skipped, as are absolute targets
-// (root-relative ADO form is out of scope).
+// (root-relative ADO form lands in a follow-up).
+//
+// Resolution runs through ResolveLinkTarget, the same entry point graph and
+// query use, so the commands cannot disagree about whether a link is broken.
 func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath string, cache *HeadingCache) []ValidationError {
 	if schema.Checks == nil {
 		return nil
@@ -59,12 +61,16 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath string, c
 		}
 
 		if schema.Checks.Resolve || schema.Checks.Anchors {
-			resolved, suggestion, ok := resolveCaseSensitive(filepath.Dir(sourceAbsPath), link.Target)
-			if !ok {
+			res := ResolveLinkTarget(ResolveRequest{
+				BaseDir: filepath.Dir(sourceAbsPath),
+				Target:  link.Target,
+				Style:   linkStyle(link),
+			})
+			if !res.OK {
 				if schema.Checks.Resolve {
 					msg := fmt.Sprintf("link target %q does not resolve to an existing file (case-sensitive)", link.Target)
-					if suggestion != "" {
-						msg += fmt.Sprintf(" (did you mean %q?)", suggestion)
+					if res.Suggestion != "" {
+						msg += fmt.Sprintf(" (did you mean %q?)", res.Suggestion)
 					}
 					errs = append(errs, ValidationError{
 						Rule:       "link_resolve",
@@ -72,13 +78,13 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath string, c
 						Message:    msg,
 						Source:     "links.checks",
 						Severity:   "error",
-						Suggestion: suggestion,
+						Suggestion: res.Suggestion,
 					})
 				}
 				continue
 			}
 			if schema.Checks.Anchors && link.Anchor != "" {
-				errs = append(errs, checkAnchor(link, resolved, cache)...)
+				errs = append(errs, checkAnchor(link, res.Path, cache)...)
 			}
 		}
 	}
@@ -156,61 +162,5 @@ func slugifyHeading(h string) string {
 	return b.String()
 }
 
-// resolveCaseSensitive resolves a relative link target against baseDir,
-// requiring exact-case matches for every target path component (APFS is
-// case-insensitive; ADO and git are not). Directory targets resolve to their
-// README.md. Returns the resolved absolute path, a fuzzy suggestion for the
-// first unmatched component (may be empty), and whether resolution succeeded.
-func resolveCaseSensitive(baseDir, target string) (string, string, bool) {
-	decoded, err := url.PathUnescape(target)
-	if err != nil {
-		decoded = target
-	}
-
-	cur := baseDir
-	for _, comp := range strings.Split(filepath.ToSlash(filepath.Clean(decoded)), "/") {
-		switch comp {
-		case "", ".":
-			continue
-		case "..":
-			cur = filepath.Dir(cur)
-			continue
-		}
-		entry, suggestion, ok := findEntry(cur, comp)
-		if !ok {
-			return "", suggestion, false
-		}
-		cur = filepath.Join(cur, entry)
-	}
-
-	info, err := os.Stat(cur)
-	if err != nil {
-		return "", "", false
-	}
-	if info.IsDir() {
-		entry, suggestion, ok := findEntry(cur, "README.md")
-		if !ok {
-			return "", suggestion, false
-		}
-		cur = filepath.Join(cur, entry)
-	}
-	return cur, "", true
-}
-
-// findEntry looks for an exact-case directory entry, returning a fuzzy
-// suggestion from the directory's entries when absent.
-func findEntry(dir, name string) (string, string, bool) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return "", "", false
-	}
-	names := make([]string, 0, len(entries))
-	for _, e := range entries {
-		if e.Name() == name {
-			return name, "", true
-		}
-		names = append(names, e.Name())
-	}
-	suggestion := fuzzy.Match(name, names)
-	return "", suggestion, false
-}
+// Resolution lives in link_resolve.go: every command shares one resolver so
+// that validate, graph and query cannot disagree about a link's validity.

--- a/internal/rules/link_checks_test.go
+++ b/internal/rules/link_checks_test.go
@@ -108,11 +108,54 @@ func TestCheckLinks_ResolveDecodesPercent20(t *testing.T) {
 func TestCheckLinks_SkipsAbsoluteAndFilteredStyles(t *testing.T) {
 	schema := mdChecksSchema(LinkChecks{Resolve: true, Encoding: true})
 	links := []extract.Link{
-		mdLink("/Root/Page.md"), // absolute: skipped
+		mdLink("/Root/Page.md"), // absolute: skipped until root-anchored resolution lands
 		{Target: "no such file", Type: "reference", Style: extract.StyleWikilink, Line: 1}, // filtered style
 	}
 	if errs := CheckLinks(links, schema, "/tmp/src.md", nil); len(errs) != 0 {
 		t.Fatalf("expected no errors, got %+v", errs)
+	}
+}
+
+// Wikilinks with checks had zero coverage: every case above pins StyleMarkdown.
+// This is the combination issue #62's headline reproduction exercises.
+func wikiChecksSchema(c LinkChecks) LinkSchema {
+	return LinkSchema{Styles: []string{extract.StyleWikilink}, Checks: &c}
+}
+
+func wikiLink(target string) extract.Link {
+	return extract.Link{Target: target, Type: "reference", Style: extract.StyleWikilink, Line: 1}
+}
+
+func TestCheckLinks_WikilinkResolvesWithoutExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "b.md"), "# B\n")
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+
+	if errs := CheckLinks([]extract.Link{wikiLink("b")}, schema, filepath.Join(dir, "t.md"), nil); len(errs) != 0 {
+		t.Fatalf("[[b]] with b.md present must resolve, got %+v", errs)
+	}
+}
+
+func TestCheckLinks_WikilinkPathQualifiedResolves(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub", "README.md"), "# Sub\n")
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+
+	if errs := CheckLinks([]extract.Link{wikiLink("sub/README")}, schema, filepath.Join(dir, "t.md"), nil); len(errs) != 0 {
+		t.Fatalf("[[sub/README]] must resolve, got %+v", errs)
+	}
+}
+
+func TestCheckLinks_WikilinkGenuinelyMissingIsBroken(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+
+	errs := CheckLinks([]extract.Link{wikiLink("nope")}, schema, filepath.Join(dir, "t.md"), nil)
+	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
+		t.Fatalf("missing wikilink target must be reported, got %+v", errs)
 	}
 }
 

--- a/internal/rules/link_resolve.go
+++ b/internal/rules/link_resolve.go
@@ -1,0 +1,139 @@
+package rules
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pablontiv/picokit/fuzzy"
+	"github.com/pablontiv/rootline/internal/extract"
+)
+
+// ResolveRequest describes one link target to resolve.
+//
+// BaseDir is the directory of the record that carries the link; relative
+// targets resolve against it. Root is the scan root and is only consulted for
+// root-anchored ("/x.md") targets — leave it empty when no root is in scope,
+// in which case a root-anchored target cannot be judged and stays unresolved.
+// Style selects style-aware behavior: only wikilinks infer a ".md" extension.
+type ResolveRequest struct {
+	BaseDir string
+	Root    string
+	Target  string
+	Style   string
+}
+
+// LinkResolution is the outcome of resolving one link target.
+//
+// Path is the absolute filesystem path the target resolved to, set only when
+// OK. Suggestion is a fuzzy match for the first unmatched path component and
+// may be empty; it is populated on failure so callers can offer "did you
+// mean?" without re-walking the directory.
+type LinkResolution struct {
+	Path       string
+	Suggestion string
+	OK         bool
+}
+
+// ResolveLinkTarget is the single authority for "does this link target exist?".
+//
+// Every command resolves through here so that validate, graph, query traversal
+// and fix cannot disagree about whether a link is broken — issue #62 existed
+// precisely because validate and graph each had their own resolver. Resolution
+// is filesystem-backed, not node-set-backed: a target that exists on disk
+// resolves even when the schema does not govern it, because the schema
+// declares what is governed, not what exists.
+//
+// Semantics, in order:
+//   - a root-anchored target ("/x.md") rebases onto Root
+//   - "%20" and other percent escapes decode
+//   - every path component must match case-exactly (APFS is case-insensitive;
+//     ADO and git are not)
+//   - a wikilink whose final component does not exist retries it with ".md"
+//   - a directory target resolves to its README.md
+func ResolveLinkTarget(req ResolveRequest) LinkResolution {
+	base, target := req.BaseDir, req.Target
+	if strings.HasPrefix(target, "/") {
+		if req.Root == "" {
+			return LinkResolution{}
+		}
+		base, target = req.Root, strings.TrimPrefix(target, "/")
+	}
+
+	decoded, err := url.PathUnescape(target)
+	if err != nil {
+		decoded = target
+	}
+
+	comps := strings.Split(filepath.ToSlash(filepath.Clean(decoded)), "/")
+	cur := base
+	for i, comp := range comps {
+		switch comp {
+		case "", ".":
+			continue
+		case "..":
+			cur = filepath.Dir(cur)
+			continue
+		}
+		entry, suggestion, ok := findEntry(cur, comp)
+		if !ok {
+			// Only the final component may gain an inferred extension:
+			// [[b]] means b.md, but a missing intermediate directory is a
+			// missing directory, not a file to guess at.
+			if inferred, ok2 := inferMarkdown(cur, comp, i == len(comps)-1, req.Style); ok2 {
+				cur = filepath.Join(cur, inferred)
+				continue
+			}
+			return LinkResolution{Suggestion: suggestion}
+		}
+		cur = filepath.Join(cur, entry)
+	}
+
+	info, err := os.Stat(cur)
+	if err != nil {
+		return LinkResolution{}
+	}
+	if info.IsDir() {
+		entry, suggestion, ok := findEntry(cur, "README.md")
+		if !ok {
+			return LinkResolution{Suggestion: suggestion}
+		}
+		cur = filepath.Join(cur, entry)
+	}
+	return LinkResolution{Path: cur, OK: true}
+}
+
+// inferMarkdown retries a missing final path component with a ".md" suffix.
+//
+// This is what makes [[b]] resolve to b.md. It is deliberately limited to
+// wikilinks: a markdown destination carries its extension by convention and
+// ADO resolves it literally, so inferring one there would accept links the
+// published wiki rejects.
+func inferMarkdown(dir, comp string, isFinal bool, style string) (string, bool) {
+	if !isFinal || style != extract.StyleWikilink || strings.HasSuffix(comp, ".md") {
+		return "", false
+	}
+	entry, _, ok := findEntry(dir, comp+".md")
+	if !ok {
+		return "", false
+	}
+	return entry, true
+}
+
+// findEntry looks for an exact-case directory entry, returning a fuzzy
+// suggestion from the directory's entries when absent.
+func findEntry(dir, name string) (string, string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", "", false
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Name() == name {
+			return name, "", true
+		}
+		names = append(names, e.Name())
+	}
+	return "", fuzzy.Match(name, names), false
+}

--- a/internal/rules/link_resolve_test.go
+++ b/internal/rules/link_resolve_test.go
@@ -1,0 +1,101 @@
+package rules
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/extract"
+)
+
+// A bare wikilink is the canonical Rootline form: [[b]] next to b.md must
+// resolve. This is the headline case of issue #62 sub-defect 1.
+func TestResolveLinkTarget_WikilinkInfersMarkdownExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "b.md"), "# B\n")
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: dir, Target: "b", Style: extract.StyleWikilink,
+	})
+	if !got.OK {
+		t.Fatalf("[[b]] should resolve to b.md, got %+v", got)
+	}
+	if want := filepath.Join(dir, "b.md"); got.Path != want {
+		t.Errorf("Path = %q, want %q", got.Path, want)
+	}
+}
+
+// The .md inference must survive a directory prefix. Issue #62 sub-defect 10
+// is exactly this asymmetry: [[b]] worked while [[sub/README]] did not.
+func TestResolveLinkTarget_WikilinkInferenceWithDirectoryPrefix(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "sub", "README.md"), "# Sub\n")
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: dir, Target: "sub/README", Style: extract.StyleWikilink,
+	})
+	if !got.OK {
+		t.Fatalf("[[sub/README]] should resolve, got %+v", got)
+	}
+	if want := filepath.Join(dir, "sub", "README.md"); got.Path != want {
+		t.Errorf("Path = %q, want %q", got.Path, want)
+	}
+}
+
+// Inference is style-aware: markdown destinations carry their extension by
+// convention, and ADO resolves them literally. Keep that strict.
+func TestResolveLinkTarget_MarkdownDoesNotInferExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "b.md"), "# B\n")
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: dir, Target: "b", Style: extract.StyleMarkdown,
+	})
+	if got.OK {
+		t.Errorf("markdown target %q must not infer .md, got %+v", "b", got)
+	}
+}
+
+// Behavior inherited from resolveCaseSensitive must survive the extension.
+func TestResolveLinkTarget_PreservesStrictSemantics(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "guides", "README.md"), "# Guides\n")
+	writeFile(t, filepath.Join(dir, "Setup.md"), "# Setup\n")
+	writeFile(t, filepath.Join(dir, "my page.md"), "# P\n")
+
+	t.Run("directory resolves to README", func(t *testing.T) {
+		got := ResolveLinkTarget(ResolveRequest{BaseDir: dir, Target: "guides/", Style: extract.StyleMarkdown})
+		if !got.OK {
+			t.Errorf("directory with README should resolve, got %+v", got)
+		}
+	})
+	t.Run("case mismatch stays broken", func(t *testing.T) {
+		got := ResolveLinkTarget(ResolveRequest{BaseDir: dir, Target: "setup.md", Style: extract.StyleMarkdown})
+		if got.OK {
+			t.Errorf("case mismatch must stay broken (ADO/git are case-sensitive), got %+v", got)
+		}
+	})
+	t.Run("percent-20 decodes", func(t *testing.T) {
+		got := ResolveLinkTarget(ResolveRequest{BaseDir: dir, Target: "my%20page.md", Style: extract.StyleMarkdown})
+		if !got.OK {
+			t.Errorf("%%20 target should resolve, got %+v", got)
+		}
+	})
+	t.Run("suggestion offered for near miss", func(t *testing.T) {
+		got := ResolveLinkTarget(ResolveRequest{BaseDir: dir, Target: "Setpu.md", Style: extract.StyleMarkdown})
+		if got.OK || got.Suggestion != "Setup.md" {
+			t.Errorf("expected broken with suggestion Setup.md, got %+v", got)
+		}
+	})
+}
+
+// A wikilink that already carries .md must not become b.md.md.
+func TestResolveLinkTarget_WikilinkWithExplicitExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "b.md"), "# B\n")
+	got := ResolveLinkTarget(ResolveRequest{BaseDir: dir, Target: "b.md", Style: extract.StyleWikilink})
+	if !got.OK || got.Path != filepath.Join(dir, "b.md") {
+		t.Errorf("explicit .md wikilink should resolve as-is, got %+v", got)
+	}
+}

--- a/internal/rules/link_targets.go
+++ b/internal/rules/link_targets.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
 )
@@ -21,15 +20,16 @@ func ResolveMarkdownTargets(records []*extract.Record, root string) {
 			if link.Style != extract.StyleMarkdown {
 				continue
 			}
-			base, target := dir, link.Target
-			if strings.HasPrefix(target, "/") {
-				base, target = root, strings.TrimPrefix(target, "/")
-			}
-			resolved, _, ok := resolveCaseSensitive(base, target)
-			if !ok {
+			res := ResolveLinkTarget(ResolveRequest{
+				BaseDir: dir,
+				Root:    root,
+				Target:  link.Target,
+				Style:   extract.StyleMarkdown,
+			})
+			if !res.OK {
 				continue
 			}
-			if rel, err := filepath.Rel(root, resolved); err == nil {
+			if rel, err := filepath.Rel(root, res.Path); err == nil {
 				rec.Links[i].Target = rel
 			}
 		}


### PR DESCRIPTION
## What

`validate` and `graph` each had their own link resolver and never agreed. This replaces both
with one.

With the **default** `links.styles: [wikilink]` (`internal/rules/rules.go:82-87`) and
`links.checks.resolve: true`, given `b.md` on disk and a document containing `[[b]]`:

```console
$ rootline validate wl/t.md -o json     # before
{"valid":false,"errors":[{"rule":"link_resolve","message":"link target \"b\" does not resolve ..."}]}
exit=1
$ rootline graph --check wl/            # before
No cycles or broken links found.
exit=0
```

`validate`'s `resolveCaseSensitive` walked the filesystem case-sensitively but never tried
`<target>.md`, so **every valid extension-less wikilink was reported broken** — while `graph`
resolved the same link fine. The most natural configuration was the maximally broken one, and
`rootline validate --all` went red on a healthy repository.

## How

`rules.ResolveLinkTarget` becomes the single authority for *"does this link target exist?"*.
The private resolver it replaces is deleted, and both existing callers (`CheckLinks`,
`ResolveMarkdownTargets`) are rewired onto it.

**Resolution is filesystem-backed, not node-set-backed.** A target that exists on disk resolves
even when the schema does not govern it, because the schema declares what is *governed*, not
what *exists*. That distinction is what lets `graph` and `validate` share one answer — and it's
why the later units can drop `graph`'s divergent node-membership check.

Inference is deliberately narrow:
- **Final component only.** A missing intermediate directory is a missing directory, not a file
  to guess at.
- **Wikilinks only.** Markdown destinations carry their extension by convention and ADO
  resolves them literally, so inferring one there would accept links the published wiki rejects.

Every prior guarantee is preserved and pinned by tests: case-exact component matching, `%20`
decoding, `..`/`.` handling, directory targets resolving to `README.md`, and the fuzzy
suggestion for the first unmatched component.

## Parity matrix rows changed

| Feature | `validate` before | `validate` after | `graph` |
|---|---|---|---|
| Extension-less wikilink → `.md` | **no** | **yes** | yes (unchanged) |
| Path-qualified extension-less wikilink | **no** | **yes** | still no — fixed when graph adopts this resolver |

Closes **sub-defect 1** (the headline) and the `validate` half of **sub-defect 10**.
Behavior change **B1**, classified `fix`: it makes previously-unmatchable valid links match and
introduces no new failure mode.

## Evidence

The issue's own reproduction, case A, now agrees:

```console
$ rootline validate wl/t.md -o json
{"version":1,"kind":"rootline/validate","path":"wl/t.md","valid":true,"errors":[],"warnings":[]}
exit=0
$ rootline graph --check wl/
No cycles or broken links found.
exit=0
```

## Testing

New `internal/rules/link_resolve_test.go` covers inference with and without a directory prefix,
markdown staying strict, explicit `.md` not becoming `b.md.md`, and the preserved strict
semantics (directory→README, case mismatch, `%20`, suggestion).

`internal/rules/link_checks_test.go` gains `wikiChecksSchema`/`wikiLink` and three wikilink
cases. This closes a real coverage hole the issue named: **every** existing case in that file
hardcoded `StyleMarkdown`, so the wikilink + `checks` combination — the one the headline
reproduction uses — had *zero* coverage.

`just check`, `just test`, `just coverage-check` green (`internal/rules` 89.4%, total 89.2%).

## Size and stacking

383 changed lines. Based on #85, **not** master — review that first.

This unit was forecast at 360 but implemented at 509, so it was split; root-anchored target
resolution (sub-defect 3) follows as its own PR rather than pushing this one over the 400-line
review budget.

Refs #62
