### PR TITLE
fix(installer): avoid API limits resolving latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,29 @@ jobs:
       - run: go build -o rootline ./cmd/rootline/
       - run: ./rootline validate --all docs/roadmap/
 
+  installer-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Test install.sh resolver
+        if: runner.os != 'Windows'
+        shell: bash
+        run: sh tests/installers/install-sh-test.sh
+      - name: Test install.ps1 resolver
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./tests/installers/install-ps1-test.ps1
+
   release:
     uses: pablontiv/crossbeam/.github/workflows/go-release.yml@v1
-    needs: [ci, gitleaks, docs-validate]
+    needs: [ci, gitleaks, docs-validate, installer-tests]
     if: github.event_name == 'push'
     with:
-      quality-gate-jobs: '["ci","gitleaks","docs-validate"]'
+      quality-gate-jobs: '["ci","gitleaks","docs-validate","installer-tests"]'
       binary-name: rootline
     permissions:
       contents: write
@@ -70,9 +87,10 @@ jobs:
         shell: bash
         run: |
           set -eu
-          # Retry: the scripts hit the GitHub API and release CDN, which flake.
+          # Retry transient release-page and CDN failures.
           for attempt in 1 2 3; do
             if sh install.sh; then break; fi
+            if [ "$attempt" -eq 3 ]; then exit 1; fi
             echo "install.sh attempt ${attempt} failed; retrying in 5s..."
             sleep 5
           done
@@ -85,7 +103,11 @@ jobs:
         run: |
           for ($i = 1; $i -le 3; $i++) {
             try { & ./install.ps1; break }
-            catch { Write-Host "install.ps1 attempt $i failed: $_"; Start-Sleep 5 }
+            catch {
+              if ($i -eq 3) { throw }
+              Write-Host "install.ps1 attempt $i failed: $_; retrying in 5s..."
+              Start-Sleep 5
+            }
           }
           # install.ps1 installs to %LOCALAPPDATA%\rootline\bin and only updates
           # the persistent User PATH, not this job's PATH — invoke by full path.

--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,12 @@ fmt:
 test:
     go test ./... -race
 
+# Run deterministic offline tests for the public installers. PowerShell coverage
+# runs when pwsh is available locally and unconditionally on the Windows CI leg.
+test-install:
+    sh tests/installers/install-sh-test.sh
+    if command -v pwsh >/dev/null 2>&1; then pwsh -NoProfile -File tests/installers/install-ps1-test.ps1; else echo "pwsh not found; PowerShell installer tests skipped locally"; fi
+
 # Show coverage per package and total
 coverage:
     go test ./... -coverprofile=coverage.out
@@ -101,4 +107,3 @@ validate:
 # Fix docs (propagate aggregates)
 fix-docs:
     rootline fix --all docs/roadmap/
-

