### PR TITLE
feat(graph): resolve links through the canonical resolver

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -111,7 +111,9 @@ links:
     cycles: true                # graph --check fails on link cycles (default: informational)
 ```
 
-**Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. Absolute targets (`/...`), external schemes, images, and pure fragments are not checked.
+**Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. External schemes, images, and pure fragments are not checked.
+
+**One resolver**: `validate`, `graph` and `query` traversal share one resolver, so they agree on which links are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches a uniquely-named record anywhere. A resolved target is never broken even when `scope.match`/`.stemignore` excludes it: the schema declares what is governed, not what exists.
 
 **Query link traversal**: `--has-inbound` and `--has-outbound` predicates search both wiki-link and markdown-link styles (governed by `.stem links.styles`). Combine with `--inbound-type` / `--outbound-type` to restrict to one link type.
 

--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -68,7 +68,7 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	rules.FilterLinksByStyles(records, absRoot)
-	rules.ResolveMarkdownTargets(records, absRoot)
+	rules.PrepareLinks(records, absRoot)
 
 	derive.EnrichBuiltinsSimple(ctx, records, absRoot)
 

--- a/cmd/rootline/query.go
+++ b/cmd/rootline/query.go
@@ -233,7 +233,7 @@ func scanForTraversal(ctx context.Context, absQueryRoot string) ([]*extract.Reco
 	// Mirror the `graph` command's link preparation so both commands see
 	// the same edge universe for the same root.
 	rules.FilterLinksByStyles(all, absGraphRoot)
-	rules.ResolveMarkdownTargets(all, absGraphRoot)
+	rules.PrepareLinks(all, absGraphRoot)
 
 	derive.DeriveAllSimple(ctx, all, absGraphRoot)
 	derive.EnrichBuiltinsSimple(ctx, all, absGraphRoot)

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -80,6 +80,15 @@ rootline graph docs/epics/ --where 'estado == "Specified"' --check  # Check only
 
 ### With --check
 
+### How a link target resolves
+
+`graph` resolves links through the same engine `validate` uses, so the two agree on which links
+are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown
+targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches
+a uniquely-named record anywhere. A resolved target is never reported broken **even when the
+schema does not govern it** — `scope.match` and `.stemignore` declare what is *governed*, not
+what *exists*, so such a link is an edge to a non-node. Unresolved targets are reported verbatim.
+
 Prints a text report and exits 1 when a blocking problem is found (broken links always block; cycles block only with `--fail-cycles` or `links.checks.cycles: true`, otherwise they are informational):
 
 ```text

--- a/internal/extract/links.go
+++ b/internal/extract/links.go
@@ -13,7 +13,26 @@ type Link struct {
 	Source string `json:"source,omitempty"` // "body" or "frontmatter:<fieldname>"
 	Style  string `json:"style,omitempty"`  // StyleWikilink or StyleMarkdown
 	Anchor string `json:"anchor,omitempty"` // fragment part of markdown targets, without '#'
+
+	// Resolution records what the link resolver concluded about Target.
+	// Extraction never sets it; rules.PrepareLinks does. Consumers that
+	// report broken links read this instead of guessing from the node set,
+	// so every command agrees on which links are broken. Not serialized:
+	// it is pipeline state, not part of any command's JSON contract.
+	Resolution string `json:"-"`
 }
