### PR TITLE
fix(fix): preserve key order and comments when rewriting frontmatter

### DIFF
--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -121,6 +121,16 @@ func ApplyFixes(_ context.Context, record *extract.Record, effective *rules.Stem
 }
 
 // RewriteFrontmatter rebuilds a markdown file with updated frontmatter.
+//
+// Existing keys keep their original position, comments and scalar quoting style,
+// so a one-field mutation yields a one-field diff. Keys the map introduces are
+// appended after the existing ones; keys it omits are removed.
+//
+// The preserved guarantee is bounded by what a yaml.Node round-trip provides:
+// yaml.v3 re-emits from the node tree rather than the source bytes, so
+// inter-token whitespace and nested indentation are normalized. Frontmatter that
+// does not parse as a YAML mapping falls back to the sorted, comment-less
+// rebuild this function used previously.
 func RewriteFrontmatter(original string, fm map[string]any) string {
 	// Find frontmatter boundaries
 	if !strings.HasPrefix(original, "---\n") {
@@ -137,7 +147,12 @@ func RewriteFrontmatter(original string, fm map[string]any) string {
 	if endIdx == -1 {
 		return original
 	}
+	fmText := original[4 : 4+endIdx+1]
 	body := original[4+endIdx+5:]
+
+	if rendered, ok := renderPreservedFrontmatter(fmText, fm); ok {
+		return "---\n" + rendered + "---\n" + body
+	}
 
 	var b strings.Builder
 	b.WriteString("---\n")
@@ -148,6 +163,8 @@ func RewriteFrontmatter(original string, fm map[string]any) string {
 }
 
 // WriteFrontmatterFields writes frontmatter fields to a builder in sorted order.
+// It is the fallback path for frontmatter that RewriteFrontmatter cannot parse
+// as a YAML mapping, and the writer used when a document has no frontmatter yet.
 func WriteFrontmatterFields(b *strings.Builder, fm map[string]any) {
 	keys := make([]string, 0, len(fm))
 	for k := range fm {

--- a/internal/fix/frontmatter.go
+++ b/internal/fix/frontmatter.go
@@ -1,0 +1,132 @@
+package fix
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// frontmatterIndent is the nesting indentation used when re-emitting frontmatter.
+// yaml.v3 defaults to 4; two spaces matches the map-based writer this replaced
+// and the convention already present in the repository's documents.
+const frontmatterIndent = 2
+
+// renderPreservedFrontmatter re-emits fmText with the values from fm applied,
+// keeping the original key order, comments and scalar quoting style.
+//
+// It reports false when fmText is not a YAML mapping it can round-trip, which
+// leaves the caller on its map-based fallback. RewriteFrontmatter cannot return
+// an error — its signature is shared by six call sites, one of them under
+// cmd/rootline — so an unparseable block degrades rather than failing the write.
+func renderPreservedFrontmatter(fmText string, fm map[string]any) (string, bool) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(fmText), &doc); err != nil {
+		return "", false
+	}
+
+	mapping := documentMapping(&doc)
+	if mapping == nil {
+		return "", false
+	}
+
+	seen := reconcileMapping(mapping, fm)
+	appendNewKeys(mapping, fm, seen)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(frontmatterIndent)
+	if err := enc.Encode(mapping); err != nil {
+		return "", false
+	}
+	if err := enc.Close(); err != nil {
+		return "", false
+	}
+	return buf.String(), true
+}
+
+// documentMapping unwraps a parsed document down to its top-level mapping node,
+// synthesising an empty mapping for empty frontmatter. It returns nil when the
+// block holds something other than a mapping, which this rewrite cannot edit
+// key-by-key.
+func documentMapping(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == 0 || len(doc.Content) == 0 {
+		return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	return root
+}
+
+// reconcileMapping updates the values of keys present in fm, drops keys absent
+// from it, and reports which keys it consumed. A key whose value is unchanged is
+// left completely untouched so its comment and quoting style survive verbatim.
+func reconcileMapping(mapping *yaml.Node, fm map[string]any) map[string]bool {
+	seen := make(map[string]bool, len(fm))
+	kept := make([]*yaml.Node, 0, len(mapping.Content))
+
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		keyNode, valNode := mapping.Content[i], mapping.Content[i+1]
+		newVal, ok := fm[keyNode.Value]
+		if !ok {
+			continue // key dropped from the map — remove the pair
+		}
+		seen[keyNode.Value] = true
+
+		if !valueNodeMatches(valNode, newVal) {
+			replaceValueNode(valNode, newVal)
+		}
+		kept = append(kept, keyNode, valNode)
+	}
+
+	mapping.Content = kept
+	return seen
+}
+
+// valueNodeMatches reports whether the node already decodes to want, in which
+// case it must not be rewritten.
+func valueNodeMatches(valNode *yaml.Node, want any) bool {
+	var current any
+	if err := valNode.Decode(&current); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(current, want)
+}
+
+// replaceValueNode overwrites a value node in place, carrying its comments over
+// so that a changed value does not silently discard the note attached to it.
+func replaceValueNode(valNode *yaml.Node, value any) {
+	head, line, foot := valNode.HeadComment, valNode.LineComment, valNode.FootComment
+
+	var encoded yaml.Node
+	if err := encoded.Encode(value); err != nil {
+		return
+	}
+	*valNode = encoded
+
+	valNode.HeadComment, valNode.LineComment, valNode.FootComment = head, line, foot
+}
+
+// appendNewKeys adds keys that fm introduced, after the existing ones. They are
+// sorted so repeated runs over the same document produce the same output.
+func appendNewKeys(mapping *yaml.Node, fm map[string]any, seen map[string]bool) {
+	fresh := make([]string, 0, len(fm))
+	for k := range fm {
+		if !seen[k] {
+			fresh = append(fresh, k)
+		}
+	}
+	sort.Strings(fresh)
+
+	for _, k := range fresh {
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k}
+		valNode := &yaml.Node{}
+		if err := valNode.Encode(fm[k]); err != nil {
+			continue
+		}
+		mapping.Content = append(mapping.Content, keyNode, valNode)
+	}
+}

--- a/internal/fix/frontmatter_preserve_test.go
+++ b/internal/fix/frontmatter_preserve_test.go
@@ -1,0 +1,143 @@
+package fix
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests cover the format-preserving frontmatter rewrite required by
+// issue #60 defect 3: a one-field mutation must produce a one-field diff.
+//
+// The guarantee is deliberately bounded to what a yaml.Node round-trip can
+// deliver. gopkg.in/yaml.v3 rebuilds output from the node tree rather than from
+// the source bytes, so key order, comments and each scalar's quoting style
+// survive, but inter-token whitespace and nested indentation are normalized.
+// Nothing here asserts byte equality of the whole block.
+
+func TestRewriteFrontmatter_PreservesKeyOrder(t *testing.T) {
+	original := "---\nzzz: last\nestado: Pending\naaa: first\n---\n\n# Doc\n\nbody\n"
+	fm := map[string]any{"zzz": "last", "estado": "Done", "aaa": "first"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	zIdx := strings.Index(result, "zzz")
+	eIdx := strings.Index(result, "estado")
+	aIdx := strings.Index(result, "aaa")
+	if zIdx == -1 || eIdx == -1 || aIdx == -1 {
+		t.Fatalf("expected all three keys present, got:\n%s", result)
+	}
+	if zIdx >= eIdx || eIdx >= aIdx {
+		t.Errorf("expected original order zzz < estado < aaa, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_PreservesComments(t *testing.T) {
+	original := "---\nzzz: last # comment A\nestado: Pending\n---\n\n# Doc\n"
+	fm := map[string]any{"zzz": "last", "estado": "Done"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	if !strings.Contains(result, "# comment A") {
+		t.Errorf("expected YAML comment retained, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_PreservesCommentOnMutatedKey(t *testing.T) {
+	original := "---\nestado: Pending # current phase\n---\n\n# Doc\n"
+	fm := map[string]any{"estado": "Done"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	if !strings.Contains(result, "estado: Done") {
+		t.Errorf("expected value updated, got:\n%s", result)
+	}
+	if !strings.Contains(result, "# current phase") {
+		t.Errorf("expected comment on the mutated key retained, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_AppendsNewKeyAfterExisting(t *testing.T) {
+	original := "---\ntitle: A\nstatus: open\n---\n\n# Doc\n"
+	fm := map[string]any{"title": "A", "status": "open", "labels": "x"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	tIdx := strings.Index(result, "title")
+	sIdx := strings.Index(result, "status")
+	lIdx := strings.Index(result, "labels")
+	if lIdx == -1 {
+		t.Fatalf("expected new key appended, got:\n%s", result)
+	}
+	if tIdx >= sIdx || sIdx >= lIdx {
+		t.Errorf("expected new key after existing ones, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_RemovesDroppedKey(t *testing.T) {
+	original := "---\ntitle: A\nobsolete: gone\nstatus: open\n---\n\n# Doc\n"
+	fm := map[string]any{"title": "A", "status": "open"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	if strings.Contains(result, "obsolete") {
+		t.Errorf("expected key absent from the map to be removed, got:\n%s", result)
+	}
+	if !strings.Contains(result, "title: A") || !strings.Contains(result, "status: open") {
+		t.Errorf("expected remaining keys intact, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_PreservesQuotingStyle(t *testing.T) {
+	original := "---\nstatus: \"pending\"\nother: plain\n---\n\n# Doc\n"
+	fm := map[string]any{"status": "pending", "other": "changed"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	if !strings.Contains(result, `status: "pending"`) {
+		t.Errorf("expected double-quoted style retained on the untouched key, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_UntouchedFieldsKeepValues(t *testing.T) {
+	original := "---\na: 1\nb: two\nc: true\nd: Pending\n---\n\n# Doc\n"
+	fm := map[string]any{"a": 1, "b": "two", "c": true, "d": "Done"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	for _, want := range []string{"a: 1", "b: two", "c: true", "d: Done"} {
+		if !strings.Contains(result, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, result)
+		}
+	}
+}
+
+func TestRewriteFrontmatter_MalformedYAMLFallsBack(t *testing.T) {
+	// Frontmatter delimiters are well formed but the content is not valid YAML.
+	// RewriteFrontmatter cannot return an error (its signature is load-bearing
+	// for the six call sites), so it must degrade to the map-based rebuild
+	// rather than lose the document.
+	original := "---\nthis: is: not: valid: yaml\n---\n\n# Doc\n\nbody\n"
+	fm := map[string]any{"estado": "Done"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	if !strings.Contains(result, "estado: Done") {
+		t.Errorf("expected fallback to still write the field, got:\n%s", result)
+	}
+	if !strings.Contains(result, "body") {
+		t.Errorf("expected body preserved through fallback, got:\n%s", result)
+	}
+}
+
+func TestRewriteFrontmatter_BodyUntouchedByNodeRewrite(t *testing.T) {
+	// The body must survive verbatim, including content that looks like YAML.
+	original := "---\nestado: Pending\n---\n\n# Doc\n\nkey: not frontmatter\n\n---\n\ntail\n"
+	fm := map[string]any{"estado": "Done"}
+
+	result := RewriteFrontmatter(original, fm)
+
+	body := "\n# Doc\n\nkey: not frontmatter\n\n---\n\ntail\n"
+	if !strings.HasSuffix(result, body) {
+		t.Errorf("expected body preserved verbatim, got:\n%s", result)
+	}
+}


### PR DESCRIPTION
Refs #60 (defect 3). PR 1 of 4 in a stacked chain.

## Problem

`RewriteFrontmatter` rebuilt the whole frontmatter block from a `map[string]any` via
`WriteFrontmatterFields`, which sorts keys and has no comment channel. A one-field mutation
produced a whole-block diff that buried the real change in review, and YAML comments were lost
with no way to recover them. This affected `fix`, `fix --all`, `repair apply` and `set` alike.

## Approach

Reconcile the original document's `yaml.Node` against the incoming map: keys in both keep their
position and are rewritten only when the decoded value actually differs, keys only in the map are
appended in sorted order, keys only in the node are dropped. Leaving an unchanged value's node
untouched is what preserves its comment and quoting style for free.

The signature is deliberately unchanged, so all six call sites stay untouched
(`cmd/rootline/fix.go:136`, `internal/fix/repair.go` x3, `internal/fix/fix.go` x2). That also
means the function cannot return an error, so frontmatter that does not parse as a YAML mapping
falls back to the previous map-based rebuild rather than failing the write.

## Before / after

Source document:

```
---
zzz: last          # comment A
estado: Pending
aaa: first
---
```

After a one-field mutation of `estado`:

| | Result |
|---|---|
| before | `aaa: first` / `estado: ...` / `zzz: last` — keys re-sorted, `# comment A` destroyed |
| after | `zzz: last # comment A` / `estado: Done` / `aaa: first` — order and comment intact |

## Bounded scope of the guarantee

`gopkg.in/yaml.v3` re-emits from the node tree rather than the source bytes, so key order,
comments and each scalar's quoting style survive, but inter-token whitespace and nested
indentation are normalized (`last          #` becomes `last #`). Byte-identical preservation of
untouched fields is **not** achievable through a node round-trip and is deliberately neither
claimed nor tested. An earlier draft of the spec demanded byte equality; under Strict TDD that
would have been a test that could never pass.

## Size and verification

292 changed lines. `just check` 0 issues, `just test` green, `just coverage-check` TOTAL 89.2%.
Bounded review approved with zero findings (lineage `review-71d2e1804facd3e8`).