### PR TITLE
feat(cli)!: apply scope.match and .stemignore to every command

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -114,6 +114,8 @@ links:
 
 **Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. External schemes, images, and pure fragments are not checked.
 
+**One record set**: `validate` (both modes), `graph`, `query` and `fix --all` apply the same `scope.match` and `.stemignore` filters. `validate <file>` on an excluded file reports a `skipped` warning instead of validating it, so the pre-commit hook and CI agree.
+
 **`resolve` is always on**: broken-target detection needs no declaration (it matches `graph --check`, which never had an opt-in). Set `links.checks.resolve: false` to opt out. `anchors` and `encoding` remain opt-in.
 
 **Basename fallback**: `links.basename_fallback` (default off) lets a path-less target match a uniquely-named record anywhere — the wiki convention. It needs a full-tree index, which `graph` and `query` traversal have and `validate` does not, so with it ON `validate` reports `link_unverifiable` (warning) instead of guessing or staying silent. Off is what makes every command agree.

--- a/cmd/rootline/analyze.go
+++ b/cmd/rootline/analyze.go
@@ -61,13 +61,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 
 	// Index and extract records.
 	reg := extract.NewRegistry()
-	resolver := func(dir string) (*rules.StemFile, error) {
-		entries, err := rules.WalkUp(dir)
-		if err != nil || len(entries) == 0 {
-			return nil, err
-		}
-		return rules.MergeStemFiles(entries), nil
-	}
+	resolver := stemScopeResolver()
 
 	// Bootstrap scan: this command derives a schema from documents that may
 	// not have one yet, so a missing schema must not stop it.

--- a/cmd/rootline/fix.go
+++ b/cmd/rootline/fix.go
@@ -174,13 +174,7 @@ func runFixAll(ctx context.Context, cmd *cobra.Command, args []string) error {
 	}
 
 	reg := extract.NewRegistry()
-	resolver := func(dir string) (*rules.StemFile, error) {
-		entries, err := rules.WalkUp(dir)
-		if err != nil || len(entries) == 0 {
-			return nil, err
-		}
-		return rules.MergeStemFiles(entries), nil
-	}
+	resolver := stemScopeResolver()
 
 	records, err := index.Scan(ctx, root, reg, index.WithScopeResolver(resolver))
 	if err != nil {

--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pablontiv/rootline/internal/derive"
 	"github.com/pablontiv/rootline/internal/extract"
 	"github.com/pablontiv/rootline/internal/graph"
-	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/rules"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +61,7 @@ func runGraph(cmd *cobra.Command, args []string) error {
 	}
 
 	reg := extract.NewRegistry()
-	records, err := index.Scan(ctx, absRoot, reg)
+	records, err := scanGoverned(ctx, absRoot, reg)
 	if err != nil {
 		return fmt.Errorf("scanning %s: %w", scanRoot, err)
 	}

--- a/cmd/rootline/query.go
+++ b/cmd/rootline/query.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pablontiv/rootline/internal/derive"
 	"github.com/pablontiv/rootline/internal/extract"
 	"github.com/pablontiv/rootline/internal/graph"
-	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/query"
 	"github.com/pablontiv/rootline/internal/rules"
 	"github.com/spf13/cobra"
@@ -109,7 +108,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		reg := extract.NewRegistry()
-		records, err = index.Scan(ctx, absRoot, reg)
+		records, err = scanGoverned(ctx, absRoot, reg)
 		if err != nil {
 			return fmt.Errorf("scanning %s: %w", scanRoot, err)
 		}
@@ -225,7 +224,7 @@ func scanForTraversal(ctx context.Context, absQueryRoot string) ([]*extract.Reco
 	}
 
 	reg := extract.NewRegistry()
-	all, err := index.Scan(ctx, absGraphRoot, reg)
+	all, err := scanGoverned(ctx, absGraphRoot, reg)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("scanning graph root %s: %w", absGraphRoot, err)
 	}

