### PR TITLE
feat(extract): resolve source: directives through a single ResolveBodyValue

### DIFF
--- a/internal/derive/enrich.go
+++ b/internal/derive/enrich.go
@@ -3,7 +3,6 @@ package derive
 import (
 	"context"
 	"path/filepath"
-	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
 	"github.com/pablontiv/rootline/internal/rules"
@@ -44,20 +43,7 @@ func EnrichBuiltins(ctx context.Context, records []*extract.Record, root string,
 					continue
 				}
 
-				var value string
-				if field.Extract == "body.h1" {
-					value = extract.ExtractBodyH1(rec.Body)
-				} else if strings.HasPrefix(field.Extract, "body.section[") {
-					// Parse body.section["## Heading"] format
-					start := strings.Index(field.Extract, "[\"")
-					end := strings.LastIndex(field.Extract, "\"]")
-					if start >= 0 && end > start {
-						heading := field.Extract[start+2 : end]
-						value = extract.ExtractBodySection(rec.Body, heading)
-					}
-				}
-
-				if value != "" {
+				if value, ok := extract.ResolveBodyValue(rec, field.Extract); ok {
 					rec.Derived[name] = value
 				}
 			}

--- a/internal/extract/body.go
+++ b/internal/extract/body.go
@@ -250,3 +250,51 @@ func ExtractBodySection(body string, heading string) string {
 	}
 	return ""
 }
+
+// ResolveBodyValue resolves a `source:` directive against a record's body.
+// It deliberately never consults frontmatter: precedence between an explicit
+// frontmatter value and an extracted one belongs to the caller, and the derive
+// pipeline needs the extracted value even when frontmatter also carries the key.
+//
+// Supported directives:
+//   - body.h1                       the text of the first H1 heading
+//   - body.section["## Heading"]    the content under that heading
+//
+// The second form prefers record.Sections, which the AST extractors populate
+// with keys in the same "## Heading" shape the directive uses. When Sections is
+// nil — the non-AST registries leave it so — it falls back to parsing the body.
+//
+// Returns ok=false for an unknown directive or an empty result.
+func ResolveBodyValue(record *Record, directive string) (string, bool) {
+	if record == nil {
+		return "", false
+	}
+
+	// body.h1 must yield the heading TEXT, whereas record.Sections is keyed by
+	// "# Title" and stores the section CONTENT. The map cannot answer this
+	// directive, and ranging over it to recover the text would be
+	// non-deterministic: Go randomises map iteration order, so a document with
+	// more than one H1 would resolve to an arbitrary heading. Parse the body,
+	// which returns the first H1.
+	if directive == "body.h1" {
+		value := ExtractBodyH1(record.Body)
+		return value, value != ""
+	}
+
+	if strings.HasPrefix(directive, "body.section[") {
+		start := strings.Index(directive, "[\"")
+		end := strings.LastIndex(directive, "\"]")
+		if start < 0 || end <= start {
+			return "", false
+		}
+		heading := directive[start+2 : end]
+
+		if content, ok := record.Sections[heading]; ok && content != "" {
+			return content, true
+		}
+		value := ExtractBodySection(record.Body, heading)
+		return value, value != ""
+	}
+
+	return "", false
+}

