### PR TITLE
fix(proposal): record where an add_field value came from

### DIFF
--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -58,6 +58,11 @@ type Proposal struct {
 	WikiLinks     []string `json:"wiki_links,omitempty"`
 	AggregateExpr string   `json:"aggregate_expr,omitempty"`
 	MigrationNote string   `json:"migration_note,omitempty"` // rationale for schema evolution proposals
+	// ValueSource records where Value came from on an add_field proposal, so a
+	// reviewer can tell a schema-declared value from one the engine picked. It
+	// is set on every generated add_field proposal and omitted for proposal
+	// types where provenance carries no meaning.
+	ValueSource string `json:"value_source,omitempty"`
 	// set_section fields
 	Heading string `json:"heading,omitempty"`
 	Mode    string `json:"mode,omitempty"` // "replace" (default) or "append"
@@ -461,7 +466,32 @@ func detectInferFromChildren(records []*extract.Record, effective *rules.StemFil
 	return nil
 }
 
+// Value provenance for add_field proposals. Only ValueSourceSchemaDefault
+// reflects a value the schema author actually declared; the other two are the
+// engine choosing a legal token because nothing was declared.
+const (
+	ValueSourceSchemaDefault = "schema_default" // the field's declared default:
+	ValueSourceEnumFirst     = "enum_first"     // first member of values, no default declared
+	ValueSourceEmpty         = "empty"          // empty string, nothing declared at all
+)
+
+// IsEngineChosen reports whether a value was synthesized by the engine rather
+// than declared by the schema.
+//
+// An empty source means the proposal predates provenance — a report file written
+// by an earlier rootline. Those are treated as schema-declared so that reports
+// which used to apply cleanly keep doing so; proposals generated in-process
+// always carry the marker, so this never weakens the fix --all guarantee.
+func IsEngineChosen(valueSource string) bool {
+	return valueSource == ValueSourceEnumFirst || valueSource == ValueSourceEmpty
+}
+
 // detectAddField finds required fields that are missing from records.
+//
+// A value is still proposed in every case, because seeing the candidate is
+// useful, but it is tagged with its origin so callers can refuse to write one
+// the schema never declared. Filling a required field that has no default:
+// destroys exactly the missing-data signal the author asked for.
 func detectAddField(effective *rules.StemFile, errs map[string][]rules.ValidationError) []Proposal {
 	var proposals []Proposal
 
@@ -474,20 +504,32 @@ func detectAddField(effective *rules.StemFile, errs map[string][]rules.Validatio
 			if !ok {
 				continue
 			}
-			defaultVal := sf.Default
-			if defaultVal == "" && len(sf.Values) > 0 {
-				defaultVal = sf.Values[0]
-			}
+			defaultVal, source := AddFieldValue(sf)
 			proposals = append(proposals, Proposal{
 				Type:        AddField,
 				Field:       e.Field,
 				Description: fmt.Sprintf("required field %q is missing", e.Field),
 				Paths:       []string{path},
 				Value:       defaultVal,
+				ValueSource: source,
 			})
 		}
 	}
 	return proposals
+}
+
+// AddFieldValue picks the value to propose for a missing required field and
+// reports where it came from. It is exported because the single-file fix path
+// has no Proposal to inspect and must derive provenance from the schema itself,
+// and both paths must agree on what counts as engine-chosen.
+func AddFieldValue(sf rules.SchemaField) (value, source string) {
+	if sf.Default != "" {
+		return sf.Default, ValueSourceSchemaDefault
+	}
+	if len(sf.Values) > 0 {
+		return sf.Values[0], ValueSourceEnumFirst
+	}
+	return "", ValueSourceEmpty
 }
 
 // extractEnumValue extracts the invalid value from a validation error message.

