### PR TITLE
fix(hooks): stop pre-push from installing branch builds

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -78,14 +78,3 @@ skill="rootline"
 rm -rf "${SKILLS_DEST:?}/$skill"
 cp -r "$REPO_ROOT/.claude/skills/$skill" "$SKILLS_DEST/$skill"
 echo "rootline: installed $skill skill → $SKILLS_DEST/$skill"
-
-# Rebuild the rootline binary so the installed version matches the pushed code.
-# Delegate to `just install` — the single source of truth for install destination
-# (~/.local/bin) and version scheme (<tag>+local.<sha>). Non-fatal: a failed
-# rebuild must never block the push.
-echo "Rebuilding rootline binary..."
-if command -v just >/dev/null 2>&1; then
-  ( cd "$REPO_ROOT" && just install ) || echo "Warning: just install failed (push continues)"
-else
-  echo "Warning: just not found; skipping rootline reinstall"
-fi

--- a/Justfile
+++ b/Justfile
@@ -36,8 +36,8 @@ coverage-check: coverage
 # Build and install a local development binary to ~/.local/bin
 #
 # The single canonical install destination. install.sh (the public installer)
-# defaults here too, and the post-merge / pre-push hooks delegate to this
-# recipe, so all three agree on one location and one version scheme.
+# defaults here too, and the post-merge hook delegates to this recipe. The
+# pre-push hook intentionally does not install unmerged branch builds.
 install: && doctor-install
     #!/usr/bin/env bash
     set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ go vet ./...                      # Static analysis
 golangci-lint run ./...           # Full lint
 ```
 
-Pre-commit hooks run `golangci-lint` and `gofmt` automatically. Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`), enforced by a commit-msg hook. To manually sync skills and rebuild after pulling: `bash .githooks/pre-push`.
+Pre-commit hooks run `golangci-lint` and `gofmt` automatically. Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`), enforced by a commit-msg hook. The post-merge hook syncs skills and rebuilds after pulling; pre-push keeps validation and skill synchronization without installing an unmerged branch build. Run `just install` when you explicitly want to install the current checkout.
 
 **Note**: Git workflow is contributor-only; Rootline itself does not require Git.
 

--- a/cmd/rootline/hooks_test.go
+++ b/cmd/rootline/hooks_test.go
@@ -2,10 +2,50 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestPrePushSyncsSkillWithoutInstallingBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pre-push is a Bash hook")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	testHome := t.TempDir()
+	testBin := t.TempDir()
+	installMarker := filepath.Join(testHome, "just-install-called")
+
+	justPath := filepath.Join(testBin, "just")
+	justScript := "#!/bin/sh\n: > \"$INSTALL_MARKER\"\n"
+	mustWriteFile(t, justPath, []byte(justScript), 0755)
+
+	cmd := exec.Command(filepath.Join(repoRoot, ".githooks", "pre-push"), "origin", "unused") //nolint:gosec // fixed repository hook under test
+	cmd.Dir = repoRoot
+	cmd.Stdin = strings.NewReader("")
+	cmd.Env = append(os.Environ(),
+		"HOME="+testHome,
+		"INSTALL_MARKER="+installMarker,
+		"PATH="+testBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pre-push failed: %v\n%s", err, output)
+	}
+
+	installedSkill := filepath.Join(testHome, ".claude", "skills", "rootline", "SKILL.md")
+	if _, err := os.Stat(installedSkill); err != nil {
+		t.Fatalf("expected pre-push to synchronize the rootline skill: %v", err)
+	}
+	if _, err := os.Stat(installMarker); !os.IsNotExist(err) {
+		t.Fatalf("pre-push must not invoke just install; stat error: %v", err)
+	}
+}
 
 func TestHooksInstallAndStatus(t *testing.T) {
 	// We're in a git repo, so this should work


### PR DESCRIPTION
## What

- Stop the pre-push hook from rebuilding and replacing the global `rootline` binary.
- Keep pre-push validation and skill synchronization intact.
- Add a regression test proving pre-push synchronizes the skill without invoking `just install`.

## Related issue

Closes #112

## Why

The pre-push hook ran `just install` after every push, including pushes from unmerged feature branches. That replaced `~/.local/bin/rootline` with arbitrary in-flight code and bypassed the repository's PR and release boundaries.

Those branch builds used `<highest-tag>+local.<sha>`. SemVer comparison treats that as the current release, so the auto-updater could not restore the released binary.

## How

The implicit rebuild was removed only from `.githooks/pre-push`. The hook still performs its validation gates and synchronizes the Rootline skill.

Automatic rebuilds remain in `.githooks/post-merge`, which is the correct boundary for locally receiving merged code in a PR workflow. Explicit `just install` also remains available for developers who intentionally want the current checkout installed.

The version-stamping recipe is intentionally unchanged. Its release-equivalent local version remains appropriate for explicit and post-merge development installs; removing the unsafe pre-push trigger prevents unmerged branches from receiving that sticky version implicitly.

Restricting the pre-push rebuild to pushes of `master` was rejected because PR merges occur remotely. The existing post-merge hook already covers the legitimate local update path without coupling global installation to branch publication.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)

## Verification

- `go test ./... -race`
- `just coverage-check` (89.5% total)
- fresh-cache `golangci-lint run ./...` (0 issues)
- `go vet ./...`
- `go build ./...`
- `git diff --check`
- Shellcheck with only pre-existing `SC2034` and `SC2162` findings excluded
