### PR TITLE
test(e2e): assert validate and graph agree on every parity-matrix row

### DIFF
--- a/internal/e2e/link_parity_e2e_test.go
+++ b/internal/e2e/link_parity_e2e_test.go
@@ -1,0 +1,247 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/graph"
+	"github.com/pablontiv/rootline/internal/index"
+	"github.com/pablontiv/rootline/internal/rules"
+)
+
+// Issue #62 was that `validate` and `graph` ran two disjoint link engines and
+// never agreed. These tests are the regression guard: each one runs BOTH
+// engines over the same corpus and asserts they reach the same verdict, so a
+// future change cannot quietly reintroduce the divergence.
+//
+// Rows that intentionally differ get their own test pinning the DECLARED
+// difference, because the defect was never "they differ" — it was that they
+// differed silently.
+
+// scanFresh returns a fresh record set. Both engines mutate the links they are
+// given, so each needs its own copy of the corpus.
+func scanFresh(t *testing.T, root string) []*extract.Record {
+	t.Helper()
+	records, err := index.Scan(context.Background(), root, extract.NewRegistry())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return records
+}
+
+// brokenByValidate returns "<record> -> <target>" for every link validate
+// reports as an error, which is the verdict a CI job running validate sees.
+func brokenByValidate(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	cache := rules.NewHeadingCache()
+	for _, rec := range scanFresh(t, root) {
+		abs := filepath.Join(root, rec.Path)
+		effective, err := rules.ResolveForRecord(filepath.Dir(abs), rec.Path)
+		if err != nil {
+			continue
+		}
+		for _, e := range rules.CheckLinks(rec.Links, effective.Links, abs, root, cache) {
+			if e.Severity != "error" {
+				continue // warnings are not a broken-link verdict
+			}
+			out = append(out, fmt.Sprintf("%s -> %s", rec.Path, targetOf(e.Message)))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// brokenByGraph returns the same shape for the verdict `graph --check` sees.
+func brokenByGraph(t *testing.T, root string) []string {
+	t.Helper()
+	records := scanFresh(t, root)
+	rules.FilterLinksByStyles(records, root)
+	rules.FilterLinksByTypedRules(records, root)
+	rules.PrepareLinks(records, root)
+	g := graph.Build(context.Background(), records)
+
+	var out []string
+	for _, b := range g.BrokenLinks() {
+		out = append(out, fmt.Sprintf("%s -> %s", b.Source, b.Target))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// targetOf pulls the quoted target out of a link error message so the two
+// engines can be compared on the same key.
+func targetOf(msg string) string {
+	first := strings.Index(msg, "\"")
+	if first < 0 {
+		return msg
+	}
+	rest := msg[first+1:]
+	end := strings.Index(rest, "\"")
+	if end < 0 {
+		return msg
+	}
+	return rest[:end]
+}
+
+// assertEngines checks both that the two engines agree AND that they reached
+// the verdict the row expects.
+//
+// Agreement alone is a false guard: a row where both engines resolve every
+// link compares empty against empty and passes no matter what, which is
+// exactly how the original defect would slip back in — validate going silent
+// looks like agreement. wantBroken pins the expected count so a row that is
+// supposed to find something must actually find it.
+func assertEngines(t *testing.T, root string, wantBroken int) {
+	t.Helper()
+	v, g := brokenByValidate(t, root), brokenByGraph(t, root)
+	if strings.Join(v, "|") != strings.Join(g, "|") {
+		t.Errorf("engines disagree on broken links:\n  validate: %v\n  graph:    %v", v, g)
+	}
+	if len(v) != wantBroken {
+		t.Errorf("validate broken = %d, want %d: %v", len(v), wantBroken, v)
+	}
+	if len(g) != wantBroken {
+		t.Errorf("graph broken = %d, want %d: %v", len(g), wantBroken, g)
+	}
+}
+
+// One corpus per parity-matrix row. Each row is a link shape the two engines
+// used to answer differently.
+func TestE2E_Parity_EnginesAgreePerMatrixRow(t *testing.T) {
+	stem := "version: 2\nroot: true\nscope:\n  match: \"*.md\"\n"
+	mdStem := stem + "links:\n  styles: [markdown]\n"
+
+	type row struct {
+		files      map[string]string
+		wantBroken int
+	}
+	rows := map[string]row{
+		// Sub-defect 1: the headline. validate reported every valid
+		// extension-less wikilink broken while graph reported clean.
+		"extension-less wikilink resolves": {map[string]string{
+			".stem": stem, "b.md": "# B\n", "t.md": "See [[b]].\n",
+		}, 0},
+		// Sub-defect 10: worked for [[b]] but not once a directory prefix
+		// was added, an inconsistency inside graph itself.
+		"path-qualified wikilink resolves": {map[string]string{
+			".stem": stem, "sub/README.md": "# Sub\n", "t.md": "See [[sub/README]].\n",
+		}, 0},
+		// Sub-defect 9: the anchor was folded into the filename.
+		"wikilink anchor resolves": {map[string]string{
+			".stem": stem, "b.md": "# Heading One\n", "t.md": "See [[b#heading-one]].\n",
+		}, 0},
+		// Sub-defect 3: validate skipped root-anchored targets outright.
+		"root-anchored target resolves": {map[string]string{
+			".stem": mdStem, "docs/Page.md": "# P\n", "deep/t.md": "See [x](/docs/Page.md).\n",
+		}, 0},
+		"root-anchored missing target is broken": {map[string]string{
+			".stem": mdStem, "deep/t.md": "See [x](/docs/Nope.md).\n",
+		}, 1},
+		// Sub-defect 2: no links.checks block. validate was silent, graph failed.
+		"broken target with no checks block": {map[string]string{
+			".stem": stem, "b.md": "# B\n", "t.md": "See [[nope]].\n",
+		}, 1},
+		// Markdown stays literal: no .md inference for that style.
+		"markdown target resolves literally": {map[string]string{
+			".stem": mdStem, "b.md": "# B\n", "t.md": "See [x](b.md).\n",
+		}, 0},
+		"markdown target without extension is broken": {map[string]string{
+			".stem": mdStem, "b.md": "# B\n", "t.md": "See [x](b).\n",
+		}, 1},
+		"case mismatch is broken": {map[string]string{
+			".stem": mdStem, "Setup.md": "# S\n", "t.md": "See [x](setup.md).\n",
+		}, 1},
+		"directory target resolves to README": {map[string]string{
+			".stem": mdStem, "guides/README.md": "# G\n", "t.md": "See [x](guides/).\n",
+		}, 0},
+		"percent-encoded target resolves": {map[string]string{
+			".stem": mdStem, "my page.md": "# P\n", "t.md": "See [x](my%20page.md).\n",
+		}, 0},
+	}
+
+	for name, r := range rows {
+		t.Run(name, func(t *testing.T) {
+			assertEngines(t, setupProject(t, r.files), r.wantBroken)
+		})
+	}
+}
+
+// A target that exists but is not a governed record resolved fine: the schema
+// declares what is governed, not what exists. Reporting it broken is what made
+// the two commands disagree, so neither may report it.
+func TestE2E_Parity_UngovernedButExistingTargetIsNotBroken(t *testing.T) {
+	root := setupProject(t, map[string]string{
+		".stem":    "version: 2\nroot: true\nscope:\n  match: \"T*.md\"\n",
+		"T001.md":  "See [[other]].\n",
+		"other.md": "# Other\n",
+	})
+	assertEngines(t, root, 0)
+	if g := brokenByGraph(t, root); len(g) != 0 {
+		t.Errorf("existing-but-ungoverned target reported broken by graph: %v", g)
+	}
+}
+
+// The one DECLARED divergence. With links.basename_fallback on, graph resolves
+// a bare cross-directory target and validate cannot, because it checks one
+// record at a time and has no index. validate must say so explicitly — a
+// warning, not silence and not a wrong "broken" verdict. This test exists so a
+// future change cannot turn the declared difference back into a silent one.
+func TestE2E_Parity_BasenameFallbackDivergenceIsDeclared(t *testing.T) {
+	root := setupProject(t, map[string]string{
+		".stem":       "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  basename_fallback: true\n",
+		"deep/far.md": "# Far\n",
+		"t.md":        "See [[far]].\n",
+	})
+
+	if g := brokenByGraph(t, root); len(g) != 0 {
+		t.Errorf("graph should resolve the bare target via basename fallback, got broken: %v", g)
+	}
+	if v := brokenByValidate(t, root); len(v) != 0 {
+		t.Errorf("validate must not report a hard error it cannot substantiate: %v", v)
+	}
+
+	var sawUnverifiable bool
+	cache := rules.NewHeadingCache()
+	for _, rec := range scanFresh(t, root) {
+		abs := filepath.Join(root, rec.Path)
+		effective, err := rules.ResolveForRecord(filepath.Dir(abs), rec.Path)
+		if err != nil {
+			continue
+		}
+		for _, e := range rules.CheckLinks(rec.Links, effective.Links, abs, root, cache) {
+			if e.Rule == "link_unverifiable" {
+				sawUnverifiable = true
+				if e.Severity != "warn" {
+					t.Errorf("link_unverifiable severity = %q, want warn so it does not fail the run", e.Severity)
+				}
+			}
+		}
+	}
+	if !sawUnverifiable {
+		t.Error("validate went silent on a link it cannot decide — that is the silent divergence issue #62 removed")
+	}
+}
+
+// Sub-defect 13, fixed earlier: graph refused to build without a .stem. Link
+// integrity is a property of document bodies, not of any schema.
+func TestE2E_Parity_GraphWorksWithoutSchema(t *testing.T) {
+	root := setupProject(t, map[string]string{
+		"a.md": "See [[missing]].\n",
+	})
+	records := scanFresh(t, root)
+	rules.FilterLinksByStyles(records, root)
+	rules.PrepareLinks(records, root)
+	g := graph.Build(context.Background(), records)
+	if len(g.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want the schemaless record still graphed", len(g.Nodes))
+	}
+	if len(g.BrokenLinks()) != 1 {
+		t.Errorf("broken = %v, want the dangling target reported", g.BrokenLinks())
+	}
+}

--- a/internal/e2e/link_styles_e2e_test.go
+++ b/internal/e2e/link_styles_e2e_test.go
@@ -53,7 +53,13 @@ func TestE2E_LinkStyles_WikilinkRepoUnaffected(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Validation: the markdown link to a NONEXISTENT c.md produces no errors.
+	// Validation: the markdown link to a NONEXISTENT c.md produces no errors,
+	// because links.styles leaves markdown ungoverned here. The wikilink to
+	// b.md resolves. This used to be true for a second, wrong reason — the
+	// schema declares no links.checks, and validate skipped every check
+	// without one while graph failed on the same corpus. Broken-target
+	// detection is always on now, so this asserts agreement rather than
+	// asserting that validate simply was not looking.
 	for _, rec := range records {
 		absPath := filepath.Join(root, rec.Path)
 		effective, err := rules.ResolveForRecord(filepath.Dir(absPath), rec.Path)
@@ -79,6 +85,51 @@ func TestE2E_LinkStyles_WikilinkRepoUnaffected(t *testing.T) {
 	}
 	if edges[0].Target == "c.md" {
 		t.Error("markdown link leaked into wikilink-only graph")
+	}
+
+	// Both engines agree on this corpus: neither reports a broken link.
+	if broken := g.BrokenLinks(); len(broken) != 0 {
+		t.Errorf("graph broken = %+v, want none — validate reports none either", broken)
+	}
+}
+
+// The corpus above with an ACTUALLY broken wikilink: both engines must now
+// report it. Before, validate stayed silent without a links.checks block while
+// graph --check failed, which is the disagreement issue #62 was filed for.
+func TestE2E_LinkStyles_BrokenWikilinkFailsBothEngines(t *testing.T) {
+	root := setupProject(t, map[string]string{
+		".stem": "version: 2\nlinks:\n  allowed: [reference]\n",
+		"a.md":  "[[nope]]\n",
+		"b.md":  "# B\n",
+	})
+	ctx := context.Background()
+	records, err := index.Scan(ctx, root, extract.NewRegistry())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var validateErrs int
+	for _, rec := range records {
+		absPath := filepath.Join(root, rec.Path)
+		effective, err := rules.ResolveForRecord(filepath.Dir(absPath), rec.Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range rules.CheckLinks(rec.Links, effective.Links, absPath, root, nil) {
+			if e.Severity == "error" {
+				validateErrs++
+			}
+		}
+	}
+
+	rules.FilterLinksByStyles(records, root)
+	rules.PrepareLinks(records, root)
+	g := graph.Build(ctx, records)
+	graphBroken := len(g.BrokenLinks())
+
+	if validateErrs != 1 || graphBroken != 1 {
+		t.Errorf("engines disagree: validate errors = %d, graph broken = %d, want 1 and 1",
+			validateErrs, graphBroken)
 	}
 }
 


### PR DESCRIPTION
## What

Issue #62 was that `validate` and `graph` ran **two disjoint link engines over two different record
sets**, and each accepted links the other rejected. The fixes are spread across nine PRs. This is
the guard that proves they hold — and that keeps holding.

Each row builds one corpus, runs **both** engines over it, and asserts they reach the same verdict.

## Before / after parity matrix

Re-run of the issue's own reproduction script, exit codes only. `✗` marks a disagreeing pair.

| Case | What it exercises | Before | After |
|---|---|---|---|
| A1 / A2 | `[[b]]` with `b.md` present, default styles — **the headline** | validate `1`, graph `0` ✗ | both `0` ✓ |
| B1 / B2 | broken link, no `links.checks` block | validate `0`, graph `1` ✗ | both `1` ✓ |
| C1 / C2 | root-anchored `/nonexistent.md` | validate `0`, graph `1` ✗ | both `1` ✓ |
| C3 / C4 | anchors + encoding | validate only | both report them ✓ |
| D2 | out-of-scope file in graph | flagged `other.md` ✗ | scoped out ✓ |
| D3 | `validate <file>` on out-of-scope file | validated it, `1` ✗ | skipped with warning, `0` ✓ |
| E1 / E2 | `cycles: true` in a subdirectory | `1` from subdir, `0` from parent ✗ | both `1` ✓ |
| F1 / F2 | typed rules in `query` traversal | query matched an edge graph filtered ✗ | both filter ✓ |
| G1 | `--select links` without a traversal flag | leaked markdown ✗ | styles honored ✓ |
| G3 | `[[sub/README]]`, `[[b#heading-one]]` | `1`, both broken ✗ | `0` ✓ |
| H2 | `fix --all` on a `link_resolve` failure | clean run, no warning ✗ | reports the finding ✓ |
| I1 | `graph` with no `.stem` | errored ✗ | builds (fixed in #76) ✓ |
| J2 | `validate <file>` on a `.stemignore`d file | validated it, `1` ✗ | skipped, `0` ✓ |

## Why agreement alone would be a false guard

A row where both engines resolve everything compares empty against empty and passes **regardless**
— which is exactly how the original defect returns, because *validate going silent looks like
agreement*.

So every row also declares the verdict it expects. A row that should find a broken link has to
actually find one. I verified this: injecting a silent-validate regression fails four rows plus the
parent. Without the expected counts it would have failed **none**.

The reviewer raised this on the first pass and was right; the `wantBroken` assertions are that fix.

## The intentional divergence is pinned too

With `links.basename_fallback` on, `graph` resolves a bare cross-directory target and `validate`
cannot, having no global index. That test pins **both** sides — graph resolves, validate emits
`link_unverifiable` at `warn` — so a future change cannot turn a *declared* difference back into a
*silent* one. The defect was never "they differ"; it was that they differed silently.

## De-divergencing the existing suite

`link_styles_e2e_test.go` asserted no validation errors on a corpus with no `links.checks` block.
That was true for the **wrong reason** — validate skipped every check without one. It now asserts
agreement, plus a companion test pinning that an actually broken wikilink fails both engines.

## Rows deliberately not asserted

- **Cycle parity**: cycles are a graph-only concept; `validate` has no notion of them, so this is
  not a parity row (it appears as `n/a` in the issue's own matrix).
- **`query` (plain) broken-target detection**: `query` is a projection command. Per the proposal's
  intentional-differences section it gains style filtering, not validation.
- **`fix --all` link repair**: `fix` surfaces findings but never rewrites link bodies — a
  destructive edit outside its data-repair contract.

## Testing

`just check`, `just test` (14 packages), `just coverage-check` green.

## Size and stacking

300 changed lines, test-only. Based on #109, **not** master. Last PR in the stack:
#93 → #94 → #97 → #98 → #102 → #105 → #109 → this.

Fixes #62