+
+// Link resolution states carried by Link.Resolution.
+//
+// LinkUnchecked is the zero value, meaning nothing has resolved this link yet;
+// consumers fall back to their own matching. Keeping it as the zero value lets
+// callers that build links in memory behave exactly as they did before
+// resolution existed.
+const (
+	LinkUnchecked  = ""
+	LinkResolved   = "resolved"
+	LinkUnresolved = "unresolved"
+)
 
 // Link styles produced by extraction.
 const (

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -27,10 +27,16 @@ type Edge struct {
 	Type   string `json:"type"`
 	Line   int    `json:"line"`
 
-	// noFallback excludes the edge from basename fallback resolution.
-	// Markdown targets are path-resolved upstream; an unresolved one must
-	// stay verbatim so BrokenLinks reports it, matching validate.
-	noFallback bool
+	// resolution carries extract.Link.Resolution for this edge. When the
+	// links were prepared by rules.PrepareLinks it is authoritative and
+	// BrokenLinks trusts it instead of the node set; when it is the zero
+	// value nothing resolved this link and BrokenLinks falls back to node
+	// membership, which is how in-memory callers have always behaved.
+	resolution string
+
+	// markdown excludes the edge from the unchecked basename fallback: a
+	// markdown destination names a path literally, so it stays verbatim.
+	markdown bool
 }
 
 // BrokenLink represents a link whose target doesn't match any record.
@@ -43,8 +49,12 @@ type BrokenLink struct {
 }
 
 // Build constructs a Graph from a slice of records.
-// Link targets are resolved relative to the source record's directory.
-// Unresolved targets get a basename fallback lookup across all nodes.
+//
+// Targets are expected to be resolved already, by rules.PrepareLinks, which
+// rewrites them to root-relative node keys and records whether each resolved.
+// Build no longer does any resolution of its own beyond a directory join for
+// links nothing has looked at, so graph and validate cannot disagree about
+// which links are broken (issue #62).
 func Build(_ context.Context, records []*extract.Record) *Graph {
 	g := &Graph{
 		Nodes: make(map[string]*extract.Record, len(records)),
@@ -58,8 +68,9 @@ func Build(_ context.Context, records []*extract.Record) *Graph {
 	for _, rec := range records {
 		for _, link := range rec.Links {
 			target := link.Target
-			markdown := link.Style == extract.StyleMarkdown
-			if !markdown {
+			// An unprepared wikilink still gets the directory join it always
+			// had; a prepared one already carries its root-relative key.
+			if link.Resolution == extract.LinkUnchecked && link.Style != extract.StyleMarkdown {
 				target = resolveTarget(rec.Path, link.Target)
 			}
 			g.Edges[rec.Path] = append(g.Edges[rec.Path], Edge{
@@ -67,13 +78,15 @@ func Build(_ context.Context, records []*extract.Record) *Graph {
 				Target:     target,
 				Type:       link.Type,
 				Line:       link.Line,
-				noFallback: markdown,
+				resolution: link.Resolution,
+				markdown:   link.Style == extract.StyleMarkdown,
 			})
 		}
 	}
 
-	// Second pass: resolve unmatched targets by basename fallback.
-	g.resolveByBasename()
+	// Links nothing resolved keep the historical basename fallback, so callers
+	// that build a graph without preparing links behave exactly as before.
+	g.resolveUncheckedByBasename()
 
 	return g
 }
@@ -127,37 +140,6 @@ func compareEdges(a, b Edge) int {
 		return a.Line - b.Line
 	}
 	return strings.Compare(a.Type, b.Type)
-}
-
-// resolveByBasename rewrites edge targets that don't match any node
-// by searching for a unique basename match (with and without .md).
-func (g *Graph) resolveByBasename() {
-	// Build basename index: basename → list of full paths.
-	idx := make(map[string][]string, len(g.Nodes))
-	for path := range g.Nodes {
-		base := filepath.Base(path)
-		idx[base] = append(idx[base], path)
-		// Also index without .md extension.
-		noExt := strings.TrimSuffix(base, ".md")
-		if noExt != base {
-			idx[noExt] = append(idx[noExt], path)
-		}
-	}
-
-	for src, edges := range g.Edges {
-		for i, edge := range edges {
-			if edge.noFallback {
-				continue
-			}
-			if _, exists := g.Nodes[edge.Target]; exists {
-				continue // already resolved
-			}
-			// Try basename lookup.
-			if matches, ok := idx[edge.Target]; ok && len(matches) == 1 {
-				g.Edges[src][i].Target = matches[0]
-			}
-		}
-	}
 }
 
 // DetectCycles finds all cycles in the graph using DFS.
@@ -216,7 +198,14 @@ func (g *Graph) DetectCycles() [][]string {
 	return cycles
 }
 
-// BrokenLinks returns links whose targets don't match any record in the graph.
+// BrokenLinks returns links whose targets do not resolve.
+//
+// Brokenness comes from the resolver, not from node membership. A target that
+// exists on disk but is not a governed record resolved fine — the schema
+// declares what is governed, not what exists — so it is an edge to a non-node
+// rather than a broken link. Reporting it broken is what made graph and
+// validate disagree in issue #62. Edges nothing resolved keep the historical
+// node-membership check.
 func (g *Graph) BrokenLinks() []BrokenLink {
 	nodeNames := make([]string, 0, len(g.Nodes))
 	for name := range g.Nodes {
@@ -226,7 +215,7 @@ func (g *Graph) BrokenLinks() []BrokenLink {
 	var broken []BrokenLink
 	for _, edges := range g.Edges {
 		for _, edge := range edges {
-			if _, exists := g.Nodes[edge.Target]; !exists {
+			if edge.isBroken(g.Nodes) {
 				bl := BrokenLink{
 					Source: edge.Source,
 					Target: edge.Target,
@@ -368,4 +357,52 @@ func resolveTarget(sourcePath, target string) string {
 		return filepath.Clean(filepath.Join(dir, target))
 	}
 	return target
+}
+
+// resolveUncheckedByBasename rewrites unchecked edge targets that match no node
+// by searching for a unique basename match, with and without ".md".
+//
+// Prepared edges are excluded: rules.PrepareLinks already applied the same
+// fallback against the same record set, and re-running it here could rewrite a
+// target the resolver deliberately left alone.
+func (g *Graph) resolveUncheckedByBasename() {
+	idx := make(map[string][]string, len(g.Nodes))
+	for path := range g.Nodes {
+		base := filepath.Base(path)
+		idx[base] = append(idx[base], path)
+		if noExt := strings.TrimSuffix(base, ".md"); noExt != base {
+			idx[noExt] = append(idx[noExt], path)
+		}
+	}
+
+	for src, edges := range g.Edges {
+		for i, edge := range edges {
+			if edge.resolution != extract.LinkUnchecked || edge.markdown {
+				continue
+			}
+			if _, exists := g.Nodes[edge.Target]; exists {
+				continue
+			}
+			if matches, ok := idx[edge.Target]; ok && len(matches) == 1 {
+				g.Edges[src][i].Target = matches[0]
+			}
+		}
+	}
+}
+
+// isBroken reports whether an edge should be listed as a broken link.
+//
+// A prepared edge answers from its own resolution outcome. An unprepared one
+// (resolution is the zero value) falls back to node membership, preserving the
+// behavior every in-memory caller relied on before resolution existed.
+func (e Edge) isBroken(nodes map[string]*extract.Record) bool {
+	switch e.resolution {
+	case extract.LinkResolved:
+		return false
+	case extract.LinkUnresolved:
+		return true
+	default:
+		_, exists := nodes[e.Target]
+		return !exists
+	}
 }

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -476,3 +476,26 @@ func TestSortedEdges_EmptyGraph(t *testing.T) {
 		t.Fatalf("SortedEdges() = %+v, want empty", got)
 	}
 }
+
+// A prepared link is authoritative. rules.PrepareLinks already applied the
+// basename fallback against the same record set, so Build must not re-run it
+// and must trust the recorded outcome: an unresolved target is broken even if
+// a same-named node exists, and a resolved one is not broken even though it
+// names no node. That second case is the crux of issue #62 — an existing but
+// ungoverned file resolved fine, and calling it broken is what made graph and
+// validate disagree, because the schema declares what is governed, not what
+// exists.
+func TestBuild_PreparedResolutionIsAuthoritative(t *testing.T) {
+	records := []*extract.Record{
+		makeRecord("dir/missing.md", nil),
+		makeRecord("a.md", []extract.Link{
+			{Target: "missing.md", Style: extract.StyleWikilink, Line: 1, Resolution: extract.LinkUnresolved},
+			{Target: "ungoverned.md", Style: extract.StyleMarkdown, Line: 2, Resolution: extract.LinkResolved},
+		}),
+	}
+	g := Build(context.Background(), records)
+	broken := g.BrokenLinks()
+	if len(broken) != 1 || broken[0].Target != "missing.md" {
+		t.Fatalf("broken = %+v, want only the unresolved target, left verbatim", broken)
+	}
+}

--- a/internal/rules/link_prepare.go
+++ b/internal/rules/link_prepare.go
@@ -1,0 +1,84 @@
+package rules
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/pablontiv/rootline/internal/extract"
+)
+
+// PrepareLinks resolves every link through the canonical resolver and rewrites
+// resolvable targets to the root-relative form used as a graph node key.
+//
+// This is the bridge between the resolver, which answers in filesystem paths,
+// and the graph, which is keyed by root-relative record paths. Running it means
+// graph, query traversal and validate all ask the same question of the same
+// resolver, which is what issue #62 was about: the two used to run disjoint
+// engines and could not agree on whether a link was broken.
+//
+// Each link is annotated with the outcome. A target that fails to resolve keeps
+// its verbatim text so the reported broken link matches what the author wrote.
+// A target that resolves but names a file outside the governed record set is
+// still marked resolved — the schema declares what is governed, not what
+// exists, so such a link is an edge to a non-node, not a broken link.
+//
+// It replaces ResolveMarkdownTargets, which handled only markdown targets.
+func PrepareLinks(records []*extract.Record, root string) {
+	index := basenameIndex(records)
+	for _, rec := range records {
+		dir := filepath.Dir(filepath.Join(root, rec.Path))
+		for i, link := range rec.Links {
+			res := ResolveLinkTarget(ResolveRequest{
+				BaseDir: dir,
+				Root:    root,
+				Target:  link.Target,
+				Style:   linkStyle(link),
+			})
+			// Resolving is only half the job: without a root-relative key the
+			// graph has nothing to match against, so a target that resolves on
+			// disk but cannot be expressed relative to root stays unresolved
+			// rather than being marked resolved with an unusable target.
+			if rel, err := filepath.Rel(root, res.Path); res.OK && err == nil {
+				rec.Links[i].Resolution = extract.LinkResolved
+				rec.Links[i].Target = rel
+				continue
+			}
+			if match, ok := index.lookup(link.Target); ok {
+				rec.Links[i].Resolution = extract.LinkResolved
+				rec.Links[i].Target = match
+				continue
+			}
+			rec.Links[i].Resolution = extract.LinkUnresolved
+		}
+	}
+}
+
+// basenames maps a bare name to the record paths carrying it.
+type basenames map[string][]string
+
+// basenameIndex indexes every record by its basename, with and without the
+// ".md" extension, so a target naming no path can be matched against the
+// record set.
+func basenameIndex(records []*extract.Record) basenames {
+	idx := make(basenames, len(records))
+	for _, rec := range records {
+		base := filepath.Base(rec.Path)
+		idx[base] = append(idx[base], rec.Path)
+		if noExt := strings.TrimSuffix(base, ".md"); noExt != base {
+			idx[noExt] = append(idx[noExt], rec.Path)
+		}
+	}
+	return idx
+}
+
+// lookup resolves a bare target to a record path when exactly one record
+// carries that basename. An ambiguous name resolves to nothing: guessing
+// between two equally-plausible records would be worse than reporting the
+// link unresolved.
+func (b basenames) lookup(target string) (string, bool) {
+	matches, ok := b[target]
+	if !ok || len(matches) != 1 {
+		return "", false
+	}
+	return matches[0], true
+}

--- a/internal/rules/link_prepare_test.go
+++ b/internal/rules/link_prepare_test.go
@@ -1,0 +1,132 @@
+package rules
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/extract"
+)
+
+func recWithLinks(path string, links ...extract.Link) *extract.Record {
+	return &extract.Record{Path: path, Type: "markdown", Links: links}
+}
+
+// PrepareLinks resolves every governed link through the canonical resolver and
+// rewrites it to the root-relative form the graph uses as a node key, so graph
+// and validate agree on which links are broken (issue #62).
+func TestPrepareLinks_ResolvesWikilinkToNodeKey(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "b.md"), "# B\n")
+	writeFile(t, filepath.Join(root, "t.md"), "body")
+	rec := recWithLinks("t.md", extract.Link{Target: "b", Type: "reference", Style: extract.StyleWikilink, Line: 1})
+
+	PrepareLinks([]*extract.Record{rec}, root)
+
+	if got := rec.Links[0].Target; got != "b.md" {
+		t.Errorf("Target = %q, want %q", got, "b.md")
+	}
+	if got := rec.Links[0].Resolution; got != extract.LinkResolved {
+		t.Errorf("Resolution = %q, want %q", got, extract.LinkResolved)
+	}
+}
+
+// A path-qualified extension-less wikilink resolves too — graph used to report
+// this broken while suggesting the correct file one line below (sub-defect 10).
+func TestPrepareLinks_ResolvesPathQualifiedWikilink(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "sub", "README.md"), "# Sub\n")
+	writeFile(t, filepath.Join(root, "t.md"), "body")
+	rec := recWithLinks("t.md", extract.Link{Target: "sub/README", Type: "reference", Style: extract.StyleWikilink, Line: 1})
+
+	PrepareLinks([]*extract.Record{rec}, root)
+
+	if got := rec.Links[0].Target; got != filepath.Join("sub", "README.md") {
+		t.Errorf("Target = %q, want sub/README.md", got)
+	}
+	if rec.Links[0].Resolution != extract.LinkResolved {
+		t.Errorf("Resolution = %q, want resolved", rec.Links[0].Resolution)
+	}
+}
+
+// Basename fallback still applies: a bare target matches a uniquely-named
+// record anywhere in the tree, and an ambiguous one resolves to nothing rather
+// than guessing. Gating this behind a schema knob is a separate change.
+func TestPrepareLinks_BasenameFallback(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "t.md"), "body")
+	link := func(target string) extract.Link {
+		return extract.Link{Target: target, Type: "reference", Style: extract.StyleWikilink, Line: 1}
+	}
+	unique := []*extract.Record{recWithLinks("t.md", link("far")), recWithLinks(filepath.Join("deep", "far.md"))}
+	PrepareLinks(unique, root)
+	if unique[0].Links[0].Resolution != extract.LinkResolved || unique[0].Links[0].Target != filepath.Join("deep", "far.md") {
+		t.Errorf("unique basename should resolve, got %+v", unique[0].Links[0])
+	}
+
+	ambiguous := []*extract.Record{recWithLinks("t.md", link("dup")),
+		recWithLinks(filepath.Join("a", "dup.md")), recWithLinks(filepath.Join("b", "dup.md"))}
+	PrepareLinks(ambiguous, root)
+	if ambiguous[0].Links[0].Resolution != extract.LinkUnresolved {
+		t.Errorf("ambiguous basename must stay unresolved, got %q", ambiguous[0].Links[0].Resolution)
+	}
+}
+
+func TestPrepareLinks_MarksMissingTargetUnresolved(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "t.md"), "body")
+	rec := recWithLinks("t.md", extract.Link{Target: "nope", Type: "reference", Style: extract.StyleWikilink, Line: 1})
+
+	PrepareLinks([]*extract.Record{rec}, root)
+
+	if rec.Links[0].Resolution != extract.LinkUnresolved {
+		t.Errorf("Resolution = %q, want unresolved", rec.Links[0].Resolution)
+	}
+}
+
+// A target that exists but is not a governed record still RESOLVES: the schema
+// declares what is governed, not what exists. graph must not call it broken.
+func TestPrepareLinks_ExistingButUngovernedTargetResolves(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "ungoverned.md"), "# U\n")
+	writeFile(t, filepath.Join(root, "t.md"), "body")
+	rec := recWithLinks("t.md", extract.Link{Target: "ungoverned.md", Type: "reference", Style: extract.StyleMarkdown, Line: 1})
+
+	PrepareLinks([]*extract.Record{rec}, root)
+
+	if rec.Links[0].Resolution != extract.LinkResolved {
+		t.Errorf("Resolution = %q, want resolved", rec.Links[0].Resolution)
+	}
+}
+
+func TestPrepareLinks_RootAnchoredTarget(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "Page.md"), "# P\n")
+	writeFile(t, filepath.Join(root, "deep", "t.md"), "body")
+	rec := recWithLinks(filepath.Join("deep", "t.md"),
+		extract.Link{Target: "/docs/Page.md", Type: "reference", Style: extract.StyleMarkdown, Line: 1})
+
+	PrepareLinks([]*extract.Record{rec}, root)
+
+	if got := rec.Links[0].Target; got != filepath.Join("docs", "Page.md") {
+		t.Errorf("Target = %q, want docs/Page.md", got)
+	}
+}
+
+// A target that resolves but cannot be expressed relative to root gives the
+// graph no key to match, so it must not be recorded as resolved.
+func TestPrepareLinks_UnrelatableTargetStaysUnresolved(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	writeFile(t, filepath.Join(other, "elsewhere.md"), "# E\n")
+	writeFile(t, filepath.Join(root, "t.md"), "body")
+	rec := recWithLinks("t.md", extract.Link{
+		Target: filepath.Join(other, "elsewhere.md"), Type: "reference",
+		Style: extract.StyleMarkdown, Line: 1,
+	})
+
+	PrepareLinks([]*extract.Record{rec}, root)
+
+	if rec.Links[0].Resolution == extract.LinkResolved && rec.Links[0].Target == filepath.Join(other, "elsewhere.md") {
+		t.Errorf("target outside root marked resolved without a usable key: %+v", rec.Links[0])
+	}
+}