--- a/internal/proposal/value_source_test.go
+++ b/internal/proposal/value_source_test.go
@@ -1,0 +1,104 @@
+package proposal
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/rules"
+)
+
+// Issue #60 defect 1: an add_field proposal carried no marker separating a value
+// the schema declared from one the engine picked, so a reviewer reading the JSON
+// could not tell them apart and fix --all applied both alike.
+
+func addFieldFor(t *testing.T, sf rules.SchemaField) Proposal {
+	t.Helper()
+	effective := &rules.StemFile{Schema: map[string]rules.SchemaField{"campo": sf}}
+	errs := map[string][]rules.ValidationError{
+		"a.md": {{Rule: "required", Field: "campo", Message: `required field "campo" is missing`}},
+	}
+
+	proposals := detectAddField(effective, errs)
+	if len(proposals) != 1 {
+		t.Fatalf("expected exactly 1 add_field proposal, got %d", len(proposals))
+	}
+	return proposals[0]
+}
+
+func TestDetectAddField_SchemaDefaultIsMarkedAsSuch(t *testing.T) {
+	p := addFieldFor(t, rules.SchemaField{Type: "enum", Values: []string{"report", "note"}, Default: "note"})
+
+	if p.ValueSource != ValueSourceSchemaDefault {
+		t.Errorf("expected %q, got %q", ValueSourceSchemaDefault, p.ValueSource)
+	}
+	if p.Value != "note" {
+		t.Errorf("expected the declared default, got %q", p.Value)
+	}
+}
+
+func TestDetectAddField_FirstEnumMemberIsMarkedEngineChosen(t *testing.T) {
+	p := addFieldFor(t, rules.SchemaField{Type: "enum", Values: []string{"report", "note"}})
+
+	if p.ValueSource != ValueSourceEnumFirst {
+		t.Errorf("expected %q for a value taken from values[0], got %q", ValueSourceEnumFirst, p.ValueSource)
+	}
+	if p.Value != "report" {
+		t.Errorf("expected values[0], got %q", p.Value)
+	}
+}
+
+func TestDetectAddField_EmptyStringIsMarkedEngineChosen(t *testing.T) {
+	p := addFieldFor(t, rules.SchemaField{Type: "string"})
+
+	if p.ValueSource != ValueSourceEmpty {
+		t.Errorf("expected %q for a synthesized empty value, got %q", ValueSourceEmpty, p.ValueSource)
+	}
+	if p.Value != "" {
+		t.Errorf("expected empty value, got %q", p.Value)
+	}
+}
+
+func TestProposal_ValueSourceSerializes(t *testing.T) {
+	data, err := json.Marshal(Proposal{Type: AddField, Field: "campo", ValueSource: ValueSourceEnumFirst})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"value_source":"enum_first"`) {
+		t.Errorf("expected value_source in JSON, got %s", data)
+	}
+
+	var round Proposal
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.ValueSource != ValueSourceEnumFirst {
+		t.Errorf("expected value_source to survive a round trip, got %q", round.ValueSource)
+	}
+}
+
+func TestProposal_ValueSourceOmittedWhenUnset(t *testing.T) {
+	data, err := json.Marshal(Proposal{Type: CorrectValue, Field: "campo"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "value_source") {
+		t.Errorf("expected value_source omitted where provenance is meaningless, got %s", data)
+	}
+}
+
+func TestIsEngineChosen(t *testing.T) {
+	cases := map[string]bool{
+		ValueSourceSchemaDefault: false,
+		ValueSourceEnumFirst:     true,
+		ValueSourceEmpty:         true,
+		// An absent marker means the report predates provenance. Treating it as
+		// engine-chosen would silently stop applying previously valid reports.
+		"": false,
+	}
+	for source, want := range cases {
+		if got := IsEngineChosen(source); got != want {
+			t.Errorf("IsEngineChosen(%q) = %v, want %v", source, got, want)
+		}
+	}
+}


### PR DESCRIPTION
> **Stacked chain — merge in order #87 -> #88 -> #89 -> #90.**
> All four target `master` so that merging a parent with `--delete-branch` cannot close a
> child (GitHub refuses to reopen those). The consequence is that this PR's diff is
> **cumulative**: it also contains #87 and #88. Review only the commit(s) unique to this branch, or
> diff against #87 and #88. Once the parent merges, this diff collapses to its own commit.

Refs #60 (defect 1, first half). PR 3 of 4 in a stacked chain. Base: #88.

> Retarget to `master` before #88 merges. Merging a stacked PR's base with `--delete-branch`
> closes the child, and GitHub then refuses to reopen it.

## Problem

An `add_field` proposal's value is the field's declared `default:` when there is one, otherwise
the first member of `values`, otherwise the empty string. The payload carried no marker
separating the three, so a reviewer reading the JSON could not tell a value the schema author
declared from one the engine picked to satisfy a required rule.

## Approach

Add `ValueSource` to `Proposal`, recorded by `detectAddField` as `schema_default`, `enum_first`
or `empty`, plus an `IsEngineChosen` predicate. The field is additive and `omitempty`, so the
`rootline/proposals` version 1 contract and existing consumers are unaffected.

`IsEngineChosen` treats an **absent** marker as schema-declared rather than engine-chosen. A
report file written by an earlier rootline carries no provenance at all, and reading that silence
as "guessed" would stop applying reports that used to work.

`AddFieldValue` is exported alongside it because the single-file `fix` path consumes no proposals
and derives provenance straight from the schema; both derivations have to agree on what counts as
engine-chosen.

## Before / after

`fix --all --dry-run -o json` for a required enum with no `default:`:

| | Proposal payload |
|---|---|
| before | `{"type":"add_field","field":"tipo","value":"report"}` — indistinguishable from a declared default |
| after | `{"type":"add_field","field":"tipo","value":"report","value_source":"enum_first"}` |

With `default: note` declared, the same proposal reports `"value_source":"schema_default"`.

## Not a behaviour change

This slice is metadata only. No apply path consults `ValueSource` yet, so nothing about which
values get written changes here. The enforcement, and the breaking default change it carries,
is PR 4.

## Size and verification

154 changed lines. `just check` 0 issues, `just test` green, `just coverage-check` TOTAL 89.3%.
Bounded review approved with zero findings (lineage `review-ced4b80ca20b02d0`).