### PR TITLE
fix(rules): resolve root-anchored link targets instead of skipping them

### DIFF
--- a/.claude/skills/rootline/ref-validate.md
+++ b/.claude/skills/rootline/ref-validate.md
@@ -52,7 +52,7 @@ Batch:
 
 Each issue includes `rule`, `field`, `message`, `source`, `severity`, and optional `suggestion`.
 
-Link-check rules (emitted when the effective `.stem` sets `links.checks`): `link_resolve` (target missing, case-sensitive; carries fuzzy `suggestion`), `link_anchor` (`#anchor` matches no heading slug in the target), `link_encoding` (raw space in target; use `%20`). These are not auto-fixable by `fix` — repair the link or the target file manually. `checks.cycles: true` additionally makes `graph --check` fail on link cycles; without it cycles are printed as informational and only broken links set the exit code (override per-run with `--fail-cycles`).
+Link-check rules (emitted when the effective `.stem` sets `links.checks`): `link_resolve` (target missing, case-sensitive; carries fuzzy `suggestion`; wikilinks infer `.md` so `[[b]]` matches `b.md` and `[[sub/README]]` matches `sub/README.md`, while markdown targets resolve literally; root-anchored `/x.md` resolves against the scan root, or the governance boundary for single-file `validate`; resolution is clamped to that root, so a target escaping it via `..` or via a symlink pointing outside the tree never resolves, while a symlink staying inside still does), `link_anchor` (`#anchor` matches no heading slug in the target), `link_encoding` (raw space in target; use `%20`). These are not auto-fixable by `fix` — repair the link or the target file manually. `checks.cycles: true` additionally makes `graph --check` fail on link cycles; without it cycles are printed as informational and only broken links set the exit code (override per-run with `--fail-cycles`).
 
 ### Reporting Format
 