--- a/cmd/rootline/scope.go
+++ b/cmd/rootline/scope.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+
+	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/index"
+	"github.com/pablontiv/rootline/internal/rules"
+)
+
+// stemScopeResolver returns the schema resolver every scanning command passes
+// to index.Scan so they all see the same record set.
+//
+// validate --all and fix --all already filtered by scope.match while graph and
+// query did not, so a file the schema explicitly declared out of governance
+// still became a graph node and could fail graph --check (issue #62
+// sub-defect 5). The closure was duplicated at every call site, which is how
+// two of them ended up without it.
+func stemScopeResolver() func(dir string) (*rules.StemFile, error) {
+	return func(dir string) (*rules.StemFile, error) {
+		entries, err := rules.WalkUp(dir)
+		if err != nil || len(entries) == 0 {
+			return nil, err
+		}
+		return rules.MergeStemFiles(entries), nil
+	}
+}
+
+// excludedFromGovernance reports why a path is outside the governed record
+// set, or "" when it is governed. It mirrors the two filters index.Scan
+// applies: .stemignore and scope.match.
+func excludedFromGovernance(absPath string) string {
+	dir := filepath.Dir(absPath)
+	entries, err := rules.WalkUp(dir)
+	if err != nil || len(entries) == 0 {
+		return "" // no schema governs it; ordinary validation reports that
+	}
+	root := filepath.Dir(entries[0].Path)
+	if index.IsIgnored(root, absPath) {
+		return "skipped: excluded by .stemignore"
+	}
+	if !index.MatchesScope(absPath, rules.MergeStemFiles(entries)) {
+		return "skipped: out of scope for this .stem (scope.match)"
+	}
+	return ""
+}
+
+// scanGoverned scans root with scope filtering, falling back to an ungoverned
+// scan only when nothing under root resolved a schema at all.
+//
+// The retry is deliberately narrower than passing AllowUngoverned outright: as
+// soon as one record IS governed the first scan keeps its scope filtering, so
+// a file the schema excluded stays excluded. It exists because graph and query
+// describe a tree that may carry no schema, while still honoring scope.match
+// on trees that do.
+func scanGoverned(ctx context.Context, root string, reg *extract.Registry) ([]*extract.Record, error) {
+	resolver := stemScopeResolver()
+	records, err := index.Scan(ctx, root, reg, index.WithScopeResolver(resolver))
+	if errors.Is(err, rules.ErrNoSchemaFound) {
+		return index.Scan(ctx, root, reg, index.WithScopeResolver(resolver), index.AllowUngoverned())
+	}
+	return records, err
+}

