### PR TITLE
ci(release): add deliberate major dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      force-bump:
+        description: Force a deliberate major release
+        required: true
+        type: choice
+        options:
+          - major
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -50,10 +58,11 @@ jobs:
   release:
     uses: pablontiv/crossbeam/.github/workflows/go-release.yml@v1
     needs: [ci, gitleaks, docs-validate, installer-tests]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     with:
       quality-gate-jobs: '["ci","gitleaks","docs-validate","installer-tests"]'
       binary-name: rootline
+      force-bump: ${{ inputs['force-bump'] }}
     permissions:
       contents: write
       id-token: write
@@ -74,7 +83,7 @@ jobs:
   # docs-validate — while it proves its value. Tracked in docs/roadmap/T012.
   installer-smoke:
     needs: [release]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,19 +105,23 @@ Format: `type(scope): description` — scope is optional. Add `!` before `:` for
 
 ### Version Strategy
 
-Standard semver, derived automatically from conventional commits by the release workflow:
+Versions are derived from conventional commits by the release workflow, with MAJOR releases reserved for an explicit maintainer decision:
 
 | Commit type | Bump |
 |---|---|
 | `fix`, `perf` | patch |
 | `feat` | minor |
-| `feat!`, `fix!` (breaking `!`) | major |
+| `feat!`, `fix!` (breaking `!`) | minor |
+
+`docs`, `test`, `refactor`, `ci`, `chore`, and `style` remain non-release-worthy. If the complete commit range since the latest tag contains only those types, the workflow produces no tag and no GitHub Release. This removes the previous contradiction where this table documented those types as `none` while CI still created a PATCH release for them.
 
 ## Release Flow
 
-Releases are fully automated via CI. On push to `master`, the `go-release` reusable workflow (from `pablontiv/crossbeam@v1`) analyzes conventional commits since the last tag, creates version tags, and triggers goreleaser to build multi-platform binaries. Smoke tests verify `--version` and `--help` before creating GitHub Releases. Version is injected at build time via `-ldflags -X main.version={{.Version}}`.
+Release-worthy pushes to `master` are automated via CI. The `go-release` reusable workflow (from `pablontiv/crossbeam@v1`) analyzes conventional commits since the latest tag, creates a PATCH or MINOR tag, and triggers goreleaser to build multi-platform binaries. A range containing only `docs`, `test`, `refactor`, `ci`, `chore`, or `style` commits stops without creating a tag or release. Smoke tests verify `--version` and `--help` before creating GitHub Releases. Version is injected at build time via `-ldflags -X main.version={{.Version}}`.
 
-No manual release steps are needed — just push to master with conventional commit messages. The Justfile contains only development recipes (`check`, `test`, `fmt`, `validate`). Release logic lives in crossbeam shared workflows.
+MAJOR releases are deliberate. Before cutting one, a maintainer must review the full commit range since the latest tag, confirm that the compatibility break warrants a MAJOR, and verify that `master` is green and points at the exact commit to release. Then run `gh workflow run ci.yml --ref master -f force-bump=major`, or dispatch the **CI** workflow from the Actions UI with `master` selected and **Force a deliberate major release** set to `major`. The dispatch runs the normal quality gates and passes `force-bump: major` to crossbeam; do not use it to compensate for malformed commit history or a failing branch.
+
+The Justfile contains only development recipes (`check`, `test`, `fmt`, `validate`). Release logic lives in crossbeam shared workflows.
 
 ## Auto-update
 


### PR DESCRIPTION
## What

- Adds a major-only `workflow_dispatch` input and forwards `force-bump: major` to the shared release workflow.
- Restricts manually dispatched releases to `refs/heads/master` while preserving automatic push releases.
- Documents the B+D policy: breaking commits bump MINOR, non-release-worthy ranges create no release, and MAJOR releases require an explicit maintainer action.

## Related issue

Owner-directed versioning policy adoption; no issue was created for this task.

## Why

Rootline is adopting the owner-selected B+D policy. Crossbeam now owns the breaking-to-MINOR and no-phantom-release defaults for all consumers, so Rootline must only provide the deliberate MAJOR escape hatch and accurate maintainer documentation.

## How

- Adds a required, single-choice `force-bump` dispatch input with `major` as the only value.
- Runs the release job for pushes or master-only manual dispatches and passes the dispatch input to `pablontiv/crossbeam@v1`.
- Keeps the dropped `breaking-bump` and `require-release-worthy-commits` inputs out of the caller.
- Updates `CLAUDE.md` with the new bump table, no-release behavior, resolved documentation contradiction, and the `gh workflow run` procedure.

## Merge order

**DRAFT: DO NOT MERGE YET.**

This PR depends on [pablontiv/crossbeam#20](https://github.com/pablontiv/crossbeam/pull/20). It must remain unmerged until that PR is merged **and** the moving `v1` tag points to a commit containing the new `force-bump` input. Merging earlier would make Rootline's release workflow fail with an unknown-input error.

## Verification

- [x] `actionlint .github/workflows/ci.yml`
- [x] Ruby YAML parse with aliases enabled
- [x] Focused B+D workflow and documentation assertions
- [x] `git diff --check`
- [x] Pre-commit hooks: gofmt check, golangci-lint, and gitleaks
- [x] Bounded review and targeted correction validation

## Checklist

- [ ] Tests pass (`go test ./... -race`) — not run; no Go code changed
- [ ] Code is clean (`go vet ./...`) — not run; no Go code changed
- [x] Changes are documented if user-facing
- [ ] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain) — deliberately unlinked because this is an owner-directed task without an issue