--- a/cmd/rootline/validate.go
+++ b/cmd/rootline/validate.go
@@ -110,7 +110,7 @@ func runValidateFiles(cmd *cobra.Command, files []string) error {
 
 		// Validate
 		errs = append(errs, rules.Validate(ctx, record, effective)...)
-		errs = append(errs, rules.CheckLinks(record.Links, effective.Links, absPath, linkCache)...)
+		errs = append(errs, rules.CheckLinks(record.Links, effective.Links, absPath, rules.SchemaRoot(absPath), linkCache)...)
 		errs = append(errs, rules.ExtractionErrors(record)...)
 		errs = append(errs, structErrs...)
 
@@ -187,7 +187,7 @@ func runValidateAll(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		errs := rules.Validate(ctx, rec, effective)
-		errs = append(errs, rules.CheckLinks(rec.Links, effective.Links, absPath, linkCache)...)
+		errs = append(errs, rules.CheckLinks(rec.Links, effective.Links, absPath, root, linkCache)...)
 		errs = append(errs, rules.ExtractionErrors(rec)...)
 		if content, readErr := os.ReadFile(absPath); readErr == nil {
 			errs = append(errs, rules.ValidateStructure(content, rec.Path)...)

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -46,9 +46,49 @@ Batch validation runs four phases in order:
    - `unknown-check-keys` — keys under `links.checks` are recognized (fuzzy "did you mean?" on typos)
    - `nested-root-marker` — reports (info) a `.stem` that declares `root: true` below another one that already does, since records under it stop inheriting the ancestor
 
-2. **Document Validation** — Checks each record against its effective schema: required fields, enum values, non_empty, exists, requires rules.
+2. **Document Validation** — Checks each record against its effective schema: required fields, enum values, non_empty, exists, requires rules. When the effective `.stem` declares `links.checks`, link targets are resolved here too — see [Link resolution](#link-resolution).
 3. **Structural Validation** — Directory-level rules: `require_index` (must have README.md), `min_children`/`max_children` constraints.
 4. **Drift Detection** — Warns when an index file's field value contradicts its children (e.g., parent says "Completed" but children are "Pending").
+
+## Link resolution
+
+`links.checks` resolves targets through the same engine `graph` and `query` use, so the
+commands cannot disagree about whether a link is broken.
+
+| Target form | Resolves to |
+|---|---|
+| `[[b]]` (wikilink, no extension) | `b.md` beside the source |
+| `[[sub/README]]` | `sub/README.md` |
+| `[b](b.md)` (markdown) | `b.md` literally — markdown targets never infer an extension |
+| `[x](/docs/Page.md)` (root-anchored) | `docs/Page.md` under the scan root |
+| `[x](guides/)` (directory) | `guides/README.md` |
+| `[x](my%20page.md)` | `my page.md` — percent escapes decode |
+
+Two rules are deliberate rather than incidental:
+
+- **`.md` is inferred only for wikilinks, and only on the last path component.** A markdown
+  destination carries its extension by convention and Azure DevOps resolves it literally, so
+  inferring one would accept links the published wiki rejects. A missing intermediate directory
+  is a missing directory, not a file to guess at.
+- **Matching is case-sensitive on every component.** APFS is case-insensitive; Azure DevOps and
+  git are not, so a link that works locally can 404 once published. Rootline reports the
+  mismatch rather than hiding it.
+
+Root-anchored targets (`/x.md`) resolve against the scan root. For `validate --all` that is the
+directory you pointed the command at; for a single-file `rootline validate <file>` it is the
+governance boundary — the directory of the root-most `.stem`. When no schema governs the file,
+a root-anchored target cannot be anchored and stays unresolved rather than guessing.
+
+Resolution is clamped to the root. A target that walks out of the tree does not resolve —
+whether it escapes with `..` (root-anchored `/../secrets.md` or relative `../../secrets.md`) or
+through a symlink inside the tree that points outside it. Containment compares real paths, so a
+symlink that stays inside the root still resolves normally. Link targets are document-controlled
+text, and resolution would otherwise report on — and with `anchors` enabled, read — files
+outside the tree being governed.
+
+Resolution asks the filesystem, not the record set. A target that exists on disk resolves even
+when `scope.match` or `.stemignore` excludes it from governance: the schema declares what is
+*governed*, not what *exists*.
 
 ## Single File Result
 

--- a/internal/e2e/link_checks_e2e_test.go
+++ b/internal/e2e/link_checks_e2e_test.go
@@ -41,7 +41,7 @@ links:
 			t.Fatalf("resolve %s: %v", rec.Path, err)
 		}
 		all := rules.Validate(ctx, rec, effective)
-		all = append(all, rules.CheckLinks(rec.Links, effective.Links, absPath, cache)...)
+		all = append(all, rules.CheckLinks(rec.Links, effective.Links, absPath, root, cache)...)
 		for _, e := range all {
 			errsByRule[e.Rule]++
 		}

--- a/internal/e2e/link_styles_e2e_test.go
+++ b/internal/e2e/link_styles_e2e_test.go
@@ -61,7 +61,7 @@ func TestE2E_LinkStyles_WikilinkRepoUnaffected(t *testing.T) {
 			t.Fatal(err)
 		}
 		errs := rules.Validate(ctx, rec, effective)
-		errs = append(errs, rules.CheckLinks(rec.Links, effective.Links, absPath, nil)...)
+		errs = append(errs, rules.CheckLinks(rec.Links, effective.Links, absPath, root, nil)...)
 		if len(errs) != 0 {
 			t.Errorf("%s: unexpected errors %+v", rec.Path, errs)
 		}

--- a/internal/rules/link_checks.go
+++ b/internal/rules/link_checks.go
@@ -24,13 +24,14 @@ func NewHeadingCache() *HeadingCache {
 
 // CheckLinks runs filesystem-backed link checks (links.checks in .stem)
 // against a record's links. sourceAbsPath is the absolute path of the record
-// file; relative targets resolve against its directory. Links whose style is
-// not in the schema's effective styles are skipped, as are absolute targets
-// (root-relative ADO form lands in a follow-up).
+// file; relative targets resolve against its directory. root is the scan root
+// that root-anchored ("/x.md") targets rebase onto — pass "" when no root is
+// in scope and such targets stay unresolved. Links whose style is not in the
+// schema's effective styles are skipped.
 //
 // Resolution runs through ResolveLinkTarget, the same entry point graph and
 // query use, so the commands cannot disagree about whether a link is broken.
-func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath string, cache *HeadingCache) []ValidationError {
+func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root string, cache *HeadingCache) []ValidationError {
 	if schema.Checks == nil {
 		return nil
 	}
@@ -56,13 +57,10 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath string, c
 			})
 		}
 
-		if strings.HasPrefix(link.Target, "/") {
-			continue
-		}
-
 		if schema.Checks.Resolve || schema.Checks.Anchors {
 			res := ResolveLinkTarget(ResolveRequest{
 				BaseDir: filepath.Dir(sourceAbsPath),
+				Root:    root,
 				Target:  link.Target,
 				Style:   linkStyle(link),
 			})

--- a/internal/rules/link_checks_test.go
+++ b/internal/rules/link_checks_test.go
@@ -28,7 +28,7 @@ func mdLink(target string) extract.Link {
 
 func TestCheckLinks_NilChecksIsNoop(t *testing.T) {
 	schema := LinkSchema{Styles: []string{extract.StyleMarkdown}}
-	errs := CheckLinks([]extract.Link{mdLink("missing.md")}, schema, "/nonexistent/src.md", nil)
+	errs := CheckLinks([]extract.Link{mdLink("missing.md")}, schema, "/nonexistent/src.md", "", nil)
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors without checks, got %+v", errs)
 	}
@@ -36,7 +36,7 @@ func TestCheckLinks_NilChecksIsNoop(t *testing.T) {
 
 func TestCheckLinks_EncodingRejectsRawSpaces(t *testing.T) {
 	schema := mdChecksSchema(LinkChecks{Encoding: true})
-	errs := CheckLinks([]extract.Link{mdLink("my file.md")}, schema, "/tmp/src.md", nil)
+	errs := CheckLinks([]extract.Link{mdLink("my file.md")}, schema, "/tmp/src.md", "", nil)
 	if len(errs) != 1 || errs[0].Rule != "link_encoding" {
 		t.Fatalf("expected 1 link_encoding error, got %+v", errs)
 	}
@@ -47,7 +47,7 @@ func TestCheckLinks_ResolveExisting(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "guides", "setup.md"), "# Setup\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
 	schema := mdChecksSchema(LinkChecks{Resolve: true})
-	errs := CheckLinks([]extract.Link{mdLink("guides/setup.md")}, schema, filepath.Join(dir, "src.md"), nil)
+	errs := CheckLinks([]extract.Link{mdLink("guides/setup.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 0 {
 		t.Fatalf("expected resolve to pass, got %+v", errs)
 	}
@@ -58,7 +58,7 @@ func TestCheckLinks_ResolveBrokenWithSuggestion(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "guides", "setup.md"), "# Setup\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
 	schema := mdChecksSchema(LinkChecks{Resolve: true})
-	errs := CheckLinks([]extract.Link{mdLink("guides/setpu.md")}, schema, filepath.Join(dir, "src.md"), nil)
+	errs := CheckLinks([]extract.Link{mdLink("guides/setpu.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
 		t.Fatalf("expected 1 link_resolve error, got %+v", errs)
 	}
@@ -73,7 +73,7 @@ func TestCheckLinks_ResolveCaseMismatchIsBroken(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
 	schema := mdChecksSchema(LinkChecks{Resolve: true})
 	// APFS would resolve this case-insensitively; ADO/git will not.
-	errs := CheckLinks([]extract.Link{mdLink("guides/setup.md")}, schema, filepath.Join(dir, "src.md"), nil)
+	errs := CheckLinks([]extract.Link{mdLink("guides/setup.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
 		t.Fatalf("expected case mismatch to be broken, got %+v", errs)
 	}
@@ -86,10 +86,10 @@ func TestCheckLinks_ResolveDirectoryTargetNeedsReadme(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
 	schema := mdChecksSchema(LinkChecks{Resolve: true})
 	src := filepath.Join(dir, "src.md")
-	if errs := CheckLinks([]extract.Link{mdLink("guides/")}, schema, src, nil); len(errs) != 0 {
+	if errs := CheckLinks([]extract.Link{mdLink("guides/")}, schema, src, dir, nil); len(errs) != 0 {
 		t.Fatalf("dir with README should resolve, got %+v", errs)
 	}
-	if errs := CheckLinks([]extract.Link{mdLink("empty/")}, schema, src, nil); len(errs) != 1 {
+	if errs := CheckLinks([]extract.Link{mdLink("empty/")}, schema, src, dir, nil); len(errs) != 1 {
 		t.Fatalf("dir without README should be broken, got %+v", errs)
 	}
 }
@@ -99,20 +99,38 @@ func TestCheckLinks_ResolveDecodesPercent20(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "my page.md"), "# P\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
 	schema := mdChecksSchema(LinkChecks{Resolve: true})
-	errs := CheckLinks([]extract.Link{mdLink("my%20page.md")}, schema, filepath.Join(dir, "src.md"), nil)
+	errs := CheckLinks([]extract.Link{mdLink("my%20page.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 0 {
 		t.Fatalf("%%20 target should resolve, got %+v", errs)
 	}
 }
 
-func TestCheckLinks_SkipsAbsoluteAndFilteredStyles(t *testing.T) {
+func TestCheckLinks_SkipsFilteredStyles(t *testing.T) {
 	schema := mdChecksSchema(LinkChecks{Resolve: true, Encoding: true})
 	links := []extract.Link{
-		mdLink("/Root/Page.md"), // absolute: skipped until root-anchored resolution lands
 		{Target: "no such file", Type: "reference", Style: extract.StyleWikilink, Line: 1}, // filtered style
 	}
-	if errs := CheckLinks(links, schema, "/tmp/src.md", nil); len(errs) != 0 {
+	if errs := CheckLinks(links, schema, "/tmp/src.md", "", nil); len(errs) != 0 {
 		t.Fatalf("expected no errors, got %+v", errs)
+	}
+}
+
+// Root-anchored targets are the idiomatic ADO code-wiki form. validate used to
+// skip them outright, so a dangling /x.md passed while graph flagged it
+// (issue #62 sub-defect 3). They are now resolved against the scan root.
+func TestCheckLinks_RootAnchoredIsChecked(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "Page.md"), "# Page\n")
+	writeFile(t, filepath.Join(root, "deep", "src.md"), "body")
+	src := filepath.Join(root, "deep", "src.md")
+	schema := mdChecksSchema(LinkChecks{Resolve: true})
+
+	if errs := CheckLinks([]extract.Link{mdLink("/docs/Page.md")}, schema, src, root, nil); len(errs) != 0 {
+		t.Errorf("existing root-anchored target should resolve, got %+v", errs)
+	}
+	errs := CheckLinks([]extract.Link{mdLink("/docs/Missing.md")}, schema, src, root, nil)
+	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
+		t.Errorf("missing root-anchored target should be reported, got %+v", errs)
 	}
 }
 
@@ -132,7 +150,7 @@ func TestCheckLinks_WikilinkResolvesWithoutExtension(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
 	schema := wikiChecksSchema(LinkChecks{Resolve: true})
 
-	if errs := CheckLinks([]extract.Link{wikiLink("b")}, schema, filepath.Join(dir, "t.md"), nil); len(errs) != 0 {
+	if errs := CheckLinks([]extract.Link{wikiLink("b")}, schema, filepath.Join(dir, "t.md"), dir, nil); len(errs) != 0 {
 		t.Fatalf("[[b]] with b.md present must resolve, got %+v", errs)
 	}
 }
@@ -143,7 +161,7 @@ func TestCheckLinks_WikilinkPathQualifiedResolves(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
 	schema := wikiChecksSchema(LinkChecks{Resolve: true})
 
-	if errs := CheckLinks([]extract.Link{wikiLink("sub/README")}, schema, filepath.Join(dir, "t.md"), nil); len(errs) != 0 {
+	if errs := CheckLinks([]extract.Link{wikiLink("sub/README")}, schema, filepath.Join(dir, "t.md"), dir, nil); len(errs) != 0 {
 		t.Fatalf("[[sub/README]] must resolve, got %+v", errs)
 	}
 }
@@ -153,7 +171,7 @@ func TestCheckLinks_WikilinkGenuinelyMissingIsBroken(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
 	schema := wikiChecksSchema(LinkChecks{Resolve: true})
 
-	errs := CheckLinks([]extract.Link{wikiLink("nope")}, schema, filepath.Join(dir, "t.md"), nil)
+	errs := CheckLinks([]extract.Link{wikiLink("nope")}, schema, filepath.Join(dir, "t.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
 		t.Fatalf("missing wikilink target must be reported, got %+v", errs)
 	}
@@ -182,13 +200,13 @@ func TestCheckLinks_AnchorValidAndInvalid(t *testing.T) {
 	cache := NewHeadingCache()
 
 	good := extract.Link{Target: "master.md", Anchor: "6-zonas-inciertas-black-boxes", Type: "reference", Style: extract.StyleMarkdown, Line: 1}
-	if errs := CheckLinks([]extract.Link{good}, schema, src, cache); len(errs) != 0 {
+	if errs := CheckLinks([]extract.Link{good}, schema, src, dir, cache); len(errs) != 0 {
 		t.Fatalf("valid anchor rejected: %+v", errs)
 	}
 
 	bad := good
 	bad.Anchor = "7-no-existe"
-	errs := CheckLinks([]extract.Link{bad}, schema, src, cache)
+	errs := CheckLinks([]extract.Link{bad}, schema, src, dir, cache)
 	if len(errs) != 1 || errs[0].Rule != "link_anchor" {
 		t.Fatalf("expected 1 link_anchor error, got %+v", errs)
 	}
@@ -200,7 +218,7 @@ func TestCheckLinks_AnchorNilCacheStillWorks(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
 	schema := mdChecksSchema(LinkChecks{Resolve: true, Anchors: true})
 	link := extract.Link{Target: "master.md", Anchor: "intro", Type: "reference", Style: extract.StyleMarkdown, Line: 1}
-	if errs := CheckLinks([]extract.Link{link}, schema, filepath.Join(dir, "src.md"), nil); len(errs) != 0 {
+	if errs := CheckLinks([]extract.Link{link}, schema, filepath.Join(dir, "src.md"), dir, nil); len(errs) != 0 {
 		t.Fatalf("nil cache should parse on the fly: %+v", errs)
 	}
 }
@@ -218,7 +236,7 @@ func TestCheckLinks_AnchorCacheReuse(t *testing.T) {
 		{Target: "target.md", Anchor: "section2", Type: "reference", Style: extract.StyleMarkdown, Line: 2},
 	}
 
-	if errs := CheckLinks(links, schema, src, cache); len(errs) != 0 {
+	if errs := CheckLinks(links, schema, src, dir, cache); len(errs) != 0 {
 		t.Fatalf("both anchors should pass; got %+v", errs)
 	}
 	if len(cache.slugs) != 1 {

--- a/internal/rules/link_resolve.go
+++ b/internal/rules/link_resolve.go
@@ -90,6 +90,10 @@ func ResolveLinkTarget(req ResolveRequest) LinkResolution {
 		cur = filepath.Join(cur, entry)
 	}
 
+	if !withinRoot(req.Root, cur) {
+		return LinkResolution{}
+	}
+
 	info, err := os.Stat(cur)
 	if err != nil {
 		return LinkResolution{}
@@ -102,6 +106,57 @@ func ResolveLinkTarget(req ResolveRequest) LinkResolution {
 		cur = filepath.Join(cur, entry)
 	}
 	return LinkResolution{Path: cur, OK: true}
+}
+
+// withinRoot reports whether a resolved path stayed inside root.
+//
+// Link targets are document-controlled text, and a target may contain ".."
+// components, so resolution can otherwise walk above the tree being governed
+// and report on files outside it — with links.checks.anchors enabled that
+// means reading them. Rootline already treats path containment as an
+// invariant elsewhere (internal/fix/contain.go), so resolution honors it too.
+// An empty root means no boundary is known and nothing can be judged against
+// it; callers that need containment must pass one.
+func withinRoot(root, path string) bool {
+	if root == "" {
+		return true
+	}
+	// Compare real paths: a lexical check alone cannot see through a symlink
+	// inside the tree that points out of it. EvalSymlinks is applied to both
+	// sides so a root that is itself reached through a symlink (/tmp on macOS)
+	// still compares equal. A path that cannot be evaluated does not exist
+	// yet, so fall back to the lexical form and let the later Stat decide.
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		realRoot = root
+	}
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		realPath = path
+	}
+	rel, err := filepath.Rel(realRoot, realPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// SchemaRoot returns the directory of the root-most .stem governing path — the
+// declared governance boundary, or the top of the discovered chain when none
+// declares `root: true`.
+//
+// Root-anchored links ("/x.md") are relative to the wiki root, and a
+// single-file `validate` invocation has no scan root to use. The schema
+// boundary is the closest thing the engine actually knows about, and it is the
+// same directory `validate --all` would be pointed at. Returns "" when no
+// schema governs the path, which leaves root-anchored targets unresolved
+// rather than silently anchoring them somewhere arbitrary.
+func SchemaRoot(path string) string {
+	entries, err := WalkUp(path)
+	if err != nil || len(entries) == 0 {
+		return ""
+	}
+	return filepath.Dir(entries[0].Path)
 }
 
 // inferMarkdown retries a missing final path component with a ".md" suffix.

--- a/internal/rules/link_resolve_test.go
+++ b/internal/rules/link_resolve_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -97,5 +98,143 @@ func TestResolveLinkTarget_WikilinkWithExplicitExtension(t *testing.T) {
 	got := ResolveLinkTarget(ResolveRequest{BaseDir: dir, Target: "b.md", Style: extract.StyleWikilink})
 	if !got.OK || got.Path != filepath.Join(dir, "b.md") {
 		t.Errorf("explicit .md wikilink should resolve as-is, got %+v", got)
+	}
+}
+
+// Root-anchored targets are the idiomatic form in an ADO code wiki — the
+// stated target of links.checks. validate used to skip them with a bare
+// `continue`, so a dangling /x.md passed validation while graph flagged it
+// (issue #62 sub-defect 3).
+func TestResolveLinkTarget_RootAnchored(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "README.md"), "# Docs\n")
+	writeFile(t, filepath.Join(root, "deep", "src.md"), "body")
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: filepath.Join(root, "deep"), Root: root,
+		Target: "/docs/README.md", Style: extract.StyleMarkdown,
+	})
+	if !got.OK {
+		t.Fatalf("/docs/README.md should resolve against root, got %+v", got)
+	}
+	if want := filepath.Join(root, "docs", "README.md"); got.Path != want {
+		t.Errorf("Path = %q, want %q", got.Path, want)
+	}
+}
+
+func TestResolveLinkTarget_RootAnchoredMissingIsBroken(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src.md"), "body")
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: root, Root: root, Target: "/nonexistent.md", Style: extract.StyleMarkdown,
+	})
+	if got.OK {
+		t.Errorf("missing root-anchored target must not resolve, got %+v", got)
+	}
+}
+
+// Without a root there is nothing to anchor to, so the target cannot be
+// judged. Better unresolved than anchored somewhere arbitrary.
+func TestResolveLinkTarget_RootAnchoredWithoutRootIsUnresolved(t *testing.T) {
+	dir := t.TempDir()
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: dir, Target: "/docs/README.md", Style: extract.StyleMarkdown,
+	})
+	if got.OK {
+		t.Errorf("root-anchored target with no root must not resolve, got %+v", got)
+	}
+}
+
+func TestSchemaRoot(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".stem"), "version: 2\nroot: true\n")
+	writeFile(t, filepath.Join(root, "sub", ".stem"), "version: 2\n")
+	writeFile(t, filepath.Join(root, "sub", "a.md"), "body")
+
+	if got := SchemaRoot(filepath.Join(root, "sub", "a.md")); got != root {
+		t.Errorf("SchemaRoot = %q, want the boundary %q", got, root)
+	}
+	if got := SchemaRoot(filepath.Join(t.TempDir(), "orphan.md")); got != "" {
+		t.Errorf("SchemaRoot with no governing schema = %q, want \"\"", got)
+	}
+}
+
+// A link target must never resolve outside the root it is anchored to.
+// Removing validate's blanket skip of "/"-prefixed targets newly exposes this
+// path to document-controlled text, and rootline already treats path
+// containment as an invariant (see internal/fix/contain.go, issue #69).
+func TestResolveLinkTarget_CannotEscapeRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(filepath.Dir(root), "outside-"+filepath.Base(root)+".md")
+	if err := os.WriteFile(outside, []byte("# Outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(outside) }()
+	writeFile(t, filepath.Join(root, "deep", "src.md"), "body")
+	base := filepath.Join(root, "deep")
+	escape := "../" + filepath.Base(outside)
+
+	for _, tc := range []struct{ name, target string }{
+		{"root-anchored", "/" + escape},
+		{"relative", "../" + escape},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveLinkTarget(ResolveRequest{
+				BaseDir: base, Root: root, Target: tc.target, Style: extract.StyleMarkdown,
+			})
+			if got.OK {
+				t.Errorf("target %q escaped the root and resolved to %q", tc.target, got.Path)
+			}
+		})
+	}
+}
+
+// Containment must not reject legitimate parent traversal that stays inside.
+func TestResolveLinkTarget_ParentTraversalInsideRootIsAllowed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.md"), "# A\n")
+	writeFile(t, filepath.Join(root, "deep", "src.md"), "body")
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: filepath.Join(root, "deep"), Root: root, Target: "../a.md", Style: extract.StyleMarkdown,
+	})
+	if !got.OK {
+		t.Errorf("../a.md stays inside root and must resolve, got %+v", got)
+	}
+}
+
+// A lexical containment check cannot see through a symlink inside the tree
+// that points out of it, so containment compares real paths.
+func TestResolveLinkTarget_SymlinkCannotEscapeRoot(t *testing.T) {
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	writeFile(t, filepath.Join(outsideDir, "secret.md"), "# Secret\n")
+	writeFile(t, filepath.Join(root, "src.md"), "body")
+	if err := os.Symlink(outsideDir, filepath.Join(root, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: root, Root: root, Target: "escape/secret.md", Style: extract.StyleMarkdown,
+	})
+	if got.OK {
+		t.Errorf("symlink escaping the root must not resolve, got %q", got.Path)
+	}
+}
+
+// A symlink that stays inside the root is legitimate and must still resolve.
+func TestResolveLinkTarget_SymlinkInsideRootResolves(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "real", "page.md"), "# Page\n")
+	writeFile(t, filepath.Join(root, "src.md"), "body")
+	if err := os.Symlink(filepath.Join(root, "real"), filepath.Join(root, "alias")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got := ResolveLinkTarget(ResolveRequest{
+		BaseDir: root, Root: root, Target: "alias/page.md", Style: extract.StyleMarkdown,
+	})
+	if !got.OK {
+		t.Errorf("symlink inside the root must resolve, got %+v", got)
 	}
 }


### PR DESCRIPTION
## What

`validate` skipped **every** root-anchored link target with a bare `continue`:

```go
if strings.HasPrefix(link.Target, "/") { continue }   // internal/rules/link_checks.go
```

So a dangling `/x.md` passed validation while `graph --check` flagged the same link. Root-anchored
links are the idiomatic form in an Azure DevOps code wiki — the stated target of `links.checks` —
so this was the common case, not an edge case.

## How

`CheckLinks` now takes the scan root and resolves root-anchored targets against it.

- `validate --all` passes its scan root directly.
- A single-file `rootline validate <file>` has no scan root, so `rules.SchemaRoot` anchors to the
  **governance boundary** — the directory of the root-most `.stem`, which is the same directory
  `--all` would be pointed at. With no governing schema the target stays unresolved rather than
  being anchored somewhere arbitrary.

### Containment

Following these targets means resolution now walks document-controlled path text, so resolution
is **clamped to the root**. A target that escapes the tree does not resolve — whether it walks
out with `..` (`/../secrets.md`, `../../secrets.md`) or through a symlink inside the tree that
points outside it. Containment compares *real* paths, so a symlink that stays inside the root
still resolves normally.

This repo already treats path containment as an invariant (`internal/fix`, issue #69); resolution
now honors it too.

## Parity matrix rows changed

| Feature | `validate` before | `validate` after | `graph` |
|---|---|---|---|
| Root-anchored `/x.md` targets | **skipped silently** | resolved and checked | resolved (unchanged) |

Closes **sub-defect 3**. Behavior change **B2**.

## Evidence — the two commands now agree

Issue #62 reproduction case C1/C2. Before, `validate` said `valid: true` while `graph` reported
the link broken:

```console
$ rootline validate md/rootrel.md -o json
{"valid":false,"errors":[{"rule":"link_resolve","message":"link target \"/nonexistent.md\" does not resolve ..."}]}
exit=1
$ rootline graph --check md/
Broken links: 1
  rootrel.md:1 → /nonexistent.md (reference)
exit=1
```

## Blast radius

This newly fails repositories that previously passed: a repository with dangling root-anchored
links and `links.checks.resolve: true` went green before and goes red now. That is the point of
the fix — `graph --check` already failed those repositories — but it is a real, user-visible
change and is called out here rather than buried.

## Testing

Root-anchored resolve/broken, escape via `..` (root-anchored and relative), in-root parent
traversal still allowed, symlink escape blocked, in-root symlink still resolves, and `SchemaRoot`
with and without a governing schema. Symlink tests `t.Skipf` where symlinks are unavailable.

`just check`, `just test`, `just coverage-check` all green.

## Review note

Three review rounds ran on this change. Rounds 1 and 2 found genuine defects — the `..` root
escape and then the symlink escape — both fixed here and pinned by tests. The final round
returned zero findings from the risk, readability and reliability lenses.

One non-blocking `SUGGESTION`-severity observation from the resilience lens (the blast-radius
note above) could not be recorded in the receipt's findings array because the review facade
rejected every finding location, including verbatim strings from its own frozen path manifest.
Its text is preserved in the receipt's evidence and restated above, so nothing is hidden. No
defect was suppressed — the two real defects found were fixed, not waived.

## Size and stacking

189 → 314 changed lines after two rounds of containment hardening. Based on #86, **not** master.

Refs #62
