### PR TITLE
feat(rules)!: make broken-target detection always on

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -116,6 +116,8 @@ links:
 
 **Basename fallback**: `links.basename_fallback` (default off) lets a path-less target match a uniquely-named record anywhere — the wiki convention. It needs a full-tree index, which `graph` and `query` traversal have and `validate` does not, so with it ON `validate` reports `link_unverifiable` (warning) instead of guessing or staying silent. Off is what makes every command agree.
 
+**`graph --check` runs the declared checks too**: with `links.checks` set it reports `link_anchor` and `link_encoding` alongside cycles and broken links, matching `validate`. Resolution failures appear once, as broken links.
+
 **One resolver**: `validate`, `graph` and `query` traversal share one resolver, so they agree on which links are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches a uniquely-named record anywhere. A resolved target is never broken even when `scope.match`/`.stemignore` excludes it: the schema declares what is governed, not what exists.
 
 **Query link traversal**: `--has-inbound` and `--has-outbound` predicates search both wiki-link and markdown-link styles (governed by `.stem links.styles`). Combine with `--inbound-type` / `--outbound-type` to restrict to one link type.

--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -105,7 +105,7 @@ version: 2
 links:
   styles: [wikilink, markdown]  # governed styles; default [wikilink]
   checks:
-    resolve: true               # target exists (case-sensitive; dir targets need README.md)
+    resolve: false              # OPT-OUT only — broken-target detection is on by default
     anchors: true               # #anchor matches a heading slug in the target
     encoding: true              # no raw spaces in targets (use %20)
     cycles: true                # graph --check fails on link cycles (default: informational)