--- a/cmd/rootline/scope_test.go
+++ b/cmd/rootline/scope_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeScopeFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		".stem":    "version: 2\nroot: true\nscope:\n  match: \"T*.md\"\nschema:\n  titulo:\n    type: string\n",
+		"T001.md":  "---\ntitulo: T1\n---\n\nSee [[zzz-missing]].\n",
+		"other.md": "---\nnope: x\n---\n\nSee [[qqq-missing]].\n",
+	}
+	for rel, content := range files {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// validate --all honored scope.match while graph did not, so a file the schema
+// declared out of governance still became a node and could fail graph --check
+// (issue #62 sub-defect 5).
+func TestGraphHonorsScopeMatch(t *testing.T) {
+	dir := writeScopeFixture(t)
+	out, _ := runCmd(t, "graph", dir, "--check")
+	if strings.Contains(out, "qqq-missing") {
+		t.Errorf("out-of-scope other.md contributed an edge to graph:\n%s", out)
+	}
+	if !strings.Contains(out, "zzz-missing") {
+		t.Errorf("in-scope T001.md should still report its broken link:\n%s", out)
+	}
+}
+
+// query scanned without scope filtering too.
+func TestQueryHonorsScopeMatch(t *testing.T) {
+	dir := writeScopeFixture(t)
+	out, err := runCmd(t, "query", dir, "--select", "path")
+	if err != nil {
+		t.Fatalf("query failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "other.md") {
+		t.Errorf("out-of-scope other.md appeared in query results:\n%s", out)
+	}
+}
+
+// validate --all skipped an out-of-scope file while validate <file> validated
+// it anyway, so the pre-commit hook and CI enforced different rules on the
+// same file (issue #62 sub-defect 11). Naming a file explicitly must not
+// smuggle it back into governance — but the skip has to be visible, not
+// silent, or the user cannot tell why nothing happened.
+func TestValidateNamedFileHonorsScope(t *testing.T) {
+	dir := writeScopeFixture(t)
+	out, err := runCmd(t, "validate", filepath.Join(dir, "other.md"))
+	if err != nil {
+		t.Errorf("out-of-scope file should not fail validation, got %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "out of scope") && !strings.Contains(out, "skipped") {
+		t.Errorf("skip must be reported, not silent:\n%s", out)
+	}
+	if strings.Contains(out, "required field") {
+		t.Errorf("out-of-scope file was validated anyway:\n%s", out)
+	}
+}
+
+func TestValidateNamedFileHonorsStemignore(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  titulo:\n    type: string\n    required: true\n")
+	write(".stemignore", "skipme.md\n")
+	write("skipme.md", "---\nzzz: x\n---\n\n# S\n")
+
+	out, err := runCmd(t, "validate", filepath.Join(dir, "skipme.md"))
+	if err != nil {
+		t.Errorf("ignored file should not fail validation, got %v\n%s", err, out)
+	}
+	if strings.Contains(out, "required field") {
+		t.Errorf("ignored file was validated anyway:\n%s", out)
+	}
+}

--- a/cmd/rootline/tree.go
+++ b/cmd/rootline/tree.go
@@ -95,13 +95,7 @@ func runTree(cmd *cobra.Command, args []string) error {
 	}
 
 	reg := extract.NewRegistry()
-	resolver := func(dir string) (*rules.StemFile, error) {
-		entries, err := rules.WalkUp(dir)
-		if err != nil || len(entries) == 0 {
-			return nil, err
-		}
-		return rules.MergeStemFiles(entries), nil
-	}
+	resolver := stemScopeResolver()
 	records, err := index.Scan(ctx, absRoot, reg, index.WithScopeResolver(resolver))
 	if errors.Is(err, rules.ErrNoSchemaFound) {
 		// Nothing under absRoot resolved a schema. There is no scope to filter

--- a/cmd/rootline/validate.go
+++ b/cmd/rootline/validate.go
@@ -80,6 +80,21 @@ func runValidateFiles(cmd *cobra.Command, files []string) error {
 			return fmt.Errorf("%s is a directory; use 'rootline validate --all %s'", file, file)
 		}
 
+		// Honor the same exclusions `--all` applies. Naming a file explicitly
+		// must not smuggle it back into governance, or the pre-commit hook
+		// and CI enforce different rules on the same file. The skip is
+		// reported rather than silent so the user can tell why.
+		if reason := excludedFromGovernance(absPath); reason != "" {
+			results = append(results, rules.NewValidationResult(file, []rules.ValidationError{{
+				Rule:     "skipped",
+				Field:    "",
+				Message:  reason,
+				Source:   "scope",
+				Severity: "warn",
+			}}))
+			continue
+		}
+
 		// Check extractor exists
 		ext := reg.ForFile(absPath, "")
 		if ext == nil {
@@ -153,13 +168,7 @@ func runValidateAll(cmd *cobra.Command, args []string) error {
 
 	// Phase 2: Document validation.
 	reg := extract.NewASTRegistry()
-	resolver := func(dir string) (*rules.StemFile, error) {
-		entries, err := rules.WalkUp(dir)
-		if err != nil || len(entries) == 0 {
-			return nil, err
-		}
-		return rules.MergeStemFiles(entries), nil
-	}
+	resolver := stemScopeResolver()
 
 	records, err := index.Scan(ctx, root, reg, index.WithScopeResolver(resolver))
 	if err != nil {

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -80,6 +80,10 @@ rootline graph docs/epics/ --where 'estado == "Specified"' --check  # Check only
 
 ### With --check
 
+`graph` and `query` scan the same record set `validate --all` does: `scope.match` and
+`.stemignore` both apply. A file the schema declares out of governance is not a node, contributes
+no edges, and cannot fail `--check`. A tree carrying no schema at all is still graphed.
+
 ### How a link target resolves
 
 `graph` resolves links through the same engine `validate` uses, so the two agree on which links

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -86,6 +86,21 @@ symlink that stays inside the root still resolves normally. Link targets are doc
 text, and resolution would otherwise report on — and with `anchors` enabled, read — files
 outside the tree being governed.
 
+### Naming a file does not bypass its exclusions
+
+`validate <file>` and `--staged` apply the same `scope.match` and `.stemignore` filters
+`validate --all` applies. Naming a file explicitly cannot smuggle it back into governance —
+otherwise the pre-commit hook and CI enforce different rules on the same file, and a record the
+schema declares out of scope blocks the commit while passing CI.
+
+The skip is reported rather than silent, as a warning, so a run that checks nothing says why:
+
+```console
+$ rootline validate scope/other.md -o json
+{"valid":true,"errors":[],"warnings":[{"rule":"skipped",
+ "message":"skipped: out of scope for this .stem (scope.match)","severity":"warn"}]}
+```
+
 ### Broken-target detection is always on
 
 `links.checks.resolve` needs no opt-in. `graph --check` has always failed on a broken link with

--- a/internal/index/scope.go
+++ b/internal/index/scope.go
@@ -28,3 +28,25 @@ func MatchesScope(filePath string, effectiveStem *rules.StemFile) bool {
 	}
 	return matched
 }
+
+// IsIgnored reports whether absPath is excluded by a .stemignore anywhere
+// between root and the file's own directory.
+//
+// Scan applies .stemignore while walking, but a command handed an explicit
+// file never walks. Without this, `validate <file>` checked a file that
+// `validate --all` skipped, so the pre-commit hook and CI enforced different
+// rules on the same file.
+func IsIgnored(root, absPath string) bool {
+	var stack []ignoreEntry
+	dir := filepath.Dir(absPath)
+	for {
+		if patterns, err := parseStemignore(filepath.Join(dir, ".stemignore")); err == nil && len(patterns) > 0 {
+			stack = append(stack, ignoreEntry{dir: dir, patterns: patterns})
+		}
+		if dir == root || dir == filepath.Dir(dir) {
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
+	return isIgnored(absPath, stack)
+}

--- a/internal/index/scope_test.go
+++ b/internal/index/scope_test.go
@@ -217,3 +217,31 @@ func TestScan_ScopeExcludesBeforeExtraction(t *testing.T) {
 		t.Errorf("title = %v, want Good", records[0].Frontmatter["title"])
 	}
 }
+
+func TestIsIgnored_AppliesRootAndNestedPatterns(t *testing.T) {
+	root := setupScanTree(t, map[string]string{
+		".stemignore":        "*.tmp\n",
+		"root.tmp":           "",
+		"nested/.stemignore": "draft.md\n",
+		"nested/draft.md":    "",
+		"nested/keep.md":     "",
+	})
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "root.tmp", want: true},
+		{path: "nested/draft.md", want: true},
+		{path: "nested/keep.md", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := IsIgnored(root, filepath.Join(root, tt.path))
+			if got != tt.want {
+				t.Fatalf("IsIgnored(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rules/link_checks.go
+++ b/internal/rules/link_checks.go
@@ -79,11 +79,14 @@ func CheckLinks(links []extract.Link, schema LinkSchema, sourceAbsPath, root str
 				// here and name the command that can decide it.
 				if schema.BasenameFallback && resolve {
 					errs = append(errs, ValidationError{
-						Rule:     "link_unverifiable",
-						Field:    "links",
-						Message:  fmt.Sprintf("link target %q cannot be verified: links.basename_fallback matches against every record, which this command does not scan (check it with 'rootline graph --check')", link.Target),
-						Source:   "links.checks",
-						Severity: "warning",
+						Rule:    "link_unverifiable",
+						Field:   "links",
+						Message: fmt.Sprintf("link target %q cannot be verified: links.basename_fallback matches against every record, which this command does not scan (check it with 'rootline graph --check')", link.Target),
+						Source:  "links.checks",
+						// "warn" is the severity NewValidationResult routes to
+						// warnings; anything else counts as an error and would
+						// fail the run for a link that may well be fine.
+						Severity: "warn",
 					})
 					continue
 				}

--- a/internal/rules/link_checks_test.go
+++ b/internal/rules/link_checks_test.go
@@ -268,8 +268,14 @@ func TestCheckLinks_BasenameFallbackTargetIsUnverifiable(t *testing.T) {
 	if errs[0].Rule != "link_unverifiable" {
 		t.Errorf("Rule = %q, want link_unverifiable", errs[0].Rule)
 	}
-	if errs[0].Severity != "warning" {
-		t.Errorf("Severity = %q, want warning — the link may well resolve", errs[0].Severity)
+	if errs[0].Severity != "warn" {
+		t.Errorf("Severity = %q, want warn — the link may well resolve", errs[0].Severity)
+	}
+	// Severity is not cosmetic: only "warn" is routed to Warnings, so any
+	// other value would make the record invalid.
+	if r := NewValidationResult("t.md", errs); !r.Valid || len(r.Warnings) != 1 {
+		t.Errorf("unverifiable link must not invalidate the record: valid=%v errors=%d warnings=%d",
+			r.Valid, len(r.Errors), len(r.Warnings))
 	}
 }
 


### PR DESCRIPTION
## What

`graph` and `query` scanned **without** scope filtering while `validate --all` and `fix --all`
scanned **with** it. So a file the schema explicitly declared out of governance still became a
graph node, contributed edges, and could fail `graph --check`:

```console
$ rootline graph --check scope/      # before — .stem says scope.match "T*.md"
Broken links: 2
  T001.md:1 → zzz-missing (reference)
  other.md:1 → qqq-missing (reference)   <-- other.md is out of scope
```

`validate <file>` ignored both filters too, so the pre-commit hook and CI enforced different rules
on the same file — a record the schema declared out of scope **blocked the commit and passed CI**.

## How

`graph` and `query` scan through `scanGoverned`, which applies scope filtering and falls back to
an ungoverned scan **only when nothing under the root resolved a schema at all**. That retry is
the same narrow one `tree` already used: a partially governed tree keeps its filtering, while a
schemaless tree is still graphed (preserving #76).

`validate <file>` and `--staged` apply the same exclusions `--all` applies. Naming a file
explicitly cannot smuggle it back into governance — but the skip is **reported**, not silent:

```console
$ rootline validate scope/other.md -o json
{"valid":true,"errors":[],"warnings":[{"rule":"skipped",
 "message":"skipped: out of scope for this .stem (scope.match)","severity":"warn"}]}
exit=0
```

The resolver closure was duplicated at **six** call sites — which is precisely how two of them
ended up without it. It is now one helper.

## Evidence

```console
$ rootline graph --check scope/            # after
Broken links: 1
  T001.md:1 → zzz-missing (reference)      <-- out-of-scope other.md is gone

$ rootline validate ign/skipme.md          # after: .stemignore honored
{"valid":true,"warnings":[{"rule":"skipped","message":"skipped: excluded by .stemignore"}]}
```

## MERGE DEPENDENCY: #94 must not ship without this PR

**#94 is incorrect on its own and must not be merged unless this PR merges with it or before it.**

`link_unverifiable`, introduced in #94, uses severity `"warning"` there — but
`NewValidationResult` routes only `"warn"` to warnings, so as shipped in #94's branch it lands in
**errors** and invalidates records it was meant to merely flag. #94's own description claims the
opposite. This PR carries the fix.

Recorded here as well as on #94 so the dependency is visible from both sides. The alternative —
folding the fix back into #94 — was considered and rejected: it would rewrite a branch that
already carries an approved review receipt and force a rebase of four stacked children, each then
needing re-verification, for no gain while merges are batched anyway.

## A correction to an earlier PR in this stack

`link_unverifiable` (added in #94) used severity `"warning"`, but `NewValidationResult` routes only
`"warn"` to warnings — so it was landing in **errors** and invalidating records it was meant to
merely flag. That contradicts what #94's body claims about it not failing the build.

I found this while wiring the `skipped` warning and hit the same trap. Corrected here and pinned
by a test that asserts the *routing*, not just the string. Flagging it explicitly because #94's
description is wrong until this lands — if you'd rather it be folded back into #94, say so and
I'll rebase the stack.

## Parity matrix rows changed

| Feature | `validate <file>` | `validate --all` | `graph` / `query` |
|---|---|---|---|
| Honors `scope.match` | **no → yes (skipped)** | yes | **no → yes** |
| Honors `.stemignore` | **no → yes (skipped)** | yes | yes |

Closes **sub-defects 5 and 11**.

## Semver

**`feat!`**.

BREAKING CHANGE: `graph` and `query` no longer include records excluded by `scope.match` or
`.stemignore`, and `validate` on such a file reports it skipped instead of validating it.

## Review

High risk — canonical 4R. All four lenses returned zero findings. The risk lens specifically
checked the false-green concern: `index.AllowUngoverned` warns that verdict-returning commands
must not use it, and `graph --check` is one, so I asked it to confirm the narrow retry cannot let
`graph --check` pass over zero records that should have been checked. It confirmed it cannot.

## Size and stacking

284 changed lines. Based on #98, **not** master.

Refs #62