### PR DESCRIPTION
## What

`graph` and `validate` reached the same question — *does this link target exist?* — through two
disjoint engines. `validate` resolved against the filesystem; `graph` matched strings against its
own node set. So an extension-less wikilink with a directory prefix was reported broken by `graph`
while the fuzzy suggester named the correct file one line below:

```console
$ rootline graph --check mix/      # before
Broken links: 2
  wikisub.md:1 → sub/README (reference) — did you mean: sub/README.md?
  wikianchor.md:1 → b#heading-one (reference)
exit=1

$ rootline graph --check mix/      # after
No cycles or broken links found.
exit=0
```

## How

`rules.PrepareLinks` resolves every governed link through the canonical resolver, rewrites
resolvable targets to the root-relative keys the graph uses as nodes, and records the outcome on
the link. `graph.BrokenLinks` reads that outcome instead of inferring brokenness from node
membership.

**That distinction is the point, not tidiness.** A target that exists on disk but is not a
governed record resolved fine — `scope.match` and `.stemignore` declare what is *governed*, not
what *exists* — so it is an edge to a non-node, not a broken link. Deriving brokenness from the
node set is precisely what let the two commands disagree, and it would have reintroduced #62 at a
new seam once record-set unification lands.

`Link.Resolution` is a tri-state whose **zero value means nothing resolved this link**. That is
deliberate: ~44 call sites build a graph from in-memory records without preparing links, and they
keep their existing behavior — basename fallback included — untouched.