--- a/internal/extract/body_test.go
+++ b/internal/extract/body_test.go
@@ -349,3 +349,128 @@ func TestExtractBodySection(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveBodyValue(t *testing.T) {
+	const sectionBody = "# Title\n\n## Notes\n\nSection content\n\n## End\n\nAfter"
+
+	tests := []struct {
+		name      string
+		directive string
+		record    *Record
+		wantValue string
+		wantOK    bool
+	}{
+		{
+			// Precedence between frontmatter and an extracted value is the
+			// caller's job; ResolveBodyValue only ever reads the body.
+			name:      "frontmatter is never consulted",
+			directive: "body.h1",
+			record: &Record{
+				Frontmatter: map[string]any{"title": "Frontmatter Title"},
+				Body:        "# Body Title\n\nContent",
+			},
+			wantValue: "Body Title", wantOK: true,
+		},
+		{
+			// Sections is keyed "# My Title" and holds the CONTENT, but body.h1
+			// must return the heading TEXT, so the map cannot serve it.
+			name:      "h1 ignores the sections map and reads the body",
+			directive: "body.h1",
+			record: &Record{
+				Body:     "# My Title\n\nContent here",
+				Sections: map[string]string{"# My Title": "Content here"},
+			},
+			wantValue: "My Title", wantOK: true,
+		},
+		{
+			name:      "h1 resolves when sections is nil",
+			directive: "body.h1",
+			record:    &Record{Body: "# My Title\n\nContent here"},
+			wantValue: "My Title", wantOK: true,
+		},
+		{
+			name:      "h1 absent",
+			directive: "body.h1",
+			record:    &Record{Body: "No heading here\n\nJust content"},
+			wantOK:    false,
+		},
+		{
+			name:      "section resolves through the sections map",
+			directive: `body.section["## Notes"]`,
+			record: &Record{
+				Body:     sectionBody,
+				Sections: map[string]string{"## Notes": "Section content", "## End": "After"},
+			},
+			wantValue: "Section content", wantOK: true,
+		},
+		{
+			name:      "section falls back to the body when sections is nil",
+			directive: `body.section["## Notes"]`,
+			record:    &Record{Body: sectionBody},
+			wantValue: "Section content", wantOK: true,
+		},
+		{
+			name:      "section absent",
+			directive: `body.section["## Missing"]`,
+			record:    &Record{Body: "# Title\n\n## First\n\nContent"},
+			wantOK:    false,
+		},
+		{
+			name:      "section present but empty does not resolve",
+			directive: `body.section["## Notes"]`,
+			record: &Record{
+				Body:     "# Title\n\n## Notes\n\n## End\n\nContent",
+				Sections: map[string]string{"## Notes": "", "## End": "Content"},
+			},
+			wantOK: false,
+		},
+		{
+			name:      "unknown directive",
+			directive: "body.unknown",
+			record:    &Record{Body: "# Title\n\nContent"},
+			wantOK:    false,
+		},
+		{
+			name:      "malformed section directive",
+			directive: "body.section[oops]",
+			record:    &Record{Body: "# Title\n\n## Notes\n\nContent"},
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, ok := ResolveBodyValue(tt.record, tt.directive)
+			if ok != tt.wantOK || val != tt.wantValue {
+				t.Errorf("ResolveBodyValue(%q) = %q, %v; want %q, %v",
+					tt.directive, val, ok, tt.wantValue, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestResolveBodyValue_H1IsDeterministic guards the reason body.h1 bypasses
+// record.Sections: recovering the heading text by ranging over that map
+// returned an arbitrary heading, because Go randomises map iteration order.
+// The first H1 in the body is the contract, on every run.
+func TestResolveBodyValue_H1IsDeterministic(t *testing.T) {
+	record := &Record{
+		Body: "# First Title\n\nContent\n\n# Second Title\n\nMore",
+		Sections: map[string]string{
+			"# First Title":  "Content",
+			"# Second Title": "More",
+		},
+	}
+	for i := range 50 {
+		val, ok := ResolveBodyValue(record, "body.h1")
+		if !ok || val != "First Title" {
+			t.Fatalf("iteration %d: got %q, %v; want 'First Title', true", i, val, ok)
+		}
+	}
+}
+
+func TestResolveBodyValue_NilRecord(t *testing.T) {
+	if val, ok := ResolveBodyValue(nil, "body.h1"); ok || val != "" {
+		t.Errorf("ResolveBodyValue(nil) = %q, %v; want '', false", val, ok)
+	}
+}


### PR DESCRIPTION
## What

Add `ResolveBodyValue(record *Record, directive string) (string, bool)` to `internal/extract` —
one entry point for resolving a `source:` directive against a record's body — and switch
`EnrichBuiltins` to it instead of its own inline dispatch.

## Related issue

Groundwork for #77. Closing keyword deliberately omitted — this is PR 2 of 3.

## Why

Validation needs the same `source:` resolution the derive pipeline performs, and it cannot reach
`internal/derive` (see PR 1 for the import-cycle argument). Two copies of the dispatch would drift.
PR 3 consumes this function; `EnrichBuiltins` consumes it here, so it ships with a real caller
rather than as dead code.

## How

**`body.section["## X"]`** prefers `record.Sections`, then falls back to parsing `record.Body`.
The fast path works because the map keys are built at `internal/extract/extract.go:97` as
`strings.Repeat("#", level) + " " + heading` — byte-identical to the directive argument, so no key
translation is needed. The fallback is not optional: the non-AST registries leave `Sections` nil,
and `cmd/rootline/fix.go:80`, `fix.go:166`, `internal/fix/repair.go:75`, `explain.go:50` and
`schema.go:462` all use `extract.NewRegistry()`.

**`body.h1` always parses the body, deliberately bypassing `record.Sections`.** Two reasons, and
the second is a bug that was caught during review of the first draft:

1. Wrong value in kind. `Sections` is keyed `"# Title"` and stores the section *content*, while
   `body.h1` must return the heading *text*.
2. **Non-determinism.** The first draft recovered the text by ranging over `Sections` looking for
   a `"# "` prefix. Go randomises map iteration order, so a document with more than one H1
   resolved to an arbitrary heading, differing between runs. That is also a regression against
   `derive`'s previous first-H1 behaviour. `TestResolveBodyValue_H1IsDeterministic` pins the
   contract across 50 iterations on a record whose `Sections` holds two H1 entries.

**`ResolveBodyValue` never reads frontmatter.** Precedence between an explicit frontmatter value
and an extracted one belongs to the caller — and it has to, because `EnrichBuiltins` must keep
writing the *extracted* value into `rec.Derived` even when frontmatter carries the same key.
Folding frontmatter into this function would silently change what `query`, `tree` and `stats` see.

### One behaviour change, deliberate

This is **not** pure parity for AST-backed records, and the PR does not claim it is.

Where a fenced code block contains a lookalike heading, the old line-scanning parser matched the
fenced line. `record.Sections` comes from the goldmark AST, which excludes headings inside code
blocks. For this body:

````markdown
# Doc

```
## Notes
fake content inside a fence
```

## Notes

real content
````

the old parser yields `"fake content inside a fence\n```\nreal content"`; the new path yields
`"real content"`. Affected callers are the ones pairing `NewASTRegistry` with `EnrichBuiltins`:
`validate --all` and `schema propose`. This is a correctness improvement, recorded as a WARNING
finding on the review receipt rather than glossed as a no-op.

The write guard is otherwise exactly preserved: the old code wrote `rec.Derived[name]` only under
`if value != ""`, and `ResolveBodyValue` returns `ok` as precisely `value != ""` on every branch,
so it writes on the same inputs. Unknown directives still return `ok=false` and are skipped.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`just check` — 0 lint issues)
- [x] `just coverage-check` green (89.3% total)
- [x] Deliberately left unlinked — intermediate PR of a chain

---
Stack: PR 1 (`fix/i77-1-relocate-body-helpers`) → **PR 2/3** → PR 3 (`fix/i77-3-required-body-source`, closes #77)