### PR TITLE
ci: protect master release runs from cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   ci:


### PR DESCRIPTION
## What

- Prevent newer `master` pushes from cancelling an in-progress release workflow.
- Preserve cancellation for pull-request and other non-`master` runs.

## Related issue

Closes #116

## Why

Rootline's release workflow delegates to Crossbeam, which pushes the new tag in `auto-tag` before a separate dependent job runs GoReleaser. With unconditional `cancel-in-progress: true`, another push to `master` can cancel the first run after the tag exists but before the GitHub Release and assets are published.

This is the failure window that produced orphan tags including the now-deleted `v9.1.0`.

## How

The workflow-level concurrency policy now uses:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

GitHub Actions supports expressions in `cancel-in-progress`. The condition disables cancellation only for `master`, while superseded pull-request validation remains cancellable.

`codeql.yml` and `scorecard.yml` were inspected and left unchanged because neither publishes GitHub Releases.

The deeper structural fix belongs in Crossbeam: make tag publication the final release action instead of preceding GoReleaser. That follow-up is deliberately outside this PR.

A `ci:` commit is not release-worthy under the current release rules, so merging this PR should not create a tag.

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Bounded four-lens review approved the frozen candidate.

## Checklist

- [ ] Tests pass (`go test ./... -race`) - Not applicable; this is a workflow-only change with no Go source changes.
- [ ] Code is clean (`go vet ./...`) - Not applicable; this is a workflow-only change validated by `actionlint`.
- [x] Changes are documented if user-facing - No user-facing behavior changes; the release behavior and follow-up are documented above.
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)