## Scope note

**Basename fallback is preserved here.** It moves into `PrepareLinks` and is retained for
unprepared edges inside `Build`. Gating it behind a `links.basename_fallback` schema knob
(default off) is the next PR, and that one is the breaking change.

I originally planned to drop it in this PR. While implementing I found the repo's own
`query_traversal_test.go` models a wiki as `wiki/sources/witness-a.md` containing
`[[supports:tool-a.md]]` pointing at `wiki/entities/tool-a.md` — a bare cross-directory link that
only ever resolved through basename fallback. The same shape appears in the `internal/query`
traversal tests, `internal/infer` back-reference tests, and the link-styles e2e. Bare
cross-directory linking is a core wiki ergonomic here, not a fringe convenience, so removing it
outright was the wrong call and it is now an opt-out rather than a deletion.

## Parity matrix rows changed

| Feature | `graph` before | `graph` after | `validate` |
|---|---|---|---|
| Path-qualified extension-less wikilink | **broken** | resolves | resolves (already) |
| Wikilink anchor (`[[b#heading]]`) | **broken** | resolves | resolves (already) |
| Existing-but-ungoverned target | would be broken | edge to a non-node | not an error |

Closes **sub-defect 10** and the `graph` half of **sub-defect 9**.

## Review note

The reliability lens found a real defect on the first round: `PrepareLinks` marked a link resolved
even when `filepath.Rel` failed, leaving a target the graph could never match. Fixed — resolution
is only recorded when a usable root-relative key was actually produced — and pinned by a test. The
re-review returned zero findings.

## Testing

`internal/rules/link_prepare_test.go` covers wikilink `.md` inference, path-qualified targets,
root-anchored targets, existing-but-ungoverned targets resolving, unique and ambiguous basename
fallback, and the `filepath.Rel` case. `internal/graph` gains a test that prepared resolution is
authoritative in both directions.

`just check`, `just test` (14 packages) and `just coverage-check` green — `internal/graph` 96.2%,
`internal/rules` 89.8%, total 89.5%.

## Size

400 changed lines, exactly at the review budget.

Refs #62