### PR TITLE
fix(autoupdate): enforce compatibility boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ The Justfile contains only development recipes (`check`, `test`, `fmt`, `validat
 
 ## Auto-update
 
-`rootline` uses `picokit/autoupdate` to check for and apply new releases automatically. On each run, it fetches the latest release in the background (goroutine + WaitGroup) and applies any staged update on the next invocation. Local builds (`version == "dev"`) skip all network and cache operations. No opt-out env var — controlled only by build-time version injection.
+`rootline` uses `picokit/autoupdate` to check for and apply new releases automatically within the running version's compatibility boundary. Stable releases update only within the same major; pre-1.0 releases update only within the same minor. A cross-boundary release is retained rather than applied, and Rootline prints a short stderr notice with the current and available versions plus deliberate reinstall guidance. On each run, Rootline fetches the latest release in the background (goroutine + WaitGroup) and applies any eligible staged update on the next invocation. Local builds (`version == "dev"`) skip all network and cache operations. There is no opt-out environment variable; the version policy is configured by Rootline.
 
 ## CI Workflows
 

--- a/cmd/rootline/autoupdate_test.go
+++ b/cmd/rootline/autoupdate_test.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/pablontiv/picokit/autoupdate"
 )
+
+type updaterStub struct {
+	applyErr error
+	fetchErr error
+}
+
+func (u updaterStub) ApplyStagedIfAvailable() error { return u.applyErr }
+
+func (u updaterStub) FetchAndStage(string) error { return u.fetchErr }
 
 func TestWiring_NewWithTwoArgs(t *testing.T) {
 	u := autoupdate.New("pablontiv/rootline", "rootline")
@@ -24,5 +36,70 @@ func TestWiring_VersionDev_NoSideEffects(t *testing.T) {
 	runWithUpdater("dev", func() { called = true })
 	if !called {
 		t.Fatal("execute was not called by runWithUpdater")
+	}
+}
+
+func TestRootlineUpdaterUsesSameMajorPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   string
+		candidate string
+		want      bool
+	}{
+		{name: "same major allowed", current: "v5.2.0", candidate: "v5.3.0", want: true},
+		{name: "cross major withheld", current: "v5.2.0", candidate: "v6.0.0", want: false},
+		{name: "same pre-one minor allowed", current: "v0.5.2", candidate: "v0.5.3", want: true},
+		{name: "cross pre-one minor withheld", current: "v0.5.2", candidate: "v0.6.0", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := newRootlineUpdater(tt.current)
+			if got := u.VersionPolicy(u.CurrentVersion, tt.candidate); got != tt.want {
+				t.Fatalf("VersionPolicy(%q, %q) = %v, want %v", u.CurrentVersion, tt.candidate, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunWithUpdaterWritesNoticeExactlyOnceOnlyWhenWithheld(t *testing.T) {
+	withheld := &autoupdate.UpdateWithheldError{
+		CurrentVersion:   "v5.2.0",
+		CandidateVersion: "v6.0.0",
+	}
+
+	tests := []struct {
+		name     string
+		updater  updaterStub
+		wantLine string
+	}{
+		{
+			name:    "no notice without withheld update",
+			updater: updaterStub{fetchErr: errors.New("network unavailable")},
+		},
+		{
+			name:     "one notice when both updater paths withhold",
+			updater:  updaterStub{applyErr: withheld, fetchErr: withheld},
+			wantLine: "rootline: incompatible update withheld: current v5.2.0, available v6.0.0; run the installer to upgrade deliberately\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			executed := false
+
+			runWithUpdaterUsing("v5.2.0", func() { executed = true }, tt.updater, &stderr)
+
+			if !executed {
+				t.Fatal("execute was not called")
+			}
+			if got := stderr.String(); got != tt.wantLine {
+				t.Fatalf("stderr = %q, want %q", got, tt.wantLine)
+			}
+			if strings.Count(stderr.String(), "incompatible update withheld") > 1 {
+				t.Fatalf("withheld notice emitted more than once: %q", stderr.String())
+			}
+		})
 	}
 }

--- a/cmd/rootline/main.go
+++ b/cmd/rootline/main.go
@@ -1,21 +1,50 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
 	"sync"
 
 	"github.com/pablontiv/picokit/autoupdate"
 )
 
-func runWithUpdater(ver string, execute func()) {
+type updateClient interface {
+	ApplyStagedIfAvailable() error
+	FetchAndStage(currentVersion string) error
+}
+
+func newRootlineUpdater(ver string) *autoupdate.Updater {
 	u := autoupdate.New("pablontiv/rootline", "rootline")
 	u.CurrentVersion = ver
-	_ = u.ApplyStagedIfAvailable()
+	u.VersionPolicy = autoupdate.SameMajorOnly
+	return u
+}
+
+func runWithUpdater(ver string, execute func()) {
+	runWithUpdaterUsing(ver, execute, newRootlineUpdater(ver), os.Stderr)
+}
+
+func runWithUpdaterUsing(ver string, execute func(), u updateClient, stderr io.Writer) {
+	var noticeOnce sync.Once
+	reportWithheld := func(err error) {
+		var withheld *autoupdate.UpdateWithheldError
+		if !errors.As(err, &withheld) {
+			return
+		}
+		noticeOnce.Do(func() {
+			_, _ = fmt.Fprintf(stderr, "rootline: incompatible update withheld: current %s, available %s; run the installer to upgrade deliberately\n", withheld.CurrentVersion, withheld.CandidateVersion)
+		})
+	}
+
+	reportWithheld(u.ApplyStagedIfAvailable())
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = u.FetchAndStage(ver)
+		reportWithheld(u.FetchAndStage(ver))
 	}()
 
 	execute()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/expr-lang/expr v1.17.8
-	github.com/pablontiv/picokit v0.5.4
+	github.com/pablontiv/picokit v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.5
 	golang.org/x/term v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/pablontiv/picokit v0.5.4 h1:8K/V6oFNvtWsQoRacMFj0QeixG5rKkUDwioSXs+IVdI=
-github.com/pablontiv/picokit v0.5.4/go.mod h1:p1hQXyqtGxMz0c2FXmkd7k2bvpdkq7p0LScW1y6guYk=
+github.com/pablontiv/picokit v1.0.0 h1:phGcVk2t8JsxJyBSmxlvnPOmcuSGKsikQR2Vm393RcY=
+github.com/pablontiv/picokit v1.0.0/go.mod h1:p1hQXyqtGxMz0c2FXmkd7k2bvpdkq7p0LScW1y6guYk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=


### PR DESCRIPTION
## What

- adopt picokit v1.0.0 and configure `autoupdate.SameMajorOnly`
- surface one concise stderr notice when an incompatible update is withheld
- cover stable and pre-1.0 compatibility boundaries and document the behavior

## Related issue

Closes #118

## Why

Rootline previously allowed the automatic updater to cross deliberate compatibility boundaries. That made a major release eligible for unattended application and gave users no explanation when a safety policy withheld an update.

## How

The updater is constructed with picokit's compatibility policy before either staged application or background fetch. Typed `UpdateWithheldError` values are reported through a shared `sync.Once`, preserving normal command execution and avoiding duplicate notices when both updater paths observe the same withheld candidate.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)
