### PR TITLE
feat(fix): surface link findings instead of reporting a clean run

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -114,6 +114,8 @@ links:
 
 **Validation**: Check failures surface in `validate` as rules `link_resolve` (with fuzzy suggestion), `link_anchor`, `link_encoding`. External schemes, images, and pure fragments are not checked.
 
+**`fix --all` surfaces link findings**: link problems appear under `link_findings` (JSON) rather than being silently omitted, but `fix` never rewrites a link body — the fuzzy suggestion is reported for a human to apply.
+
 **Per-record schema**: typed link rules and `links.checks.cycles` resolve per record, not from the invocation root, so a rule or cycle opt-in declared in a subdirectory still applies when the command runs from the parent. `query --select links` honors `links.styles` with or without a traversal flag, and `query` traversal applies typed-rule filtering exactly as `graph` does.
 
 **One record set**: `validate` (both modes), `graph`, `query` and `fix --all` apply the same `scope.match` and `.stemignore` filters. `validate <file>` on an excluded file reports a `skipped` warning instead of validating it, so the pre-commit hook and CI agree.

--- a/cmd/rootline/fix.go
+++ b/cmd/rootline/fix.go
@@ -36,6 +36,12 @@ type BatchFixResult struct {
 	// not the schema, chose their value. Carried so the operator can see the
 	// field was left unfilled deliberately.
 	SkippedProposals []proposal.Proposal `json:"skipped_proposals,omitempty"`
+
+	// LinkFindings reports link problems fix will not repair. Rewriting a
+	// link body on a fuzzy guess is a destructive edit outside fix's
+	// data-repair contract, but staying silent about a defect validate does
+	// report made a clean fix followed by a failing validate read as a bug.
+	LinkFindings []proposal.LinkFinding `json:"link_findings,omitempty"`
 }
 
 // FixSummary holds aggregate counts for batch fix.