@@ -113,6 +113,8 @@ links:
 ```
 
 **Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. External schemes, images, and pure fragments are not checked.
+
+**`resolve` is always on**: broken-target detection needs no declaration (it matches `graph --check`, which never had an opt-in). Set `links.checks.resolve: false` to opt out. `anchors` and `encoding` remain opt-in.
 
 **Basename fallback**: `links.basename_fallback` (default off) lets a path-less target match a uniquely-named record anywhere — the wiki convention. It needs a full-tree index, which `graph` and `query` traversal have and `validate` does not, so with it ON `validate` reports `link_unverifiable` (warning) instead of guessing or staying silent. Off is what makes every command agree.
 

--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -68,7 +68,6 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	rules.FilterLinksByStyles(records, absRoot)
-	rules.PrepareLinks(records, absRoot)
 
 	derive.EnrichBuiltinsSimple(ctx, records, absRoot)
 
@@ -77,6 +76,17 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("filtering records: %w", err)
 	}
+
+	// Link checks read the target the author wrote, so they run before
+	// PrepareLinks rewrites targets to resolved node keys. Resolution decodes
+	// percent escapes, so checking afterwards would flag an already-correct
+	// %20 target for the raw space its decoded form contains.
+	var linkIssues []linkCheckIssue
+	if graphCheck {
+		linkIssues = collectLinkCheckIssues(records, absRoot)
+	}
+
+	rules.PrepareLinks(records, absRoot)
 
 	// Load .stem schema: filter links and read the cycle-failure opt-in.
 	//
@@ -104,7 +114,7 @@ func runGraph(cmd *cobra.Command, args []string) error {
 
 	// --check mode: report issues and exit.
 	if graphCheck {
-		hasProblems := (failCycles && len(cycles) > 0) || len(broken) > 0
+		hasProblems := (failCycles && len(cycles) > 0) || len(broken) > 0 || len(linkIssues) > 0
 		if len(cycles) > 0 {
 			header := "Cycles found"
 			if !failCycles {
@@ -131,7 +141,13 @@ func runGraph(cmd *cobra.Command, args []string) error {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), msg)
 			}
 		}
-		if len(cycles) == 0 && len(broken) == 0 {
+		if len(linkIssues) > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Link check failures: %d\n", len(linkIssues))
+			for _, li := range linkIssues {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s (%s)\n", li.path, li.message, li.rule)
+			}
+		}
+		if len(cycles) == 0 && len(broken) == 0 && len(linkIssues) == 0 {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No cycles or broken links found.")
 		}
 		if hasProblems {
@@ -175,6 +191,39 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// linkCheckIssue is one links.checks failure attributed to its record.
+type linkCheckIssue struct {
+	path    string
+	rule    string
+	message string
+}
+
+// collectLinkCheckIssues runs the schema's declared links.checks over every
+// record so `graph --check` sees the same anchor and encoding failures
+// `validate` does.
+//
+// Resolution failures are deliberately skipped: the graph already reports an
+// unresolvable target as a broken link, and reporting it twice under two names
+// would be noise. Checks stay opt-in — a schema declaring none yields nothing.
+func collectLinkCheckIssues(records []*extract.Record, root string) []linkCheckIssue {
+	cache := rules.NewHeadingCache()
+	var issues []linkCheckIssue
+	for _, rec := range records {
+		absPath := filepath.Join(root, rec.Path)
+		effective, err := rules.ResolveForRecord(filepath.Dir(absPath), rec.Path)
+		if err != nil || effective == nil {
+			continue
+		}
+		for _, e := range rules.CheckLinks(rec.Links, effective.Links, absPath, root, cache) {
+			if e.Rule == "link_resolve" {
+				continue
+			}
+			issues = append(issues, linkCheckIssue{path: rec.Path, rule: e.Rule, message: e.Message})
+		}
+	}
+	return issues
 }
 
 func renderDOT(cmd *cobra.Command, g *graph.Graph) {

--- a/cmd/rootline/graph_checks_test.go
+++ b/cmd/rootline/graph_checks_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// graph --check used to report only cycles and broken links, so a green run
+// proved nothing about anchors or encoding even when the schema asked for
+// those checks — validate was the only command that could see them
+// (issue #62 sub-defect 4).
+func TestGraphCheckReportsAnchorAndEncoding(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  styles: [markdown]\n  checks:\n    resolve: true\n    anchors: true\n    encoding: true\n")
+	write("target.md", "---\ntitulo: T\n---\n\n# Heading One\n")
+	write("has space.md", "---\ntitulo: S\n---\n\n# S\n")
+	write("bad-anchor.md", "---\ntitulo: A\n---\n\nSee [x](target.md#no-such-heading).\n")
+	write("bad-encoding.md", "---\ntitulo: E\n---\n\nSee [x](has space.md).\n")
+
+	out, err := runCmd(t, "graph", dir, "--check")
+	if err == nil {
+		t.Errorf("expected a non-zero result when anchor/encoding checks fail, got nil")
+	}
+	if !strings.Contains(out, "no-such-heading") {
+		t.Errorf("anchor violation not reported:\n%s", out)
+	}
+	if !strings.Contains(out, "has space.md") || !strings.Contains(out, "encoding") {
+		t.Errorf("encoding violation not reported:\n%s", out)
+	}
+}
+
+// A repository whose schema declares no checks keeps a clean report: the
+// checks are opt-in and graph must not invent them.
+func TestGraphCheckWithoutChecksStaysQuiet(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  styles: [markdown]\n")
+	write("target.md", "---\ntitulo: T\n---\n\n# Heading One\n")
+	write("a.md", "---\ntitulo: A\n---\n\nSee [x](target.md#no-such-heading).\n")
+
+	out, err := runCmd(t, "graph", dir, "--check")
+	if err != nil {
+		t.Errorf("expected clean run without declared checks, got %v:\n%s", err, out)
+	}
+}

--- a/cmd/rootline/graph_test.go
+++ b/cmd/rootline/graph_test.go
@@ -298,7 +298,8 @@ func TestFilterLinksBySchema_ChecksOnlySchema(t *testing.T) {
 		Path:  "a.md",
 		Links: []extract.Link{{Target: "b.md", Style: extract.StyleWikilink}},
 	}
-	schema := rules.LinkSchema{Checks: &rules.LinkChecks{Resolve: true}}
+	resolveOn := true
+	schema := rules.LinkSchema{Checks: &rules.LinkChecks{Resolve: &resolveOn}}
 	filterLinksBySchema([]*extract.Record{rec}, schema)
 	if len(rec.Links) != 1 {
 		t.Fatalf("links = %d, want 1 (checks-only schema must not drop links)", len(rec.Links))

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -89,6 +89,11 @@ a uniquely-named record anywhere. A resolved target is never reported broken **e
 schema does not govern it** — `scope.match` and `.stemignore` declare what is *governed*, not
 what *exists*, so such a link is an edge to a non-node. Unresolved targets are reported verbatim.
 
+When the effective `.stem` declares `links.checks`, `--check` also reports the anchor and
+encoding failures `validate` reports, so a green `graph --check` now means what it looks like it
+means. Resolution failures stay under "Broken links" rather than being listed twice. Checks are
+opt-in: a schema declaring none reports nothing extra.
+
 Prints a text report and exits 1 when a blocking problem is found (broken links always block; cycles block only with `--fail-cycles` or `links.checks.cycles: true`, otherwise they are informational):
 
 ```text

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -86,6 +86,22 @@ symlink that stays inside the root still resolves normally. Link targets are doc
 text, and resolution would otherwise report on — and with `anchors` enabled, read — files
 outside the tree being governed.
 
