### PR TITLE
feat(graph): report anchor and encoding failures in graph --check

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -116,6 +116,8 @@ links:
 
 **Basename fallback**: `links.basename_fallback` (default off) lets a path-less target match a uniquely-named record anywhere — the wiki convention. It needs a full-tree index, which `graph` and `query` traversal have and `validate` does not, so with it ON `validate` reports `link_unverifiable` (warning) instead of guessing or staying silent. Off is what makes every command agree.
 
+**`graph --check` runs the declared checks too**: with `links.checks` set it reports `link_anchor` and `link_encoding` alongside cycles and broken links, matching `validate`. Resolution failures appear once, as broken links.
+
 **One resolver**: `validate`, `graph` and `query` traversal share one resolver, so they agree on which links are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches a uniquely-named record anywhere. A resolved target is never broken even when `scope.match`/`.stemignore` excludes it: the schema declares what is governed, not what exists.
 
 **Query link traversal**: `--has-inbound` and `--has-outbound` predicates search both wiki-link and markdown-link styles (governed by `.stem links.styles`). Combine with `--inbound-type` / `--outbound-type` to restrict to one link type.

--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -68,7 +68,6 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	rules.FilterLinksByStyles(records, absRoot)
-	rules.PrepareLinks(records, absRoot)
 
 	derive.EnrichBuiltinsSimple(ctx, records, absRoot)
 
@@ -77,6 +76,17 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("filtering records: %w", err)
 	}
+
+	// Link checks read the target the author wrote, so they run before
+	// PrepareLinks rewrites targets to resolved node keys. Resolution decodes
+	// percent escapes, so checking afterwards would flag an already-correct
+	// %20 target for the raw space its decoded form contains.
+	var linkIssues []linkCheckIssue
+	if graphCheck {
+		linkIssues = collectLinkCheckIssues(records, absRoot)
+	}
+
+	rules.PrepareLinks(records, absRoot)
 
 	// Load .stem schema: filter links and read the cycle-failure opt-in.
 	//
