### PR TITLE
feat(cli)!: resolve typed link rules and cycle hardening per record

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -114,6 +114,8 @@ links:
 
 **Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. External schemes, images, and pure fragments are not checked.
 
+**Per-record schema**: typed link rules and `links.checks.cycles` resolve per record, not from the invocation root, so a rule or cycle opt-in declared in a subdirectory still applies when the command runs from the parent. `query --select links` honors `links.styles` with or without a traversal flag, and `query` traversal applies typed-rule filtering exactly as `graph` does.
+
 **One record set**: `validate` (both modes), `graph`, `query` and `fix --all` apply the same `scope.match` and `.stemignore` filters. `validate <file>` on an excluded file reports a `skipped` warning instead of validating it, so the pre-commit hook and CI agree.
 
 **`resolve` is always on**: broken-target detection needs no declaration (it matches `graph --check`, which never had an opt-in). Set `links.checks.resolve: false` to opt out. `anchors` and `encoding` remain opt-in.

--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -87,28 +87,22 @@ func runGraph(cmd *cobra.Command, args []string) error {
 
 	rules.PrepareLinks(records, absRoot)
 
-	// Load .stem schema: filter links and read the cycle-failure opt-in.
+	// Typed-rule filtering and the cycle-failure opt-in both resolve per
+	// record. Reading them from the chain above the scan root meant hardening
+	// declared in a subdirectory evaporated the moment CI ran the command from
+	// the repository root — the most likely invocation.
 	//
-	// A missing .stem is not a missing graph. The schema only decides which
-	// link styles are governed and whether cycles fail a check, so without one
-	// the links stay unfiltered and cycles stay informational — the nil stem
-	// below already expresses exactly that.
-	failCycles := false
-	entries, err := rules.WalkUp(absRoot)
-	if rules.IsRealSchemaError(err) {
-		return fmt.Errorf("discovering schema for link filtering: %w", err)
-	}
-	stem := rules.MergeStemFiles(entries)
-	if stem != nil {
-		filterLinksBySchema(records, stem.Links)
-		failCycles = stem.Links.Checks != nil && stem.Links.Checks.Cycles
-	}
-	if cmd.Flags().Changed("fail-cycles") {
-		failCycles = graphFailCycles
-	}
+	// A missing .stem is still not a missing graph: an ungoverned record
+	// filters nothing and opts into nothing.
+	rules.FilterLinksByTypedRules(records, absRoot)
+	cycleScope := rules.CycleFailureScope(records, absRoot)
 
 	g := graph.Build(ctx, records)
 	cycles := g.DetectCycles()
+	failCycles := anyCycleOptsIn(cycles, cycleScope)
+	if cmd.Flags().Changed("fail-cycles") {
+		failCycles = graphFailCycles
+	}
 	broken := g.BrokenLinks()
 
 	// --check mode: report issues and exit.
@@ -238,23 +232,21 @@ func renderDOT(cmd *cobra.Command, g *graph.Graph) {
 	_, _ = fmt.Fprintln(w, "}")
 }
 
-// filterLinksBySchema removes links from records whose type has no rule in the schema.
-// Typed-rule filtering applies only when typed rules are declared; a schema
-// carrying only styles/checks/allowed must not suppress links (the graph
-// showed zero edges on styles-only repos otherwise).
-func filterLinksBySchema(records []*extract.Record, schema rules.LinkSchema) {
-	if len(schema.Rules) == 0 {
-		return
-	}
-	for _, rec := range records {
-		filtered := rec.Links[:0]
-		for _, link := range rec.Links {
-			if _, ok := schema.Rules[link.Type]; ok {
-				filtered = append(filtered, link)
+// anyCycleOptsIn reports whether any detected cycle passes through a record
+// whose schema asked for cycles to fail.
+//
+// Deciding per cycle rather than per run means hardening declared in one
+// subtree fails the cycles that actually run through it, without failing
+// unrelated cycles in a tree that never opted in.
+func anyCycleOptsIn(cycles [][]string, scope map[string]bool) bool {
+	for _, cycle := range cycles {
+		for _, node := range cycle {
+			if scope[node] {
+				return true
 			}
 		}
-		rec.Links = filtered
 	}
+	return false
 }
 
 func renderMermaid(cmd *cobra.Command, g *graph.Graph) {

--- a/cmd/rootline/graph_test.go
+++ b/cmd/rootline/graph_test.go
@@ -7,9 +7,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/pablontiv/rootline/internal/extract"
-	"github.com/pablontiv/rootline/internal/rules"
 )
 
 func TestGraphJSON_Empty(t *testing.T) {
@@ -234,87 +231,6 @@ func TestGraphFormat_Invalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown format") {
 		t.Errorf("expected 'unknown format' error, got: %v", err)
-	}
-}
-
-func TestFilterLinksBySchema_WithRules(t *testing.T) {
-	records := []*extract.Record{
-		{
-			Path: "a.md",
-			Links: []extract.Link{
-				{Target: "T001-task.md", Type: "blocks", Line: 1},
-				{Target: "something", Type: "reference", Line: 2},
-			},
-		},
-	}
-	schema := rules.LinkSchema{
-		Allowed: []string{"blocks", "reference"},
-		Rules:   map[string]rules.LinkRule{"blocks": {Target: "T*"}},
-	}
-
-	filterLinksBySchema(records, schema)
-
-	if len(records[0].Links) != 1 {
-		t.Fatalf("expected 1 link after filter, got %d", len(records[0].Links))
-	}
-	if records[0].Links[0].Type != "blocks" {
-		t.Errorf("expected blocks link, got %s", records[0].Links[0].Type)
-	}
-}
-
-func TestFilterLinksBySchema_EmptySchema(t *testing.T) {
-	records := []*extract.Record{
-		{
-			Path: "a.md",
-			Links: []extract.Link{
-				{Target: "b.md", Type: "reference", Line: 1},
-				{Target: "c.md", Type: "blocks", Line: 2},
-			},
-		},
-	}
-	schema := rules.LinkSchema{}
-
-	filterLinksBySchema(records, schema)
-
-	if len(records[0].Links) != 2 {
-		t.Errorf("expected 2 links (no filtering), got %d", len(records[0].Links))
-	}
-}
-
-func TestFilterLinksBySchema_StylesOnlySchema(t *testing.T) {
-	rec := &extract.Record{
-		Path:  "a.md",
-		Links: []extract.Link{{Target: "b.md", Type: "reference", Style: extract.StyleMarkdown}},
-	}
-	schema := rules.LinkSchema{Styles: []string{"markdown"}}
-	filterLinksBySchema([]*extract.Record{rec}, schema)
-	if len(rec.Links) != 1 {
-		t.Fatalf("links = %d, want 1 (styles-only schema must not drop links)", len(rec.Links))
-	}
-}
-
-func TestFilterLinksBySchema_ChecksOnlySchema(t *testing.T) {
-	rec := &extract.Record{
-		Path:  "a.md",
-		Links: []extract.Link{{Target: "b.md", Style: extract.StyleWikilink}},
-	}
-	resolveOn := true
-	schema := rules.LinkSchema{Checks: &rules.LinkChecks{Resolve: &resolveOn}}
-	filterLinksBySchema([]*extract.Record{rec}, schema)
-	if len(rec.Links) != 1 {
-		t.Fatalf("links = %d, want 1 (checks-only schema must not drop links)", len(rec.Links))
-	}
-}
-
-func TestFilterLinksBySchema_AllowedOnlySchema(t *testing.T) {
-	rec := &extract.Record{
-		Path:  "a.md",
-		Links: []extract.Link{{Target: "b.md", Type: "reference", Style: extract.StyleWikilink}},
-	}
-	schema := rules.LinkSchema{Allowed: []string{"reference"}}
-	filterLinksBySchema([]*extract.Record{rec}, schema)
-	if len(rec.Links) != 1 {
-		t.Fatalf("links = %d, want 1 (typed filtering applies only when rules are declared)", len(rec.Links))
 	}
 }
 

--- a/cmd/rootline/query.go
+++ b/cmd/rootline/query.go
@@ -112,6 +112,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("scanning %s: %w", scanRoot, err)
 		}
+		// Style filtering belongs to the projection too. Without it the same
+		// --select links returned different link sets depending on whether an
+		// unrelated traversal flag was present, leaking styles the schema
+		// declared ungoverned.
+		rules.FilterLinksByStyles(records, absRoot)
 		derive.DeriveAllSimple(ctx, records, absRoot)
 		derive.EnrichBuiltinsSimple(ctx, records, absRoot)
 		derive.AggregateAllSimple(ctx, records, absRoot)
@@ -232,6 +237,7 @@ func scanForTraversal(ctx context.Context, absQueryRoot string) ([]*extract.Reco
 	// Mirror the `graph` command's link preparation so both commands see
 	// the same edge universe for the same root.
 	rules.FilterLinksByStyles(all, absGraphRoot)
+	rules.FilterLinksByTypedRules(all, absGraphRoot)
 	rules.PrepareLinks(all, absGraphRoot)
 
 	derive.DeriveAllSimple(ctx, all, absGraphRoot)

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -84,6 +84,11 @@ rootline graph docs/epics/ --where 'estado == "Specified"' --check  # Check only
 `.stemignore` both apply. A file the schema declares out of governance is not a node, contributes
 no edges, and cannot fail `--check`. A tree carrying no schema at all is still graphed.
 
+Typed link rules and `links.checks.cycles` resolve **per record**, like link styles. Hardening
+declared in a subdirectory used to evaporate when the command ran from the repository root — the
+most likely CI invocation. A cycle now fails the check when any node in it is governed by a schema
+that asked for it, leaving unrelated cycles in never-opted-in subtrees informational.
+
 ### How a link target resolves
 
 `graph` resolves links through the same engine `validate` uses, so the two agree on which links

--- a/internal/rules/link_schema_scope.go
+++ b/internal/rules/link_schema_scope.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	"path/filepath"
+
+	"github.com/pablontiv/rootline/internal/extract"
+)
+
+// FilterLinksByTypedRules drops links whose type has no rule in the record's
+// own effective schema.
+//
+// Typed-rule filtering used to read the invocation root's stem chain once, so
+// a rule declared in a subdirectory was ignored whenever the command ran from
+// a parent — the same command already resolved link styles per record, so it
+// mixed two different schema-resolution granularities. Both are per record now.
+//
+// Filtering applies only where typed rules are actually declared: a schema
+// carrying only styles or checks must not suppress links, or a styles-only
+// repository ends up with an empty graph.
+func FilterLinksByTypedRules(records []*extract.Record, root string) {
+	for _, rec := range records {
+		if len(rec.Links) == 0 {
+			continue
+		}
+		effective := effectiveFor(rec, root)
+		if effective == nil || len(effective.Links.Rules) == 0 {
+			continue
+		}
+		filtered := rec.Links[:0]
+		for _, link := range rec.Links {
+			if _, ok := effective.Links.Rules[link.Type]; ok {
+				filtered = append(filtered, link)
+			}
+		}
+		rec.Links = filtered
+	}
+}
+
+// CycleFailureScope reports, per record path, whether that record's effective
+// schema opts into failing on link cycles.
+//
+// Cycle hardening declared in a subdirectory used to evaporate the moment CI
+// ran the command from the repository root, because the opt-in was read from
+// the chain above the scan root rather than from the records being scanned.
+// Returning the decision per record lets a cycle fail when any node in it is
+// governed by a schema that asked for it, without failing cycles elsewhere in
+// a tree that never opted in.
+func CycleFailureScope(records []*extract.Record, root string) map[string]bool {
+	scope := make(map[string]bool, len(records))
+	for _, rec := range records {
+		effective := effectiveFor(rec, root)
+		scope[rec.Path] = effective != nil &&
+			effective.Links.Checks != nil &&
+			effective.Links.Checks.Cycles
+	}
+	return scope
+}
+
+// effectiveFor resolves a record's effective schema, or nil when none governs
+// it. A record without a schema is ungoverned, not an error: graph and query
+// both describe trees that may carry no .stem at all.
+func effectiveFor(rec *extract.Record, root string) *StemFile {
+	dir := filepath.Dir(filepath.Join(root, rec.Path))
+	effective, err := ResolveForRecord(dir, rec.Path)
+	if err != nil {
+		return nil
+	}
+	return effective
+}

--- a/internal/rules/link_schema_scope_test.go
+++ b/internal/rules/link_schema_scope_test.go
@@ -1,0 +1,89 @@
+package rules
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/extract"
+)
+
+// Typed-rule filtering was read from the invocation root's stem chain only, so
+// a rule declared in a subdirectory was ignored when the command ran from the
+// parent. It now resolves per record, matching FilterLinksByStyles.
+func TestFilterLinksByTypedRules_ResolvesPerRecord(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".stem"), "version: 2\nroot: true\n")
+	writeFile(t, filepath.Join(root, "sub", ".stem"), "version: 2\nlinks:\n  reference:\n    target: \".*\"\n")
+	writeFile(t, filepath.Join(root, "sub", "x.md"), "body")
+	writeFile(t, filepath.Join(root, "top.md"), "body")
+
+	sub := &extract.Record{Path: filepath.Join("sub", "x.md"), Links: []extract.Link{
+		{Target: "y", Type: "reference", Line: 1},
+		{Target: "z", Type: "blocks", Line: 2},
+	}}
+	top := &extract.Record{Path: "top.md", Links: []extract.Link{
+		{Target: "y", Type: "blocks", Line: 1},
+	}}
+
+	FilterLinksByTypedRules([]*extract.Record{sub, top}, root)
+
+	if len(sub.Links) != 1 || sub.Links[0].Type != "reference" {
+		t.Errorf("sub/x.md links = %+v, want only the declared reference rule", sub.Links)
+	}
+	// top.md's schema declares no typed rules, so nothing is filtered there.
+	if len(top.Links) != 1 {
+		t.Errorf("top.md links = %+v, want untouched (no typed rules in its schema)", top.Links)
+	}
+}
+
+// links.checks.cycles declared in a subdirectory used to evaporate when the
+// command ran from the repository root — the most likely CI invocation
+// (issue #62 sub-defect 6).
+func TestCycleFailureScope_ResolvesPerRecord(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".stem"), "version: 2\nroot: true\n")
+	writeFile(t, filepath.Join(root, "sub", ".stem"), "version: 2\nlinks:\n  checks:\n    cycles: true\n")
+	writeFile(t, filepath.Join(root, "sub", "n1.md"), "body")
+	writeFile(t, filepath.Join(root, "top.md"), "body")
+
+	recs := []*extract.Record{
+		{Path: filepath.Join("sub", "n1.md")},
+		{Path: "top.md"},
+	}
+	scope := CycleFailureScope(recs, root)
+
+	if !scope[filepath.Join("sub", "n1.md")] {
+		t.Errorf("sub/n1.md should opt into cycle failure via its own .stem")
+	}
+	if scope["top.md"] {
+		t.Errorf("top.md declares no cycle hardening and must not opt in")
+	}
+}
+
+// A schema carrying only styles, checks or allowed must not suppress links:
+// typed filtering applies solely where typed rules are declared, or a
+// styles-only repository ends up with an empty graph.
+func TestFilterLinksByTypedRules_NonRuleSchemasDoNotSuppress(t *testing.T) {
+	for name, stem := range map[string]string{
+		"styles only":  "version: 2\nroot: true\nlinks:\n  styles: [wikilink]\n",
+		"checks only":  "version: 2\nroot: true\nlinks:\n  checks:\n    anchors: true\n",
+		"allowed only": "version: 2\nroot: true\nlinks:\n  allowed: [reference, blocks]\n",
+		"no links":     "version: 2\nroot: true\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, ".stem"), stem)
+			writeFile(t, filepath.Join(root, "a.md"), "body")
+			rec := &extract.Record{Path: "a.md", Links: []extract.Link{
+				{Target: "x", Type: "reference", Line: 1},
+				{Target: "y", Type: "blocks", Line: 2},
+			}}
+
+			FilterLinksByTypedRules([]*extract.Record{rec}, root)
+
+			if len(rec.Links) != 2 {
+				t.Errorf("links = %+v, want both kept", rec.Links)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`graph` read typed link rules and `links.checks.cycles` **once**, from the stem chain above the
scan root — while resolving link *styles* per record in the same run. So hardening declared in a
subdirectory evaporated the moment CI ran the command from the repository root:

```console
$ rootline graph --check nest/sub     # before — sub/.stem sets cycles: true
Cycles found: 1
exit=1
$ rootline graph --check nest/        # before — same cycle, run one level up
Cycles found (informational): 1
exit=0                                 <-- the opt-in vanished
```

`query` traversal never applied typed-rule filtering **at all**, despite the comment above its
link preparation promising it mirrors `graph`. And `query`'s plain branch never applied style
filtering, so the same `--select links` returned different link sets depending on whether an
unrelated traversal flag was present.

## How

Typed rules and the cycle opt-in resolve **per record**, like styles already did
(`rules.FilterLinksByTypedRules`, `rules.CycleFailureScope`).

A cycle fails the check when **any node in it** is governed by a schema that asked for it. Deciding
per cycle rather than per run means hardening declared in one subtree fails the cycles running
through it, without failing unrelated cycles in a tree that never opted in.

The cmd-level `filterLinksBySchema` helper moves into `rules`. Its invariant moves with it: a
schema carrying only `styles`, only `checks`, or only `allowed` must not suppress links, or a
styles-only repository ends up with an empty graph. The four shapes are now table-tested.

## Evidence

```console
$ rootline graph --check nest/         # after — the subdirectory opt-in fires
Cycles found: 1
  1: sub/n1.md → sub/n2.md → sub/n1.md
exit=1

$ rootline query typed/ --has-outbound "" --outbound-type blocks --select path -o json
{"meta":{"count":0},"rows":[]}         # after — matches graph, which filters the blocks edge

$ rootline query mix/ --select path,links -o json      # after — no traversal flag
... "links":[{"target":"b","style":"wikilink"}] ...    # markdown no longer leaks
```

Before, `query --has-outbound` returned `x.md` for a `blocks` edge that `graph` had already
filtered out, and `--select links` returned both styles on a `styles: [wikilink]` schema.

## Parity matrix rows changed

| Feature | before | after |
|---|---|---|
| `links.checks.cycles` opt-in | root-only — evaporates from a parent dir | per record; a cycle through an opted-in node fails |
| Typed rules in `query` traversal | **not applied** | applied, matching `graph` |
| `query --select links` honors `links.styles` | only with a traversal flag | always |

Closes **sub-defects 6, 7 and 8**.

## Semver

**`feat!`**.

BREAKING CHANGE: `links.checks.cycles` declared in a subdirectory now fails `graph --check` when a
cycle runs through that subtree, including when the command runs from an ancestor directory.

## Testing

`internal/rules/link_schema_scope_test.go` pins per-record resolution for both typed rules and the
cycle opt-in, plus the four non-suppressing schema shapes inherited from the deleted cmd-level
tests.

`just check`, `just test` (14 packages), `just coverage-check` green. Review returned zero findings.

## Size and stacking

311 changed lines. Based on #102, **not** master.

Refs #62