@@ -189,6 +195,8 @@ func runFixAll(ctx context.Context, cmd *cobra.Command, args []string) error {
 	// First pass: collect all records, their effective stems, and errors.
 	allErrs := make(map[string][]rules.ValidationError)
 	effectiveStems := make(map[string]*rules.StemFile)
+	linkCache := rules.NewHeadingCache()
+	var linkFindings []proposal.LinkFinding
 
 	for _, rec := range records {
 		absPath := filepath.Join(root, rec.Path)
@@ -200,6 +208,15 @@ func runFixAll(ctx context.Context, cmd *cobra.Command, args []string) error {
 		effectiveStems[rec.Path] = effective
 
 		errs := rules.Validate(ctx, rec, effective)
+
+		// Link checks never reached fix, so a record validate failed with
+		// link_resolve came back from fix as a clean run — with no warning,
+		// even though the error already carries a fuzzy suggestion.
+		for _, e := range rules.CheckLinks(rec.Links, effective.Links, absPath, root, linkCache) {
+			linkFindings = append(linkFindings, proposal.LinkFinding{
+				Path: rec.Path, Rule: e.Rule, Message: e.Message, Suggestion: e.Suggestion,
+			})
+		}
 
 		if len(errs) > 0 {
 			allErrs[rec.Path] = errs
@@ -228,10 +245,16 @@ func runFixAll(ctx context.Context, cmd *cobra.Command, args []string) error {
 	// In normal apply, we only apply data proposals.
 	separateSchemaAndDataProposals(report)
 
+	report.LinkFindings = linkFindings
+
 	// In dry-run mode, use proposal engine for richer output.
 	if fixDryRun {
 		if outputFormat == "table" {
-			return renderProposalTable(cmd, report)
+			if err := renderProposalTable(cmd, report); err != nil {
+				return err
+			}
+			renderLinkFindings(cmd, report.LinkFindings)
+			return nil
 		}
 		return outputJSON(cmd, report, false)
 	}
@@ -250,6 +273,7 @@ func runFixAll(ctx context.Context, cmd *cobra.Command, args []string) error {
 	results := proposalsToFixResults(report, records)
 	batch := newBatchFixResultWithSuggestions(results, len(report.SchemaSuggestions))
 	batch.SkippedProposals = skippedProposals
+	batch.LinkFindings = linkFindings
 
 	if outputFormat == "table" {
 		return renderFixTable(cmd, batch)
@@ -398,6 +422,24 @@ func newBatchFixResultWithSuggestions(results []*FixResult, schemaSuggestionsCou
 	}
 }
 
+// renderLinkFindings prints the link problems fix reported but did not repair.
+// Shared by the dry-run preview and the applied run so the preview cannot go
+// quiet about something the real run reports.
+func renderLinkFindings(cmd *cobra.Command, findings []proposal.LinkFinding) {
+	if len(findings) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Link findings: %d (reported, not repaired)\n", len(findings))
+	for _, f := range findings {
+		line := fmt.Sprintf("  %s: %s (%s)", f.Path, f.Message, f.Rule)
+		if f.Suggestion != "" {
+			line += fmt.Sprintf(" — did you mean %q?", f.Suggestion)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), line)
+	}
+}
+
 func renderProposalTable(cmd *cobra.Command, report *proposal.Report) error {
 	headers := []string{"Type", "Field", "Description", "Files"}
 	var rows [][]string
@@ -455,6 +497,7 @@ func renderFixTable(cmd *cobra.Command, batch *BatchFixResult) error {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Note: %d schema proposals were skipped (data-only repairs applied).\n", batch.SchemaSuggestions)
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "To apply schema changes, use 'rootline schema propose' or manually edit .stem files.")
 	}
+	renderLinkFindings(cmd, batch.LinkFindings)
 
 	return nil
 }

--- a/cmd/rootline/fix_links_test.go
+++ b/cmd/rootline/fix_links_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupFixLinkFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	files := map[string]string{
+		".stem":    "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  titulo:\n    type: string\nlinks:\n  styles: [markdown]\n",
+		"guide.md": "---\ntitulo: G\n---\n\n# Guide\n",
+		"a.md":     "---\ntitulo: A\n---\n\nSee [g](guied.md).\n",
+	}
+	for rel, content := range files {
+		p := filepath.Join(dir, rel)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// fix --all reported a clean run on a record validate fails with link_resolve,
+// even though that error already carries a fuzzy suggestion. A clean fix
+// followed by a failing validate reads as a tool bug (issue #62 sub-defect 12).
+func TestFixAllSurfacesLinkFindings(t *testing.T) {
+	dir := setupFixLinkFixture(t)
+	out, err := runCmd(t, "fix", "--all", dir)
+	if err != nil {
+		t.Fatalf("fix --all failed: %v\n%s", err, out)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	findings, ok := result["link_findings"].([]any)
+	if !ok || len(findings) == 0 {
+		t.Fatalf("expected link_findings to be reported, got: %s", out)
+	}
+	if !strings.Contains(out, "guied.md") {
+		t.Errorf("finding should name the unresolved target:\n%s", out)
+	}
+	if !strings.Contains(out, "guide.md") {
+		t.Errorf("finding should carry the fuzzy suggestion validate already computed:\n%s", out)
+	}
+}
+
+// fix must not rewrite link bodies on a fuzzy guess: that is a destructive
+// edit outside its data-repair contract. The finding is reported, the document
+// is left alone.
+func TestFixAllDoesNotRewriteLinkBodies(t *testing.T) {
+	dir := setupFixLinkFixture(t)
+	before, err := os.ReadFile(filepath.Join(dir, "a.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runCmd(t, "fix", "--all", dir); err != nil {
+		t.Fatalf("fix --all failed: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "a.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("fix rewrote a link body:\nbefore: %q\nafter:  %q", before, after)
+	}
+}
+
+// A repository with no link problems reports no findings.
+func TestFixAllNoLinkFindingsWhenClean(t *testing.T) {
+	dir := t.TempDir()
+	for rel, content := range map[string]string{
+		".stem":    "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  titulo:\n    type: string\nlinks:\n  styles: [markdown]\n",
+		"guide.md": "---\ntitulo: G\n---\n\n# Guide\n",
+		"a.md":     "---\ntitulo: A\n---\n\nSee [g](guide.md).\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out, err := runCmd(t, "fix", "--all", dir)
+	if err != nil {
+		t.Fatalf("fix --all failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "link_findings") {
+		t.Errorf("clean repository must report no link findings:\n%s", out)
+	}
+}
+
+// Dry-run is the preview of what fix will do, so it must report the same link
+// findings the applied run reports. Collecting them and then dropping them on
+// the dry-run branch would hide the very defect the field exists to expose.
+func TestFixAllDryRunSurfacesLinkFindings(t *testing.T) {
+	dir := setupFixLinkFixture(t)
+	out, err := runCmd(t, "fix", "--all", dir, "--dry-run")
+	if err != nil {
+		t.Fatalf("fix --all --dry-run failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "link_findings") || !strings.Contains(out, "guied.md") {
+		t.Errorf("dry-run dropped link findings:\n%s", out)
+	}
+}

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -5,6 +5,23 @@ estado: Completed
 
 The `rootline fix` command goes beyond simple mechanical repairs. It analyzes validation errors and proposes intelligent solutions based on data patterns and heuristics.
 
+## Link findings
+
+`fix --all` reports link problems it will not repair, under `link_findings` in JSON and as a
+"Link findings" block in table output:
+
+```console
+$ rootline fix --all docs/
+Link findings: 1 (reported, not repaired)
+  a.md: link target "guied.md" does not resolve to an existing file (case-sensitive) (link_resolve) — did you mean "guide.md"?
+```
+
+`fix` does not rewrite link bodies. Correcting a link on a fuzzy guess is a destructive edit
+outside its data-repair contract — the suggestion is offered so a human can make the call. Before
+this, a record `validate` failed with `link_resolve` came back from `fix` as a clean run, which
+read as a tool bug.
+
+
 ## Proposal Types
 
 Rootline categorizes issues into specific proposal types to preserve semantic meaning.

--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -76,7 +76,25 @@ type Report struct {
 	Root              string     `json:"root,omitempty"` // absolute scan root
 	Proposals         []Proposal `json:"proposals"`
 	SchemaSuggestions []Proposal `json:"schema_suggestions,omitempty"`
-	Summary           Summary    `json:"summary"`
+
+	// LinkFindings reports link problems that will be surfaced rather than
+	// repaired. Dry-run is the preview of what fix will do, so omitting them
+	// there would hide the same defect the field exists to expose.
+	LinkFindings []LinkFinding `json:"link_findings,omitempty"`
+
+	Summary Summary `json:"summary"`
+}
+
+// LinkFinding is one links.checks failure reported rather than repaired.
+//
+// fix does not rewrite link bodies: correcting a link on a fuzzy guess is a
+// destructive edit outside its data-repair contract. The suggestion validate
+// already computed is carried through so a human can make the call.
+type LinkFinding struct {
+	Path       string `json:"path"`
+	Rule       string `json:"rule"`
+	Message    string `json:"message"`
+	Suggestion string `json:"suggestion,omitempty"`
 }
 
 // Summary holds aggregate counts for a report.


### PR DESCRIPTION
## What

`rules.CheckLinks` had **no call site outside `validate`**. So on a record `validate --all` fails
with `link_resolve`, `fix --all` returned a clean run:

```console
$ rootline validate --all fixme/     # before
a.md  link_resolve  link target "guied.md" does not resolve ... (did you mean "guide.md"?)

$ rootline fix --all fixme/ -o json  # before
{"results":[{"path":"a.md","fixed":false,"changes":[]}],"summary":{"fixed":0,"skipped":2}}
```

No warning, no suggestion — even though the validation error **already carried** `guide.md`. `fix`
is the "make it clean" command, so a clean `fix` followed by a failing `validate` reads as a tool
bug.

## How

`fix` collects link findings and reports them under `link_findings`, in JSON and table output.

It does **not** repair them. Rewriting a link body on a fuzzy guess is a destructive edit outside
`fix`'s data-repair contract — the suggestion `validate` already computed is surfaced for a human
to apply. A test pins that the document bytes are unchanged.

## Evidence

```console
$ rootline fix --all fixme/ -o json    # after
summary: {'total': 2, 'fixed': 0, 'skipped': 2}
  finding: a.md link_resolve suggestion=guide.md
```

## The dry-run hole the review caught

The first implementation collected the findings and attached them to the batch result **after** the
`--dry-run` early return — so dry-run silently dropped them. That is the same silent omission this
change exists to remove, just relocated to the preview path, and dry-run is arguably where it
matters most since it is what a user reads before deciding.

`LinkFinding` moved into `internal/proposal`, `Report` gained a `link_findings` field, the findings
attach *before* the dry-run branch, and a shared `renderLinkFindings` prints them on both table
paths so the preview cannot go quiet about something the applied run reports. All four paths
(dry-run JSON, dry-run table, applied JSON, applied table) are now covered, and a test pins the
dry-run case specifically.

## Parity matrix rows changed

| Feature | `fix --all` before | after |
|---|---|---|
| Broken-target detection | **silently dropped** — reported a clean run | reported under `link_findings` |

Closes **sub-defect 12**. This is one of the two rows the proposal marked as an *intentional*
non-unification: `fix` surfaces link findings but never repairs them, by design.

## Testing

Findings surfaced, document bytes untouched, clean repository reports nothing, and dry-run reports
the same findings as the applied run.

`just check`, `just test` (14 packages), `just coverage-check` green. Re-review after the
correction returned zero findings.

## Size and stacking

191 changed lines. Based on #105, **not** master.

Refs #62
