### PR TITLE
ci: run the CI workflow on pull requests with any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  pull_request: {}
   workflow_dispatch:
     inputs:
       force-bump:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 
 ### Changed
 
+- CI now runs for feature-based and stacked pull requests, while preserving the existing push and release safeguards
 - License changed from PolyForm Noncommercial 1.0.0 to Apache License 2.0 — commercial use is now permitted
 - picokit dependency bumped to its Apache-2.0-relicensed release, so distributed binaries no longer embed noncommercially licensed code
 - **BREAKING**: Schema discovery no longer uses `.git` directory as a boundary. Projects must now declare a root marker by adding `root: true` to the project's top-level `.stem` file. Existing projects without a root marker will receive a clear error message with the fix.


### PR DESCRIPTION
PRs whose base is a feature branch received zero CI checks because .github/workflows/ci.yml filtered pull_request on branches [main, master]. Observed on PR #127: mergeStateStatus CLEAN with statusCheckRollup length 0 and no workflow runs on the branch, which is visually identical to a fully passing PR. This drops the pull_request branch filter so every PR base receives checks, and leaves the push trigger scoped to [main, master] so no feature branch can reach the release or installer-smoke path. Closes #130.