### PR TITLE
fix(fsx): replace bare os.WriteFile with atomic staged replacement

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -28,6 +28,9 @@ Schema discovery walks up from the target collecting `.stem` files and stops at 
 - Governed commands (`validate`, `fix`, `query`, `tree`, `graph`, `describe`, `explain`, `set`, `stats`) fail on a tree with no `.stem` or an unparseable one. Without a terminal they exit non-zero; the error names the exact one-line fix.
 - If a governed command reports "Schema discovery reached the filesystem root without finding a declared boundary", the fix is to add `root: true` to the project's top-level `.stem` (one line). Then retry. Do **not** use `init --force` to migrate an existing project — it re-infers and overwrites the schema.
 - `rootline init` writes `root: true` for new projects, so they never hit this.
+- `init`, template installation, and write-producing `migrate` modes replace each
+  generated file atomically. This is a per-file guarantee, not rollback for an
+  entire multi-file run.
 - Bootstrap commands (`schema propose`, `analyze`) work without any `.stem` — they derive one. `init` and `migrate` also run without a marker.
 
 ## Deterministic Execution Rules

--- a/cmd/rootline/init.go
+++ b/cmd/rootline/init.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/fsx"
 	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/infer"
 	"github.com/pablontiv/rootline/internal/rules"
@@ -127,7 +128,7 @@ func runInitFlat(cmd *cobra.Command, absTarget, target string, records []*extrac
 		return nil
 	}
 
