### PR TITLE
test(cmd): isolate staged tests from ambient index

### DIFF
--- a/cmd/rootline/coverage_boost_test.go
+++ b/cmd/rootline/coverage_boost_test.go
@@ -65,17 +65,33 @@ func TestValidateAll(t *testing.T) {
 
 // TestValidateStaged tests the validate --staged command
 func TestValidateStaged(t *testing.T) {
-	dir := setupTestDir(t)
+	dir := makeStagedRepo(t, map[string]string{
+		".stem": `version: 2
+root: true
+scope:
+  match: "*.md"
+schema:
+  title:
+    type: string
+    required: true
+`,
+		"document.md": `---
+title: Fixture
+---
+
+# Document
+`,
+	})
 	mustChdir(t, dir)
 
 	resetFlags()
 	out, err := runCmd(t, "validate", "--staged")
 	if err != nil {
-		// Expected to fail with no git repo or no staged files
-		t.Logf("validate --staged error (expected): %v", err)
+		t.Fatalf("unexpected validate --staged error: %v\noutput: %s", err, out)
 	}
-
-	_ = out
+	if !strings.Contains(out, `"path":"document.md"`) {
+		t.Fatalf("expected staged document result, got: %s", out)
+	}
 }
 
 // TestCompletionBashScript tests bash completion generation

--- a/cmd/rootline/staged_test.go
+++ b/cmd/rootline/staged_test.go
@@ -1,41 +1,81 @@
 package main
 
 import (
-	"strings"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+
+	"github.com/pablontiv/rootline/internal/gitenv"
 )
 
 func TestGetStagedFiles(t *testing.T) {
-	// This runs in a git repo, so getStagedFiles should not error
+	dir := makeStagedRepo(t, nil)
+	mustChdir(t, dir)
+
 	files, err := getStagedFiles()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Result may be empty (no staged files) — that's OK
-	_ = files
+	if len(files) != 0 {
+		t.Fatalf("expected no staged files, got: %v", files)
+	}
 }
 
 func TestGetStagedFiltersMarkdown(t *testing.T) {
-	// getStagedFiles should only return .md files
-	// We can't easily stage files in tests, but we can verify
-	// the function doesn't crash
+	dir := makeStagedRepo(t, map[string]string{
+		"document.md": "# Document\n",
+		"notes.txt":   "not markdown\n",
+	})
+	mustChdir(t, dir)
+
 	files, err := getStagedFiles()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, f := range files {
-		if !strings.HasSuffix(f, ".md") {
-			t.Errorf("expected only .md files, got: %s", f)
-		}
+	if len(files) != 1 || files[0] != "document.md" {
+		t.Fatalf("expected only document.md, got: %v", files)
 	}
 }
 
 func TestValidateStagedNoFiles(t *testing.T) {
-	// With nothing staged, --staged should return exit code 0
+	dir := makeStagedRepo(t, nil)
+	mustChdir(t, dir)
+
 	out, err := runCmd(t, "validate", "--staged", "--all")
 	if err != nil {
 		t.Fatalf("expected no error with empty staging area, got: %v", err)
 	}
-	// Output should be empty (nothing to validate)
-	_ = out
+	if out != "" {
+		t.Fatalf("expected empty output, got: %s", out)
+	}
+}
+
+func makeStagedRepo(t *testing.T, stagedFiles map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runFixtureGit(t, dir, "init", "--quiet")
+
+	for path, content := range stagedFiles {
+		fullPath := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write fixture file: %v", err)
+		}
+		runFixtureGit(t, dir, "add", "--", path)
+	}
+
+	return dir
+}
+
+func runFixtureGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...) //nolint:gosec
+	cmd.Dir = dir
+	cmd.Env = gitenv.ClearedEnv()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
 }


### PR DESCRIPTION
## What

- Give staged-file tests temporary Git repositories with indexes they fully control.
- Strengthen staged validation assertions so they prove controlled fixture behavior.

## Related issue

Closes #103

## Why

The staged-file tests previously resolved Git state from the developer's checkout. Their results therefore depended on unrelated staged changes and could pass without exercising any staged files.

## How

The shared test helper initializes repositories under `t.TempDir()`, runs fixture Git commands with `internal/gitenv.ClearedEnv()`, and stages only test-authored paths. Production behavior in `hooks.go` and `validate.go` remains unchanged.

Verification:

- `go test ./... -race`
- `go vet ./...`
- The same compiled `cmd/rootline` test binary passed from a clean throwaway repository and again with an unrelated Markdown file staged; the real worktree index hash did not change.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing (not user-facing)
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)
