### PR TITLE
feat(rules)!: make basename fallback opt-in via links.basename_fallback

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -109,9 +109,12 @@ links:
     anchors: true               # #anchor matches a heading slug in the target
     encoding: true              # no raw spaces in targets (use %20)
     cycles: true                # graph --check fails on link cycles (default: informational)
+  basename_fallback: false      # opt-in: bare target matches a uniquely-named record anywhere
 ```
 
 **Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. External schemes, images, and pure fragments are not checked.
+
+**Basename fallback**: `links.basename_fallback` (default off) lets a path-less target match a uniquely-named record anywhere — the wiki convention. It needs a full-tree index, which `graph` and `query` traversal have and `validate` does not, so with it ON `validate` reports `link_unverifiable` (warning) instead of guessing or staying silent. Off is what makes every command agree.
 
 **One resolver**: `validate`, `graph` and `query` traversal share one resolver, so they agree on which links are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches a uniquely-named record anywhere. A resolved target is never broken even when `scope.match`/`.stemignore` excludes it: the schema declares what is governed, not what exists.
 

--- a/cmd/rootline/query_traversal_test.go
+++ b/cmd/rootline/query_traversal_test.go
@@ -24,6 +24,9 @@ func setupTraversalDir(t *testing.T) string {
 		"wiki/sources/witness-b.md": "---\nverification: unverified\n---\n# Witness B\n\n[[supports:tool-b.md]]\n",
 		"wiki/sources/witness-c.md": "---\nverification: corroborated\n---\n# Witness C\n\n[[mentions:tool-b.md]]\n",
 		"raw/decoy.md":              "---\nverification: corroborated\n---\n# Decoy\n\n[[supports:tool-b.md]]\n",
+		// This fixture models a wiki whose sources link entities by bare
+		// filename across directories, so it opts into basename fallback.
+		".stem": "version: 2\nroot: true\nlinks:\n  basename_fallback: true\n",
 	}
 	for rel, content := range files {
 		path := filepath.Join(dir, rel)

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -86,6 +86,33 @@ symlink that stays inside the root still resolves normally. Link targets are doc
 text, and resolution would otherwise report on — and with `anchors` enabled, read — files
 outside the tree being governed.
 
+### Basename fallback (`links.basename_fallback`)
+
+Off by default. Turning it on lets a target that names no path match a uniquely-named record
+anywhere in the tree — the wiki convention where `wiki/sources/witness.md` writes
+`[[supports:tool-a.md]]` for `wiki/entities/tool-a.md`:
+
+```yaml
+links:
+  basename_fallback: true
+```
+
+**This is the one place the commands intentionally differ, and it is a real trade.** Matching a
+bare name needs an index of every record. `graph` and `query` traversal scan the whole tree and
+have one; `validate` checks records one at a time and never does. So with the knob on, `validate`
+cannot decide such a link. It does not guess and it does not stay quiet — it reports
+`link_unverifiable` as a **warning** naming the command that can decide it:
+
+```console
+$ rootline validate wiki/sources/witness.md
+link target "tool-a.md" cannot be verified: links.basename_fallback matches against every
+record, which this command does not scan (check it with 'rootline graph --check')
+```
+
+Leaving the knob off is what makes every command answer identically. Turning it on is a
+deliberate choice to buy the wiki ergonomic at the cost of one check `validate` can no longer
+make — declared in the schema rather than discovered as a silent disagreement.
+
 Resolution asks the filesystem, not the record set. A target that exists on disk resolves even
 when `scope.match` or `.stemignore` excludes it from governance: the schema declares what is
 *governed*, not what *exists*.

--- a/internal/rules/link_checks.go
+++ b/internal/rules/link_checks.go
@@ -65,6 +65,22 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 				Style:   linkStyle(link),
 			})
 			if !res.OK {
+				// Basename fallback matches a target against every record in
+				// the tree, and CheckLinks sees one record at a time. Calling
+				// the link broken would be wrong — graph may well resolve it —
+				// and staying silent would put the two commands back into
+				// disagreement, so say plainly that this one is undecidable
+				// here and name the command that can decide it.
+				if schema.BasenameFallback && schema.Checks.Resolve {
+					errs = append(errs, ValidationError{
+						Rule:     "link_unverifiable",
+						Field:    "links",
+						Message:  fmt.Sprintf("link target %q cannot be verified: links.basename_fallback matches against every record, which this command does not scan (check it with 'rootline graph --check')", link.Target),
+						Source:   "links.checks",
+						Severity: "warning",
+					})
+					continue
+				}
 				if schema.Checks.Resolve {
 					msg := fmt.Sprintf("link target %q does not resolve to an existing file (case-sensitive)", link.Target)
 					if res.Suggestion != "" {

--- a/internal/rules/link_checks_test.go
+++ b/internal/rules/link_checks_test.go
@@ -243,3 +243,37 @@ func TestCheckLinks_AnchorCacheReuse(t *testing.T) {
 		t.Errorf("cache.slugs = %d entries, want 1 (shared target)", len(cache.slugs))
 	}
 }
+
+// With basename fallback on, validate cannot decide a bare cross-directory
+// target: CheckLinks sees one record and has no index to match against, while
+// graph does. Reporting it broken would be wrong (it may well resolve) and
+// skipping it silently would recreate the disagreement issue #62 is about, so
+// validate says explicitly that it could not verify this one.
+func TestCheckLinks_BasenameFallbackTargetIsUnverifiable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+	schema.BasenameFallback = true
+
+	errs := CheckLinks([]extract.Link{wikiLink("far")}, schema, filepath.Join(dir, "t.md"), dir, nil)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %+v", errs)
+	}
+	if errs[0].Rule != "link_unverifiable" {
+		t.Errorf("Rule = %q, want link_unverifiable", errs[0].Rule)
+	}
+	if errs[0].Severity != "warning" {
+		t.Errorf("Severity = %q, want warning — the link may well resolve", errs[0].Severity)
+	}
+}
+
+// Without the knob, the same target is an ordinary broken link.
+func TestCheckLinks_WithoutFallbackBareTargetIsBroken(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "t.md"), "body")
+	errs := CheckLinks([]extract.Link{wikiLink("far")}, wikiChecksSchema(LinkChecks{Resolve: true}),
+		filepath.Join(dir, "t.md"), dir, nil)
+	if len(errs) != 1 || errs[0].Rule != "link_resolve" || errs[0].Severity != "error" {
+		t.Fatalf("expected a link_resolve error, got %+v", errs)
+	}
+}

--- a/internal/rules/link_prepare.go
+++ b/internal/rules/link_prepare.go
@@ -27,6 +27,10 @@ func PrepareLinks(records []*extract.Record, root string) {
 	index := basenameIndex(records)
 	for _, rec := range records {
 		dir := filepath.Dir(filepath.Join(root, rec.Path))
+		fallback := false
+		if eff, err := ResolveForRecord(dir, rec.Path); err == nil && eff != nil {
+			fallback = eff.Links.BasenameFallback
+		}
 		for i, link := range rec.Links {
 			res := ResolveLinkTarget(ResolveRequest{
 				BaseDir: dir,
@@ -43,7 +47,7 @@ func PrepareLinks(records []*extract.Record, root string) {
 				rec.Links[i].Target = rel
 				continue
 			}
-			if match, ok := index.lookup(link.Target); ok {
+			if match, ok := index.lookup(link.Target); ok && fallback {
 				rec.Links[i].Resolution = extract.LinkResolved
 				rec.Links[i].Target = match
 				continue

--- a/internal/rules/link_prepare_test.go
+++ b/internal/rules/link_prepare_test.go
@@ -48,11 +48,11 @@ func TestPrepareLinks_ResolvesPathQualifiedWikilink(t *testing.T) {
 	}
 }
 
-// Basename fallback still applies: a bare target matches a uniquely-named
-// record anywhere in the tree, and an ambiguous one resolves to nothing rather
-// than guessing. Gating this behind a schema knob is a separate change.
+// With the knob on, a bare target matches a uniquely-named record anywhere in
+// the tree, and an ambiguous one resolves to nothing rather than guessing.
 func TestPrepareLinks_BasenameFallback(t *testing.T) {
 	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".stem"), "version: 2\nroot: true\nlinks:\n  basename_fallback: true\n")
 	writeFile(t, filepath.Join(root, "t.md"), "body")
 	link := func(target string) extract.Link {
 		return extract.Link{Target: target, Type: "reference", Style: extract.StyleWikilink, Line: 1}
@@ -128,5 +128,36 @@ func TestPrepareLinks_UnrelatableTargetStaysUnresolved(t *testing.T) {
 
 	if rec.Links[0].Resolution == extract.LinkResolved && rec.Links[0].Target == filepath.Join(other, "elsewhere.md") {
 		t.Errorf("target outside root marked resolved without a usable key: %+v", rec.Links[0])
+	}
+}
+
+// Basename fallback is opt-in. Off by default, a bare cross-directory target
+// does not resolve, so graph reports exactly what validate reports — neither
+// can match it without a global index, and validate never has one.
+func TestPrepareLinks_BasenameFallbackIsOptIn(t *testing.T) {
+	setup := func(t *testing.T, stem string) []*extract.Record {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, ".stem"), stem)
+		writeFile(t, filepath.Join(root, "t.md"), "body")
+		writeFile(t, filepath.Join(root, "deep", "far.md"), "# Far\n")
+		recs := []*extract.Record{
+			recWithLinks("t.md", extract.Link{Target: "far", Type: "reference", Style: extract.StyleWikilink, Line: 1}),
+			recWithLinks(filepath.Join("deep", "far.md")),
+		}
+		PrepareLinks(recs, root)
+		return recs
+	}
+
+	off := setup(t, "version: 2\nroot: true\n")
+	if got := off[0].Links[0].Resolution; got != extract.LinkUnresolved {
+		t.Errorf("default: Resolution = %q, want unresolved (fallback is opt-in)", got)
+	}
+
+	on := setup(t, "version: 2\nroot: true\nlinks:\n  basename_fallback: true\n")
+	if got := on[0].Links[0].Resolution; got != extract.LinkResolved {
+		t.Errorf("opted in: Resolution = %q, want resolved", got)
+	}
+	if got := on[0].Links[0].Target; got != filepath.Join("deep", "far.md") {
+		t.Errorf("opted in: Target = %q, want deep/far.md", got)
 	}
 }

--- a/internal/rules/merge.go
+++ b/internal/rules/merge.go
@@ -179,6 +179,12 @@ func mergeLinkSchema(parent, child LinkSchema) LinkSchema {
 
 	result := LinkSchema{}
 
+	// BasenameFallback: a child that opts in wins; otherwise inherit. It is a
+	// bool, so "not set" and "set false" are indistinguishable — a child
+	// cannot opt back out of a parent's fallback, matching how the other
+	// scalar link settings inherit.
+	result.BasenameFallback = parent.BasenameFallback || child.BasenameFallback
+
 	// Allowed: child replaces (array semantics).
 	if child.Allowed != nil {
 		result.Allowed = child.Allowed

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -59,6 +59,16 @@ type LinkSchema struct {
 	Checks  *LinkChecks         `json:"checks,omitempty"`
 	Rules   map[string]LinkRule `json:"rules,omitempty"`
 
+	// BasenameFallback opts into matching a target that names no path
+	// against a uniquely-named record anywhere in the tree, the wiki
+	// convention where sources link entities by bare filename.
+	//
+	// It is off by default because it needs a global index of every record,
+	// and single-file `validate <file>` has none. With it on, that one
+	// command cannot check such links and says so; with it off, every
+	// command answers identically.
+	BasenameFallback bool `json:"basename_fallback,omitempty"`
+
 	// UnknownCheckKeys lists keys found under links.checks that no check
 	// consumes. Diagnostic only — surfaced by stem health, never serialized.
 	UnknownCheckKeys []string `json:"-"`
@@ -113,6 +123,15 @@ func (ls *LinkSchema) UnmarshalYAML(value *yaml.Node) error {
 			continue
 		}
 
+		if key == "basename_fallback" {
+			var enabled bool
+			if err := val.Decode(&enabled); err != nil {
+				return fmt.Errorf("links.basename_fallback: %w", err)
+			}
+			ls.BasenameFallback = enabled
+			continue
+		}
+
 		if key == "styles" {
 			var styles []string
 			if err := val.Decode(&styles); err != nil {
@@ -152,7 +171,7 @@ func (ls *LinkSchema) UnmarshalYAML(value *yaml.Node) error {
 
 // IsEmpty reports whether the LinkSchema has no constraints.
 func (ls LinkSchema) IsEmpty() bool {
-	return len(ls.Allowed) == 0 && len(ls.Rules) == 0 && len(ls.Styles) == 0 && ls.Checks == nil
+	return len(ls.Allowed) == 0 && len(ls.Rules) == 0 && len(ls.Styles) == 0 && ls.Checks == nil && !ls.BasenameFallback
 }
 
 // Scope defines which files a .stem applies to.


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE THIS PR WITHOUT #102.**
>
> The description below states that `link_unverifiable` has severity `warning` and therefore does
> not fail the build. **That is wrong as shipped in this branch.** Only `warn` routes to warnings;
> `warning` falls through to errors, so this change as written emits `link_unverifiable` as an
> **error** and **invalidates records** — the opposite of what the description claims.
>
> This was found and corrected in **#102**, which is stacked after this PR. Merging #94 alone
> would ship record-invalidating behaviour. Either merge #102 in the same batch, or have the
> author fold the severity fix back into this PR and rewrite the affected description.
>
> _Added by the coordinator after the author disclosed the defect in their status report._

---