-	if err := os.WriteFile(stemPath, []byte(yaml), 0644); err != nil {
+	if err := fsx.WriteFileAtomic(stemPath, []byte(yaml), 0o644); err != nil {
 		return fmt.Errorf("writing .stem: %w", err)
 	}
 
@@ -198,7 +199,7 @@ func runInitHierarchical(cmd *cobra.Command, absTarget, target string, hierarchy
 
 	// Write all .stem files.
 	for _, sf := range stemFiles {
-		if err := os.WriteFile(sf.path, []byte(sf.content), 0644); err != nil {
+		if err := fsx.WriteFileAtomic(sf.path, []byte(sf.content), 0o644); err != nil {
 			return fmt.Errorf("writing %s: %w", sf.path, err)
 		}
 	}

--- a/cmd/rootline/migrate.go
+++ b/cmd/rootline/migrate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/fsx"
 	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/infer"
 	"github.com/pablontiv/rootline/internal/migrate"
@@ -466,7 +467,7 @@ func runMigrateSplit(cmd *cobra.Command, args []string) error {
 
 	// Write all .stem files.
 	for _, sf := range result.Stems {
-		if writeErr := os.WriteFile(sf.Path, []byte(sf.Content), 0644); writeErr != nil {
+		if writeErr := fsx.WriteFileAtomic(sf.Path, []byte(sf.Content), 0o644); writeErr != nil {
 			return fmt.Errorf("writing %s: %w", sf.Path, writeErr)
 		}
 	}

--- a/docs/init.md
+++ b/docs/init.md
@@ -13,6 +13,11 @@ rootline init --dry-run docs/                     # Preview without writing
 rootline init --force docs/api/                   # Overwrite existing .stem
 ```
 
+Writes are atomic per file: Rootline stages each generated or template `.stem`
+beside its destination and replaces the destination only after the complete
+content is flushed. A multi-file template or hierarchical initialization is not
+a transaction; files completed before a later error remain installed.
+
 ### Flags
 
 | Flag | Description |

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -107,13 +107,18 @@ the shape you get from `rootline migrate docs --dry-run -o json`:
 
 ## Rename Mode
 
-`--rename` updates a field name across all documents and `.stem` files atomically:
+`--rename` updates a field name across all documents and `.stem` files:
 
 ```bash
 rootline migrate --rename status=estado
 ```
 
 Updates frontmatter in all affected markdown files and schema definitions in `.stem` files. Operations are logged to `.migration-log.json` (JSON Lines, append-only).
+
+Each generated document or `.stem` is replaced atomically from a sibling staging
+file, so a failed write cannot leave that destination truncated. Migration runs
+are still best-effort rather than transactional: files completed before a later
+error are not rolled back.
 
 ## Split Mode
 

--- a/internal/fsx/atomic.go
+++ b/internal/fsx/atomic.go
@@ -1,0 +1,86 @@
+// Package fsx provides shared filesystem operations with explicit durability
+// guarantees.
+package fsx
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const tempFilePrefix = ".rootline-"
+
+// WriteFileAtomic replaces target only after all content has been written to a
+// sibling staging file. The caller-provided mode is applied before replacement.
+func WriteFileAtomic(target string, content []byte, perm fs.FileMode) error {
+	return writeFileAtomic(target, perm, func(dst io.Writer) error {
+		_, err := dst.Write(content)
+		return err
+	})
+}
+
+// CopyFileAtomic streams src into a sibling staging file and replaces target
+// only after the copy is complete. The source permission bits are preserved.
+func CopyFileAtomic(src, target string) (retErr error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", src, err)
+	}
+	defer func() {
+		if err := in.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing %s: %w", src, err)
+		}
+	}()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stating %s: %w", src, err)
+	}
+
+	return writeFileAtomic(target, info.Mode().Perm(), func(dst io.Writer) error {
+		_, err := io.Copy(dst, in)
+		return err
+	})
+}
+
+func writeFileAtomic(target string, perm fs.FileMode, write func(io.Writer) error) error {
+	dir := filepath.Dir(target)
+	if info, err := os.Stat(target); err == nil {
+		perm = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stating %s: %w", target, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, tempFilePrefix+"*.tmp")
+	if err != nil {
+		return fmt.Errorf("staging a write for %s: %w", target, err)
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := write(tmp); err != nil {
+		return fmt.Errorf("writing staged content for %s: %w", target, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("flushing staged content for %s: %w", target, err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		return fmt.Errorf("setting mode on staged content for %s: %w", target, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing staged content for %s: %w", target, err)
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		return fmt.Errorf("replacing %s: %w", target, err)
+	}
+	committed = true
+	return nil
+}

--- a/internal/fsx/atomic_test.go
+++ b/internal/fsx/atomic_test.go
@@ -1,0 +1,188 @@
+package fsx
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteFileAtomicLeavesOriginalIntactAfterPartialWrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".stem")
+	if err := os.WriteFile(target, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	wantErr := errors.New("injected short write")
+	err := writeFileAtomic(target, 0o644, func(dst io.Writer) error {
+		if _, err := io.WriteString(dst, "partial"); err != nil {
+			return err
+		}
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("writeFileAtomic error = %v, want %v", err, wantErr)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("target content = %q, want original content", got)
+	}
+	assertNoStagingFiles(t, dir)
+}
+
+func TestWriteFileAtomicReplacesContentAndPreservesExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".stem")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	if err := WriteFileAtomic(target, []byte("new\n"), 0o640); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "new\n" {
+		t.Fatalf("target content = %q, want %q", got, "new\n")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("target mode = %o, want existing mode 600", got)
+	}
+	assertNoStagingFiles(t, dir)
+}
+
+func TestWriteFileAtomicCreatesFileWithRequestedMode(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".stem")
+	if err := WriteFileAtomic(target, []byte("new\n"), 0o640); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("target mode = %o, want requested mode 640", got)
+	}
+}
+
+func TestWriteFileAtomicCleansUpWhenRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("create target directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "keep"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed target directory: %v", err)
+	}
+	if err := WriteFileAtomic(target, []byte("new"), 0o644); err == nil {
+		t.Fatal("WriteFileAtomic succeeded replacing a non-empty directory")
+	}
+	assertNoStagingFiles(t, dir)
+}
+
+func TestWriteFileAtomicRejectsMissingParent(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteFileAtomic(filepath.Join(dir, "missing", ".stem"), []byte("new"), 0o644); err == nil {
+		t.Fatal("WriteFileAtomic succeeded with a missing parent directory")
+	}
+}
+
+func TestCopyFileAtomicStreamsContentAndPreservesExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.stem")
+	target := filepath.Join(dir, ".stem")
+	content := strings.Repeat("schema:\n", 4096)
+	if err := os.WriteFile(src, []byte(content), 0o640); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	if err := CopyFileAtomic(src, target); err != nil {
+		t.Fatalf("CopyFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != content {
+		t.Fatal("copied content differs from source")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("target mode = %o, want existing mode 600", got)
+	}
+	assertNoStagingFiles(t, dir)
+}
+
+func TestCopyFileAtomicCreatesFileWithSourceMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source.stem")
+	target := filepath.Join(dir, ".stem")
+	if err := os.WriteFile(src, []byte("schema:\n"), 0o640); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := CopyFileAtomic(src, target); err != nil {
+		t.Fatalf("CopyFileAtomic: %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("target mode = %o, want source mode 640", got)
+	}
+}
+
+func TestCopyFileAtomicLeavesDestinationUntouchedWhenSourceCannotOpen(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, ".stem")
+	if err := os.WriteFile(target, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	if err := CopyFileAtomic(filepath.Join(dir, "missing.stem"), target); err == nil {
+		t.Fatal("CopyFileAtomic succeeded with a missing source")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "original\n" {
+		t.Fatalf("target content = %q, want original content", got)
+	}
+	assertNoStagingFiles(t, dir)
+}
+
+func assertNoStagingFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read directory: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), tempFilePrefix) {
+			t.Errorf("staging file left behind: %s", entry.Name())
+		}
+	}
+}

--- a/internal/migrate/rename.go
+++ b/internal/migrate/rename.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/fsx"
 	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/rules"
 	"gopkg.in/yaml.v3"
@@ -156,7 +157,7 @@ func renameFieldInFile(absPath, oldField, newField string) error {
 		return nil
 	}
 
-	return os.WriteFile(absPath, []byte(newContent), 0644) //nolint:gosec // migrate intentionally rewrites validated repository documents
+	return fsx.WriteFileAtomic(absPath, []byte(newContent), 0o644)
 }
 
 // renameFrontmatterField renames a key in the YAML frontmatter of a markdown string.
@@ -297,7 +298,7 @@ func renameFieldInStem(stemPath, oldField, newField string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(stemPath, out, 0644)
+	return fsx.WriteFileAtomic(stemPath, out, 0o644)
 }
 
 // renameSchemaKey renames a key under the "schema" mapping in a YAML AST node.

--- a/internal/migrate/scaffold.go
+++ b/internal/migrate/scaffold.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pablontiv/rootline/internal/extract"
+	"github.com/pablontiv/rootline/internal/fsx"
 	"github.com/pablontiv/rootline/internal/index"
 	"github.com/pablontiv/rootline/internal/rules"
 )
@@ -198,5 +199,5 @@ func appendSections(absPath string, candidates []sectionCandidate) error {
 		sb.WriteString("\n")
 	}
 
-	return os.WriteFile(absPath, []byte(sb.String()), 0644)
+	return fsx.WriteFileAtomic(absPath, []byte(sb.String()), 0o644)
 }

--- a/internal/templates/fetch.go
+++ b/internal/templates/fetch.go
@@ -3,13 +3,13 @@ package templates
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/pablontiv/rootline/internal/fsx"
 	"github.com/pablontiv/rootline/internal/gitenv"
 	"gopkg.in/yaml.v3"
 )
@@ -168,30 +168,7 @@ func FetchTemplate(ref, dest string, force, dryRun bool) ([]string, error) {
 	return FetchFromURL(url, tag, dest, force, dryRun)
 }
 
-// copyFile copies src to dst, creating or truncating dst.
-func copyFile(src, dst string) (retErr error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := in.Close(); err != nil && retErr == nil {
-			retErr = err
-		}
-	}()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := out.Close(); err != nil && retErr == nil {
-			retErr = err
-		}
-	}()
-
-	if _, err := io.Copy(out, in); err != nil {
-		return err
-	}
-	return nil
+// copyFile atomically copies src to dst without exposing partial content.
+func copyFile(src, dst string) error {
+	return fsx.CopyFileAtomic(src, dst)
 }


### PR DESCRIPTION
## Summary

- add a shared sibling-temp-file atomic write and copy utility
- convert init, migrate, scaffold, rename, and template writes to atomic replacement
- preserve existing destination permissions and document the per-file atomicity boundary

## Changes

| File | Change |
|------|--------|
| `internal/fsx/atomic.go` | Adds atomic write/copy helpers with flush, mode preservation, rename, and cleanup |
| `cmd/rootline/init.go`, `cmd/rootline/migrate.go` | Uses atomic replacement for generated `.stem` files |
| `internal/migrate/`, `internal/templates/` | Uses the shared helper for generated documents and template copies |
| `docs/`, `.claude/skills/rootline/` | Documents per-file atomicity and its non-transactional boundary |

## Test Plan

- [x] `just test`
- [x] `just check`
- [x] `just coverage-check` (`TOTAL: 89.5%`; `internal/fsx: 85.4%`)
- [x] Deterministic partial-write test proves the original destination remains intact

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts changed
- [x] Rootline skill synchronized
- [x] Docs updated for changed behavior
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

Fixes #106