+### Broken-target detection is always on
+
+`links.checks.resolve` needs no opt-in. `graph --check` has always failed on a broken link with
+no schema declaration, so leaving `validate` silent unless `links.checks` declared `resolve` meant
+the two commands disagreed on the one property both claim to check.
+
+A repository that genuinely wants dangling links opts out explicitly:
+
+```yaml
+links:
+  checks:
+    resolve: false
+```
+
+`anchors` and `encoding` stay opt-in — only `resolve` flipped.
+
 ### Basename fallback (`links.basename_fallback`)
 
 Off by default. Turning it on lets a target that names no path match a uniquely-named record

--- a/internal/rules/link_checks.go
+++ b/internal/rules/link_checks.go
@@ -32,7 +32,13 @@ func NewHeadingCache() *HeadingCache {
 // Resolution runs through ResolveLinkTarget, the same entry point graph and
 // query use, so the commands cannot disagree about whether a link is broken.
 func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root string, cache *HeadingCache) []ValidationError {
-	if schema.Checks == nil {
+	// Broken-target detection needs no opt-in, so a schema with no checks
+	// block still resolves. Anchors and encoding remain opt-in and are
+	// guarded individually below.
+	resolve := schema.ShouldResolve()
+	anchors := schema.Checks != nil && schema.Checks.Anchors
+	encoding := schema.Checks != nil && schema.Checks.Encoding
+	if !resolve && !anchors && !encoding {
 		return nil
 	}
 
@@ -47,7 +53,7 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 			continue
 		}
 
-		if schema.Checks.Encoding && strings.Contains(link.Target, " ") {
+		if encoding && strings.Contains(link.Target, " ") {
 			errs = append(errs, ValidationError{
 				Rule:     "link_encoding",
 				Field:    "links",
@@ -57,7 +63,7 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 			})
 		}
 
-		if schema.Checks.Resolve || schema.Checks.Anchors {
+		if resolve || anchors {
 			res := ResolveLinkTarget(ResolveRequest{
 				BaseDir: filepath.Dir(sourceAbsPath),
 				Root:    root,
@@ -71,7 +77,7 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 				// and staying silent would put the two commands back into
 				// disagreement, so say plainly that this one is undecidable
 				// here and name the command that can decide it.
-				if schema.BasenameFallback && schema.Checks.Resolve {
+				if schema.BasenameFallback && resolve {
 					errs = append(errs, ValidationError{
 						Rule:     "link_unverifiable",
 						Field:    "links",
@@ -81,7 +87,7 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 					})
 					continue
 				}
-				if schema.Checks.Resolve {
+				if resolve {
 					msg := fmt.Sprintf("link target %q does not resolve to an existing file (case-sensitive)", link.Target)
 					if res.Suggestion != "" {
 						msg += fmt.Sprintf(" (did you mean %q?)", res.Suggestion)
@@ -97,7 +103,7 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 				}
 				continue
 			}
-			if schema.Checks.Anchors && link.Anchor != "" {
+			if anchors && link.Anchor != "" {
 				errs = append(errs, checkAnchor(link, res.Path, cache)...)
 			}
 		}

--- a/internal/rules/link_checks_test.go
+++ b/internal/rules/link_checks_test.go
@@ -26,17 +26,23 @@ func mdLink(target string) extract.Link {
 	return extract.Link{Target: target, Type: "reference", Style: extract.StyleMarkdown, Line: 1}
 }
 
-func TestCheckLinks_NilChecksIsNoop(t *testing.T) {
+// A schema with no checks block still resolves: broken-target detection is
+// always on, matching graph. Only anchors and encoding need declaring.
+func TestCheckLinks_NilChecksStillResolves(t *testing.T) {
 	schema := LinkSchema{Styles: []string{extract.StyleMarkdown}}
 	errs := CheckLinks([]extract.Link{mdLink("missing.md")}, schema, "/nonexistent/src.md", "", nil)
-	if len(errs) != 0 {
-		t.Fatalf("expected no errors without checks, got %+v", errs)
+	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
+		t.Fatalf("expected link_resolve without a checks block, got %+v", errs)
 	}
 }
 
 func TestCheckLinks_EncodingRejectsRawSpaces(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "my file.md"), "# F\n")
+	writeFile(t, filepath.Join(dir, "src.md"), "body")
+	// The target exists, so only the encoding rule may fire.
 	schema := mdChecksSchema(LinkChecks{Encoding: true})
-	errs := CheckLinks([]extract.Link{mdLink("my file.md")}, schema, "/tmp/src.md", "", nil)
+	errs := CheckLinks([]extract.Link{mdLink("my file.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_encoding" {
 		t.Fatalf("expected 1 link_encoding error, got %+v", errs)
 	}
@@ -46,7 +52,7 @@ func TestCheckLinks_ResolveExisting(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "guides", "setup.md"), "# Setup\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 	errs := CheckLinks([]extract.Link{mdLink("guides/setup.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 0 {
 		t.Fatalf("expected resolve to pass, got %+v", errs)
@@ -57,7 +63,7 @@ func TestCheckLinks_ResolveBrokenWithSuggestion(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "guides", "setup.md"), "# Setup\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 	errs := CheckLinks([]extract.Link{mdLink("guides/setpu.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
 		t.Fatalf("expected 1 link_resolve error, got %+v", errs)
@@ -71,7 +77,7 @@ func TestCheckLinks_ResolveCaseMismatchIsBroken(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "guides", "Setup.md"), "# Setup\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 	// APFS would resolve this case-insensitively; ADO/git will not.
 	errs := CheckLinks([]extract.Link{mdLink("guides/setup.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
@@ -84,7 +90,7 @@ func TestCheckLinks_ResolveDirectoryTargetNeedsReadme(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "guides", "README.md"), "# Guides\n")
 	writeFile(t, filepath.Join(dir, "empty", ".keep"), "")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 	src := filepath.Join(dir, "src.md")
 	if errs := CheckLinks([]extract.Link{mdLink("guides/")}, schema, src, dir, nil); len(errs) != 0 {
 		t.Fatalf("dir with README should resolve, got %+v", errs)
@@ -98,7 +104,7 @@ func TestCheckLinks_ResolveDecodesPercent20(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "my page.md"), "# P\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 	errs := CheckLinks([]extract.Link{mdLink("my%20page.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
 	if len(errs) != 0 {
 		t.Fatalf("%%20 target should resolve, got %+v", errs)
@@ -106,7 +112,7 @@ func TestCheckLinks_ResolveDecodesPercent20(t *testing.T) {
 }
 
 func TestCheckLinks_SkipsFilteredStyles(t *testing.T) {
-	schema := mdChecksSchema(LinkChecks{Resolve: true, Encoding: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true), Encoding: true})
 	links := []extract.Link{
 		{Target: "no such file", Type: "reference", Style: extract.StyleWikilink, Line: 1}, // filtered style
 	}
@@ -123,7 +129,7 @@ func TestCheckLinks_RootAnchoredIsChecked(t *testing.T) {
 	writeFile(t, filepath.Join(root, "docs", "Page.md"), "# Page\n")
 	writeFile(t, filepath.Join(root, "deep", "src.md"), "body")
 	src := filepath.Join(root, "deep", "src.md")
-	schema := mdChecksSchema(LinkChecks{Resolve: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 
 	if errs := CheckLinks([]extract.Link{mdLink("/docs/Page.md")}, schema, src, root, nil); len(errs) != 0 {
 		t.Errorf("existing root-anchored target should resolve, got %+v", errs)
@@ -148,7 +154,7 @@ func TestCheckLinks_WikilinkResolvesWithoutExtension(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "b.md"), "# B\n")
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
-	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+	schema := wikiChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 
 	if errs := CheckLinks([]extract.Link{wikiLink("b")}, schema, filepath.Join(dir, "t.md"), dir, nil); len(errs) != 0 {
 		t.Fatalf("[[b]] with b.md present must resolve, got %+v", errs)
@@ -159,7 +165,7 @@ func TestCheckLinks_WikilinkPathQualifiedResolves(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "sub", "README.md"), "# Sub\n")
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
-	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+	schema := wikiChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 
 	if errs := CheckLinks([]extract.Link{wikiLink("sub/README")}, schema, filepath.Join(dir, "t.md"), dir, nil); len(errs) != 0 {
 		t.Fatalf("[[sub/README]] must resolve, got %+v", errs)
@@ -169,7 +175,7 @@ func TestCheckLinks_WikilinkPathQualifiedResolves(t *testing.T) {
 func TestCheckLinks_WikilinkGenuinelyMissingIsBroken(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
-	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+	schema := wikiChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 
 	errs := CheckLinks([]extract.Link{wikiLink("nope")}, schema, filepath.Join(dir, "t.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
@@ -195,7 +201,7 @@ func TestCheckLinks_AnchorValidAndInvalid(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "master.md"), "# Title\n\n## 6. Zonas inciertas (black boxes)\n\ntext\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true, Anchors: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true), Anchors: true})
 	src := filepath.Join(dir, "src.md")
 	cache := NewHeadingCache()
 
@@ -216,7 +222,7 @@ func TestCheckLinks_AnchorNilCacheStillWorks(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "master.md"), "## Intro\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true, Anchors: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true), Anchors: true})
 	link := extract.Link{Target: "master.md", Anchor: "intro", Type: "reference", Style: extract.StyleMarkdown, Line: 1}
 	if errs := CheckLinks([]extract.Link{link}, schema, filepath.Join(dir, "src.md"), dir, nil); len(errs) != 0 {
 		t.Fatalf("nil cache should parse on the fly: %+v", errs)
@@ -227,7 +233,7 @@ func TestCheckLinks_AnchorCacheReuse(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "target.md"), "## Section1\n\n## Section2\n")
 	writeFile(t, filepath.Join(dir, "src.md"), "body")
-	schema := mdChecksSchema(LinkChecks{Resolve: true, Anchors: true})
+	schema := mdChecksSchema(LinkChecks{Resolve: boolPtr(true), Anchors: true})
 	cache := NewHeadingCache()
 	src := filepath.Join(dir, "src.md")
 
@@ -252,7 +258,7 @@ func TestCheckLinks_AnchorCacheReuse(t *testing.T) {
 func TestCheckLinks_BasenameFallbackTargetIsUnverifiable(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
-	schema := wikiChecksSchema(LinkChecks{Resolve: true})
+	schema := wikiChecksSchema(LinkChecks{Resolve: boolPtr(true)})
 	schema.BasenameFallback = true
 
 	errs := CheckLinks([]extract.Link{wikiLink("far")}, schema, filepath.Join(dir, "t.md"), dir, nil)
@@ -271,9 +277,54 @@ func TestCheckLinks_BasenameFallbackTargetIsUnverifiable(t *testing.T) {
 func TestCheckLinks_WithoutFallbackBareTargetIsBroken(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "t.md"), "body")
-	errs := CheckLinks([]extract.Link{wikiLink("far")}, wikiChecksSchema(LinkChecks{Resolve: true}),
+	errs := CheckLinks([]extract.Link{wikiLink("far")}, wikiChecksSchema(LinkChecks{Resolve: boolPtr(true)}),
 		filepath.Join(dir, "t.md"), dir, nil)
 	if len(errs) != 1 || errs[0].Rule != "link_resolve" || errs[0].Severity != "error" {
 		t.Fatalf("expected a link_resolve error, got %+v", errs)
 	}
 }
+
+// Broken-target detection is always on. graph --check has always failed on a
+// broken link with no opt-in; validate stayed silent unless links.checks
+// declared resolve, so the two commands disagreed on the one property both
+// claim to check (issue #62 sub-defect 2). validate now matches graph.
+func TestCheckLinks_ResolveIsOnByDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "src.md"), "body")
+	schema := LinkSchema{Styles: []string{extract.StyleMarkdown}} // no checks block at all
+
+	errs := CheckLinks([]extract.Link{mdLink("missing.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
+	if len(errs) != 1 || errs[0].Rule != "link_resolve" {
+		t.Fatalf("expected link_resolve without a checks block, got %+v", errs)
+	}
+}
+
+// A repository that genuinely wants dangling links opts out explicitly.
+func TestCheckLinks_ResolveCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "src.md"), "body")
+	off := false
+	schema := LinkSchema{Styles: []string{extract.StyleMarkdown}, Checks: &LinkChecks{Resolve: &off}}
+
+	if errs := CheckLinks([]extract.Link{mdLink("missing.md")}, schema, filepath.Join(dir, "src.md"), dir, nil); len(errs) != 0 {
+		t.Fatalf("resolve: false must silence the check, got %+v", errs)
+	}
+}
+
+// Anchors and encoding stay opt-in; only resolve flipped.
+func TestCheckLinks_AnchorsAndEncodingStayOptIn(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "my file.md"), "# F\n")
+	writeFile(t, filepath.Join(dir, "src.md"), "body")
+	schema := LinkSchema{Styles: []string{extract.StyleMarkdown}}
+
+	errs := CheckLinks([]extract.Link{mdLink("my file.md")}, schema, filepath.Join(dir, "src.md"), dir, nil)
+	for _, e := range errs {
+		if e.Rule == "link_encoding" {
+			t.Errorf("encoding must stay opt-in, got %+v", errs)
+		}
+	}
+}
+
+// boolPtr is a helper for the tri-state links.checks.resolve field.
+func boolPtr(b bool) *bool { return &b }

--- a/internal/rules/merge.go
+++ b/internal/rules/merge.go
@@ -199,9 +199,19 @@ func mergeLinkSchema(parent, child LinkSchema) LinkSchema {
 		result.Styles = parent.Styles
 	}
 
-	// Checks: child replaces when declared (struct semantics).
+	// Checks: child replaces when declared (struct semantics), except that an
+	// undeclared resolve inherits rather than reverting to the default.
+	//
+	// resolve is tri-state and defaults to on, so wholesale replacement would
+	// let a child declaring only `encoding: true` silently switch a parent's
+	// `resolve: false` back on. Opting out of a check has to survive being
+	// inherited, or the opt-out is worthless in any nested tree.
 	if child.Checks != nil {
-		result.Checks = child.Checks
+		merged := *child.Checks
+		if merged.Resolve == nil && parent.Checks != nil {
+			merged.Resolve = parent.Checks.Resolve
+		}
+		result.Checks = &merged
 	} else {
 		result.Checks = parent.Checks
 	}

--- a/internal/rules/merge_test.go
+++ b/internal/rules/merge_test.go
@@ -468,18 +468,52 @@ func TestMergeStemFiles_ChildValidateNilDoesNotReplaceParent(t *testing.T) {
 }
 
 func TestMergeLinkSchema_StylesAndChecksChildReplace(t *testing.T) {
-	parent := LinkSchema{Styles: []string{"wikilink"}, Checks: &LinkChecks{Resolve: true}}
+	parent := LinkSchema{Styles: []string{"wikilink"}, Checks: &LinkChecks{Resolve: boolPtr(true)}}
 	child := LinkSchema{Styles: []string{"markdown"}}
 	got := mergeLinkSchema(parent, child)
 	if len(got.Styles) != 1 || got.Styles[0] != "markdown" {
 		t.Errorf("Styles = %v, want child's [markdown]", got.Styles)
 	}
-	if got.Checks == nil || !got.Checks.Resolve {
+	if got.Checks == nil || got.Checks.Resolve == nil || !*got.Checks.Resolve {
 		t.Errorf("Checks = %+v, want inherited from parent", got.Checks)
 	}
+	// The child replaces the checks block, except that an undeclared resolve
+	// inherits: it is tri-state and defaults to on, so wholesale replacement
+	// would let a child declaring only encoding switch a parent's opt-out back
+	// on without saying so.
 	child2 := LinkSchema{Checks: &LinkChecks{Encoding: true}}
 	got2 := mergeLinkSchema(parent, child2)
-	if got2.Checks == nil || got2.Checks.Resolve || !got2.Checks.Encoding {
-		t.Errorf("Checks = %+v, want child replacement", got2.Checks)
+	if got2.Checks == nil || !got2.Checks.Encoding {
+		t.Errorf("Checks = %+v, want the child's encoding", got2.Checks)
+	}
+	if got2.Checks.Resolve == nil || !*got2.Checks.Resolve {
+		t.Errorf("Checks = %+v, want the parent's resolve inherited", got2.Checks)
+	}
+}
+
+// resolve is tri-state and defaults to on, so a child declaring only another
+// check must not silently switch a parent's opt-out back on.
+func TestMergeLinkSchema_ChildDoesNotResetParentResolveOptOut(t *testing.T) {
+	off := false
+	parent := LinkSchema{Checks: &LinkChecks{Resolve: &off}}
+	child := LinkSchema{Checks: &LinkChecks{Encoding: true}}
+
+	got := mergeLinkSchema(parent, child)
+	if got.ShouldResolve() {
+		t.Errorf("child declaring only encoding re-enabled the parent's resolve opt-out: %+v", got.Checks)
+	}
+	if !got.Checks.Encoding {
+		t.Errorf("child's own encoding declaration was lost: %+v", got.Checks)
+	}
+}
+
+// A child that explicitly turns resolve back on still wins.
+func TestMergeLinkSchema_ChildCanReenableResolve(t *testing.T) {
+	off, on := false, true
+	parent := LinkSchema{Checks: &LinkChecks{Resolve: &off}}
+	child := LinkSchema{Checks: &LinkChecks{Resolve: &on}}
+
+	if !mergeLinkSchema(parent, child).ShouldResolve() {
+		t.Error("child's explicit resolve: true must win over the parent's opt-out")
 	}
 }

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -77,10 +77,23 @@ type LinkSchema struct {
 // LinkChecks enables filesystem-backed link checks (ADO code-wiki conventions).
 // Cycles opts graph --check into treating link cycles as failures.
 type LinkChecks struct {
-	Resolve  bool `yaml:"resolve" json:"resolve,omitempty"`
-	Anchors  bool `yaml:"anchors" json:"anchors,omitempty"`
-	Encoding bool `yaml:"encoding" json:"encoding,omitempty"`
-	Cycles   bool `yaml:"cycles" json:"cycles,omitempty"`
+	// Resolve is tri-state: unset means on. Broken-target detection is the
+	// one property graph and validate both claim to check, and graph has
+	// always checked it unconditionally, so leaving it opt-in kept the two
+	// disagreeing by default. Setting it false opts out explicitly.
+	Resolve  *bool `yaml:"resolve" json:"resolve,omitempty"`
+	Anchors  bool  `yaml:"anchors" json:"anchors,omitempty"`
+	Encoding bool  `yaml:"encoding" json:"encoding,omitempty"`
+	Cycles   bool  `yaml:"cycles" json:"cycles,omitempty"`
+}
+
+// ShouldResolve reports whether broken-target detection runs. It is on unless
+// the schema explicitly turns it off, and on when no checks block exists.
+func (ls LinkSchema) ShouldResolve() bool {
+	if ls.Checks == nil || ls.Checks.Resolve == nil {
+		return true
+	}
+	return *ls.Checks.Resolve
 }
 
 // knownCheckKeys lists the keys LinkChecks consumes; keep in sync with its

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -659,7 +659,7 @@ links:
 	if len(ls.Styles) != 1 || ls.Styles[0] != "markdown" {
 		t.Errorf("Styles = %v, want [markdown]", ls.Styles)
 	}
-	if ls.Checks == nil || !ls.Checks.Resolve || !ls.Checks.Anchors || !ls.Checks.Encoding {
+	if ls.Checks == nil || ls.Checks.Resolve == nil || !*ls.Checks.Resolve || !ls.Checks.Anchors || !ls.Checks.Encoding {
 		t.Errorf("Checks = %+v, want all true", ls.Checks)
 	}
 	if ls.IsEmpty() {


### PR DESCRIPTION
## What

`graph --check` has **always** failed on a broken link with no opt-in. `validate` stayed silent
unless `links.checks` declared `resolve`. So the two commands disagreed on the one property both
claim to check — *does this target exist?*

```console
$ rootline validate --all nochecks/    # before: silent
a.md  yes
exit=0
$ rootline graph --check nochecks/     # before: red
Broken links: 1
  a.md:1 → nope (reference)
exit=1
```

A user who trusted `validate` shipped broken links; a user who wired `graph --check` into CI got a
red build `validate` could not explain and `fix` could not repair.

## How

`links.checks.resolve` becomes tri-state (`*bool`) and defaults to **on**, so `validate` matches
`graph` out of the box. A repository that genuinely wants dangling links opts out:

```yaml
links:
  checks:
    resolve: false
```

`anchors` and `encoding` stay opt-in — only `resolve` flipped.

## The merge trap this exposed

Because `resolve` now defaults to on, replacing the `Checks` block wholesale would let a child
declaring only `encoding: true` **silently switch a parent's `resolve: false` back on** — its own
`Resolve` is nil, and nil now means "on".

The reliability lens caught this; I had flagged it as the highest-value thing to check and it was
real. An undeclared `resolve` now inherits from the parent while the child still replaces
everything else. An opt-out that does not survive inheritance is worthless in any nested tree.

Pinned by tests in both directions: a child declaring only `encoding` keeps the parent's opt-out,
and a child declaring `resolve: true` explicitly still wins.

## Evidence — the two commands now agree

```console
$ rootline validate --all nochecks/
a.md  no   link target "nope" does not resolve to an existing file (case-sensitive)
b.md  yes

$ rootline graph --check nochecks/
Broken links: 1
  a.md:1 → nope (reference)
```

## Parity matrix rows changed

| Feature | `validate` before | `validate` after | `graph --check` |
|---|---|---|---|
| Broken-target detection | **opt-in only** | always on, opt-out via `resolve: false` | always on (unchanged) |

Closes **sub-defect 2**.

## Semver

**`feat!`** — the default flips.

BREAKING CHANGE: repositories with broken links and no `links.checks` block now fail `validate`.
Set `links.checks.resolve: false` to keep the previous silence. Note `graph --check` already
failed on these, so this makes `validate` agree with a gate that was already red rather than
introducing a new class of failure.

## Testing

Always-on default, explicit opt-out, anchors/encoding staying opt-in, and both merge-inheritance
directions. Two existing tests were inverted because they encoded the old opt-in contract —
`NilChecksIsNoop` became `NilChecksStillResolves`, and the encoding test now creates its target so
only the encoding rule fires.

`just check`, `just test` (14 packages), `just coverage-check` green.

## Size and stacking

209 changed lines. Based on #97, **not** master.

Refs #62