--- a/install.ps1
+++ b/install.ps1
@@ -21,13 +21,63 @@ function Get-Arch {
 
 function Get-LatestVersion {
     Write-Host "Fetching latest version..."
-    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
-    $version = $release.tag_name
+    $version = $null
+    try {
+        $releaseUrl = Get-LatestReleaseUrl
+        $version = Get-VersionFromReleaseUrl -ReleaseUrl $releaseUrl
+    }
+    catch {
+        $version = $null
+    }
+
+    if (-not $version) {
+        $version = Get-LatestVersionFromApi
+    }
+
     if (-not $version) {
         throw "Could not determine latest version. Check https://github.com/$Repo/releases"
     }
     Write-Host "Latest version: $version"
     return $version
+}
+
+function Get-LatestReleaseUrl {
+    $response = Invoke-WebRequest `
+        -Uri "https://github.com/$Repo/releases/latest" `
+        -Method Head `
+        -MaximumRedirection 5 `
+        -UseBasicParsing
+
+    if ($response.BaseResponse.ResponseUri) {
+        return $response.BaseResponse.ResponseUri.AbsoluteUri
+    }
+    if ($response.BaseResponse.RequestMessage.RequestUri) {
+        return $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+    }
+    if ($response.Headers.Location) {
+        return $response.Headers.Location
+    }
+    return $null
+}
+
+function Get-VersionFromReleaseUrl {
+    param([string]$ReleaseUrl)
+
+    $prefix = "https://github.com/$Repo/releases/tag/"
+    if (-not $ReleaseUrl -or -not $ReleaseUrl.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+
+    $version = $ReleaseUrl.Substring($prefix.Length)
+    if (-not $version -or $version.Contains("/")) {
+        return $null
+    }
+    return [Uri]::UnescapeDataString($version)
+}
+
+function Get-LatestVersionFromApi {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    return $release.tag_name
 }
 
 function Get-InstallDir {
@@ -116,4 +166,6 @@ function Verify-Installation {
     }
 }
 
-Main
+if ($env:ROOTLINE_INSTALLER_TESTING -ne "1") {
+    Main
+}

--- a/install.sh
+++ b/install.sh
@@ -50,11 +50,47 @@ resolve_install_dir() {
 
 get_latest_version() {
     log "Fetching latest version..."
-    VERSION="$(fetch "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+    RELEASE_URL="$(fetch_latest_release_url 2>/dev/null || true)"
+    VERSION="$(version_from_release_url "$RELEASE_URL" || true)"
+    if [ -z "$VERSION" ]; then
+        VERSION="$(fetch_latest_version_from_api || true)"
+    fi
     if [ -z "$VERSION" ]; then
         abort "Could not determine latest version. Check https://github.com/${REPO}/releases"
     fi
     log "Latest version: $VERSION"
+}
+
+fetch_latest_release_url() {
+    LATEST_URL="https://github.com/${REPO}/releases/latest"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSIL -o /dev/null -w '%{url_effective}\n' "$LATEST_URL"
+    elif command -v wget >/dev/null 2>&1; then
+        wget --server-response --spider "$LATEST_URL" 2>&1 |
+            awk 'tolower($1) == "location:" { location=$2 } END { sub(/\r$/, "", location); print location }'
+    else
+        return 1
+    fi
+}
+
+version_from_release_url() {
+    RELEASE_PREFIX="https://github.com/${REPO}/releases/tag/"
+    case "$1" in
+        "${RELEASE_PREFIX}"*)
+            RELEASE_VERSION="${1#"$RELEASE_PREFIX"}"
+            case "$RELEASE_VERSION" in
+                ""|*/*) return 1 ;;
+                *) printf '%s\n' "$RELEASE_VERSION" ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+fetch_latest_version_from_api() {
+    fetch "https://api.github.com/repos/${REPO}/releases/latest" |
+        grep '"tag_name"' |
+        sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/'
 }
 
 download_and_install() {
@@ -149,4 +185,6 @@ abort() {
     exit 1
 }
 
-main
+if [ "${ROOTLINE_INSTALLER_TESTING:-}" != "1" ]; then
+    main
+fi

--- a/tests/installers/install-ps1-test.ps1
+++ b/tests/installers/install-ps1-test.ps1
@@ -1,0 +1,58 @@
+$ErrorActionPreference = "Stop"
+
+$env:ROOTLINE_INSTALLER_TESTING = "1"
+. (Join-Path $PSScriptRoot ".." ".." "install.ps1")
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+
+    if ($Expected -ne $Actual) {
+        throw "${Message}: expected '$Expected', got '$Actual'"
+    }
+}
+
+$script:ApiCalled = $false
+function Invoke-WebRequest {
+    [CmdletBinding()]
+    param($Uri, $Method, $MaximumRedirection, [switch]$UseBasicParsing)
+
+    return [pscustomobject]@{
+        BaseResponse = [pscustomobject]@{
+            RequestMessage = [pscustomobject]@{
+                RequestUri = [Uri]"https://github.com/pablontiv/rootline/releases/tag/v9.8.7"
+            }
+        }
+    }
+}
+function Invoke-RestMethod {
+    param($Uri)
+    $script:ApiCalled = $true
+    throw "REST fallback must not run after redirect success"
+}
+
+$version = Get-LatestVersion
+Assert-Equal "v9.8.7" $version "redirect tag"
+Assert-Equal $false $script:ApiCalled "redirect REST usage"
+
+$script:ApiCalled = $false
+function Invoke-WebRequest {
+    [CmdletBinding()]
+    param($Uri, $Method, $MaximumRedirection, [switch]$UseBasicParsing)
+
+    return [pscustomobject]@{
+        BaseResponse = [pscustomobject]@{
+            ResponseUri = [Uri]"https://github.com/pablontiv/rootline/releases"
+        }
+    }
+}
+function Invoke-RestMethod {
+    param($Uri)
+    $script:ApiCalled = $true
+    return [pscustomobject]@{ tag_name = "v7.6.5" }
+}
+
+$version = Get-LatestVersion
+Assert-Equal "v7.6.5" $version "REST fallback tag"
+Assert-Equal $true $script:ApiCalled "fallback REST usage"
+
+Write-Host "install.ps1 resolver tests passed"

--- a/tests/installers/install-sh-test.sh
+++ b/tests/installers/install-sh-test.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+mkdir -p "$TEST_TMP/bin" "$TEST_TMP/home"
+cat > "$TEST_TMP/bin/curl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    *api.github.com*)
+        : > "$TEST_API_CALLED_FILE"
+        printf '{"tag_name":"%s"}\n' "$TEST_API_VERSION"
+        ;;
+    *)
+        printf '%s\n' "$TEST_REDIRECT_URL"
+        ;;
+esac
+EOF
+chmod +x "$TEST_TMP/bin/curl"
+
+export HOME="$TEST_TMP/home"
+export PATH="$TEST_TMP/bin:$PATH"
+export ROOTLINE_INSTALLER_TESTING=1
+export TEST_API_CALLED_FILE="$TEST_TMP/api-called"
+
+# shellcheck source=../../install.sh
+. "$ROOT_DIR/install.sh"
+
+assert_equal() {
+    expected="$1"
+    actual="$2"
+    message="$3"
+    if [ "$actual" != "$expected" ]; then
+        printf 'FAIL: %s: expected %s, got %s\n' "$message" "$expected" "$actual" >&2
+        exit 1
+    fi
+}
+
+TEST_REDIRECT_URL="https://github.com/pablontiv/rootline/releases/tag/v9.8.7"
+TEST_API_VERSION="v0.0.0"
+export TEST_REDIRECT_URL TEST_API_VERSION
+rm -f "$TEST_API_CALLED_FILE"
+get_latest_version >/dev/null
+assert_equal "v9.8.7" "$VERSION" "redirect tag"
+if [ -e "$TEST_API_CALLED_FILE" ]; then
+    printf 'FAIL: redirect success called the REST fallback\n' >&2
+    exit 1
+fi
+
+TEST_REDIRECT_URL="https://github.com/pablontiv/rootline/releases"
+TEST_API_VERSION="v7.6.5"
+export TEST_REDIRECT_URL TEST_API_VERSION
+rm -f "$TEST_API_CALLED_FILE"
+get_latest_version >/dev/null
+assert_equal "v7.6.5" "$VERSION" "REST fallback tag"
+if [ ! -e "$TEST_API_CALLED_FILE" ]; then
+    printf 'FAIL: malformed redirect did not call the REST fallback\n' >&2
+    exit 1
+fi
+
+printf 'install.sh resolver tests passed\n'


### PR DESCRIPTION
## What

- Resolve the latest release through the public `/releases/latest` redirect before using the REST API fallback.
- Add deterministic offline resolver tests for POSIX shell and PowerShell, and run them across all supported OSes before release.
- Preserve the real installer error on the final smoke-test attempt instead of sleeping and continuing to a missing-binary failure.

## Related issue

Fixes #111

## Why

The public installers consumed GitHub's unauthenticated REST quota simply to discover the latest tag. Users behind corporate NAT, VPN, shared office, or CI egress could therefore receive an intermittent 403 before any release asset was downloaded.

A CI token would only hide the defect in our guard job. Redirect-first resolution fixes the actual user path; the REST request remains only as a compatibility fallback.

## How

`https://github.com/pablontiv/rootline/releases/latest` redirects to the concrete `/releases/tag/<tag>` URL without consuming the REST `core` quota. Both installers follow that redirect and validate the resulting URL before extracting the tag.

This is a non-breaking `fix`: install destinations, archive naming, CLI behavior, and checksum verification are unchanged.

Strict TDD was used because the existing post-release smoke job cannot prove a PR before merge. The new offline harness stubs network transport and covers redirect success, REST non-use, and compatibility fallback in both installer implementations.

## Verification

- [x] RED: `sh tests/installers/install-sh-test.sh` failed before the installers could be sourced safely.
- [x] GREEN: shell resolver tests pass under `sh`, `dash`, and `bash --posix`.
- [x] `sh -n install.sh tests/installers/install-sh-test.sh`
- [x] `git diff --check master`
- [x] GitHub Actions CI passed, including native Windows PowerShell and the three-OS `installer-tests` matrix.
- [x] GitHub Actions YAML parsed successfully.
- [x] Live redirect resolution returned `v6.1.0`.
- [ ] `shellcheck` / `actionlint` — unavailable locally; no result is claimed.

The native Gentle AI review executable was unavailable in this session, so no review receipt is claimed. A fresh-context verifier independently checked all six changed paths and found the candidate consistent with #111.

## Checklist

- [x] Tests pass
- [x] Code is clean
- [x] Changes are documented in the issue and PR
- [x] Linked to its issue with a closing keyword
- [x] Commit author verified as `pablontiv`
- [x] No AI attribution or co-author trailers