@@ -104,7 +114,7 @@ func runGraph(cmd *cobra.Command, args []string) error {
 
 	// --check mode: report issues and exit.
 	if graphCheck {
-		hasProblems := (failCycles && len(cycles) > 0) || len(broken) > 0
+		hasProblems := (failCycles && len(cycles) > 0) || len(broken) > 0 || len(linkIssues) > 0
 		if len(cycles) > 0 {
 			header := "Cycles found"
 			if !failCycles {
@@ -131,7 +141,13 @@ func runGraph(cmd *cobra.Command, args []string) error {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), msg)
 			}
 		}
-		if len(cycles) == 0 && len(broken) == 0 {
+		if len(linkIssues) > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Link check failures: %d\n", len(linkIssues))
+			for _, li := range linkIssues {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s (%s)\n", li.path, li.message, li.rule)
+			}
+		}
+		if len(cycles) == 0 && len(broken) == 0 && len(linkIssues) == 0 {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No cycles or broken links found.")
 		}
 		if hasProblems {
@@ -175,6 +191,39 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// linkCheckIssue is one links.checks failure attributed to its record.
+type linkCheckIssue struct {
+	path    string
+	rule    string
+	message string
+}
+
+// collectLinkCheckIssues runs the schema's declared links.checks over every
+// record so `graph --check` sees the same anchor and encoding failures
+// `validate` does.
+//
+// Resolution failures are deliberately skipped: the graph already reports an
+// unresolvable target as a broken link, and reporting it twice under two names
+// would be noise. Checks stay opt-in — a schema declaring none yields nothing.
+func collectLinkCheckIssues(records []*extract.Record, root string) []linkCheckIssue {
+	cache := rules.NewHeadingCache()
+	var issues []linkCheckIssue
+	for _, rec := range records {
+		absPath := filepath.Join(root, rec.Path)
+		effective, err := rules.ResolveForRecord(filepath.Dir(absPath), rec.Path)
+		if err != nil || effective == nil {
+			continue
+		}
+		for _, e := range rules.CheckLinks(rec.Links, effective.Links, absPath, root, cache) {
+			if e.Rule == "link_resolve" {
+				continue
+			}
+			issues = append(issues, linkCheckIssue{path: rec.Path, rule: e.Rule, message: e.Message})
+		}
+	}
+	return issues
 }
 
 func renderDOT(cmd *cobra.Command, g *graph.Graph) {

--- a/cmd/rootline/graph_checks_test.go
+++ b/cmd/rootline/graph_checks_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// graph --check used to report only cycles and broken links, so a green run
+// proved nothing about anchors or encoding even when the schema asked for
+// those checks — validate was the only command that could see them
+// (issue #62 sub-defect 4).
+func TestGraphCheckReportsAnchorAndEncoding(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  styles: [markdown]\n  checks:\n    resolve: true\n    anchors: true\n    encoding: true\n")
+	write("target.md", "---\ntitulo: T\n---\n\n# Heading One\n")
+	write("has space.md", "---\ntitulo: S\n---\n\n# S\n")
+	write("bad-anchor.md", "---\ntitulo: A\n---\n\nSee [x](target.md#no-such-heading).\n")
+	write("bad-encoding.md", "---\ntitulo: E\n---\n\nSee [x](has space.md).\n")
+
+	out, err := runCmd(t, "graph", dir, "--check")
+	if err == nil {
+		t.Errorf("expected a non-zero result when anchor/encoding checks fail, got nil")
+	}
+	if !strings.Contains(out, "no-such-heading") {
+		t.Errorf("anchor violation not reported:\n%s", out)
+	}
+	if !strings.Contains(out, "has space.md") || !strings.Contains(out, "encoding") {
+		t.Errorf("encoding violation not reported:\n%s", out)
+	}
+}
+
+// A repository whose schema declares no checks keeps a clean report: the
+// checks are opt-in and graph must not invent them.
+func TestGraphCheckWithoutChecksStaysQuiet(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  styles: [markdown]\n")
+	write("target.md", "---\ntitulo: T\n---\n\n# Heading One\n")
+	write("a.md", "---\ntitulo: A\n---\n\nSee [x](target.md#no-such-heading).\n")
+
+	out, err := runCmd(t, "graph", dir, "--check")
+	if err != nil {
+		t.Errorf("expected clean run without declared checks, got %v:\n%s", err, out)
+	}
+}

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -89,6 +89,11 @@ a uniquely-named record anywhere. A resolved target is never reported broken **e
 schema does not govern it** — `scope.match` and `.stemignore` declare what is *governed*, not
 what *exists*, so such a link is an edge to a non-node. Unresolved targets are reported verbatim.
 
+When the effective `.stem` declares `links.checks`, `--check` also reports the anchor and
+encoding failures `validate` reports, so a green `graph --check` now means what it looks like it
+means. Resolution failures stay under "Broken links" rather than being listed twice. Checks are
+opt-in: a schema declaring none reports nothing extra.
+
 Prints a text report and exits 1 when a blocking problem is found (broken links always block; cycles block only with `--fail-cycles` or `links.checks.cycles: true`, otherwise they are informational):
 
 ```text


### PR DESCRIPTION
## What

`graph --check` reported only cycles and broken links. So with `links.checks` declaring `anchors`
and `encoding`, a **green `graph --check` proved nothing about either** — `validate` was the only
command that could see them. The gate CI is most likely to wire up could not catch an anchor
regression.

## How

`--check` now runs the schema's declared `links.checks` over every record and reports
`link_anchor` and `link_encoding` alongside the existing output. `link_resolve` is skipped: the
graph already reports an unresolvable target as a broken link, and naming the same defect twice
under two names would be noise. Checks stay opt-in — a schema declaring none reports nothing extra.

### The ordering detail that matters

The checks run **before** `PrepareLinks`, not after. Resolution rewrites a target to its resolved
node key and decodes percent escapes on the way, so checking afterwards flagged an
already-correct `%20` target for the raw space its *decoded* form contains. I caught this in
verification — the first implementation double-reported `enc.md`:

```
Link check failures: 3
  enc.md: link target "has space.md" contains unencoded spaces (use %20) (link_encoding)
  enc.md: link target "has space.md" contains unencoded spaces (use %20) (link_encoding)   <-- the %20 link
```

The encoding check has to see what the author wrote, not what the resolver produced.

## Evidence — the two commands now agree

Issue #62 reproduction case C, `md/` fixture:

```console
$ rootline graph --check md/
Broken links: 1
  rootrel.md:1 → /nonexistent.md (reference)
Link check failures: 2
  anchors.md: anchor "missing-anchor" not found in "b.md" (link_anchor)
  enc.md: link target "has space.md" contains unencoded spaces (use %20) (link_encoding)
exit=1

$ rootline validate --all md/     # same three findings
  anchors.md   link_anchor
  enc.md       link_encoding
  rootrel.md   link_resolve
```

Same three defects, same records. Before this change `graph --check` reported one of the three
and `validate` reported the other two.

## Parity matrix rows changed

| Feature | `graph --check` before | after | `validate` |
|---|---|---|---|
| Anchor check (`#frag`) | **not reported** | reported | reported |
| Encoding check (`%20`) | **not reported** | reported | reported |

Closes **sub-defect 4**.

## Testing

`cmd/rootline/graph_checks_test.go` covers both directions: a schema declaring the checks reports
the violations and exits non-zero, and a schema declaring none stays clean.

`just check`, `just test` (14 packages), `just coverage-check` green.

## Size and stacking

128 changed lines. Based on #94, **not** master.

Refs #62
