### PR TITLE
fix(graph): trust indexed basename resolution

### DIFF
--- a/cmd/rootline/graph.go
+++ b/cmd/rootline/graph.go
@@ -245,7 +245,7 @@ func collectLinkCheckIssues(records []*extract.Record, root string) ([]linkCheck
 			continue
 		}
 		for _, e := range rules.CheckLinks(rec.Links, effective.Links, absPath, root, cache) {
-			if e.Rule == "link_resolve" {
+			if e.Rule == "link_resolve" || e.Rule == "link_unverifiable" {
 				continue
 			}
 			issues = append(issues, linkCheckIssue{path: rec.Path, rule: e.Rule, message: e.Message})

--- a/cmd/rootline/graph_checks_test.go
+++ b/cmd/rootline/graph_checks_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+func writeGraphCheckFixtureFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // graph --check used to report only cycles and broken links, so a green run
 // proved nothing about anchors or encoding even when the schema asked for
 // those checks — validate was the only command that could see them
@@ -62,5 +73,72 @@ func TestGraphCheckWithoutChecksStaysQuiet(t *testing.T) {
 	out, err := runCmd(t, "graph", dir, "--check")
 	if err != nil {
 		t.Errorf("expected clean run without declared checks, got %v:\n%s", err, out)
+	}
+}
+
+func TestGraphCheck_BasenameFallbackUniqueLinkDoesNotReportUnverifiable(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphCheckFixtureFile(t, dir, ".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  styles: [wikilink]\n  basename_fallback: true\n  checks:\n    resolve: true\n")
+	writeGraphCheckFixtureFile(t, dir, "source.md", "---\ntitle: Source\n---\n\n# Source\n\n[[target]]\n")
+	writeGraphCheckFixtureFile(t, dir, "docs/target.md", "---\ntitle: Target\n---\n\n# Target\n")
+
+	out, err := runCmd(t, "graph", "--check", dir)
+	if err != nil {
+		t.Fatalf("expected clean check for uniquely resolvable basename target, got: %v\noutput: %s", err, out)
+	}
+	if strings.Contains(out, "Link check failures:") {
+		t.Fatalf("unexpected duplicate link-check failures for basename fallback success:\n%s", out)
+	}
+	if strings.Contains(out, "link_unverifiable") {
+		t.Fatalf("unexpected link_unverifiable for basename fallback success:\n%s", out)
+	}
+	if !strings.Contains(out, "No cycles or broken links found.") {
+		t.Fatalf("expected clean summary, got:\n%s", out)
+	}
+}
+
+func TestGraphCheck_BasenameFallbackBrokenLinksAreNotDuplicated(t *testing.T) {
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "missing target",
+			files: map[string]string{
+				"source.md": "---\ntitle: Source\n---\n\n# Source\n\n[[missing-target]]\n",
+			},
+		},
+		{
+			name: "ambiguous basename",
+			files: map[string]string{
+				"source.md":        "---\ntitle: Source\n---\n\n# Source\n\n[[target]]\n",
+				"first/target.md":  "---\ntitle: First\n---\n\n# First\n",
+				"second/target.md": "---\ntitle: Second\n---\n\n# Second\n",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeGraphCheckFixtureFile(t, dir, ".stem", "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  styles: [wikilink]\n  basename_fallback: true\n  checks:\n    resolve: true\n")
+			for rel, content := range tc.files {
+				writeGraphCheckFixtureFile(t, dir, rel, content)
+			}
+
+			out, err := runCmd(t, "graph", "--check", dir)
+			if err != ErrValidationFailed {
+				t.Fatalf("expected ErrValidationFailed for unresolved target, got %v\noutput: %s", err, out)
+			}
+			if !strings.Contains(out, "Broken links: 1") {
+				t.Fatalf("expected exactly one broken link report, got:\n%s", out)
+			}
+			if strings.Contains(out, "Link check failures:") {
+				t.Fatalf("broken link must not be duplicated as a link-check failure:\n%s", out)
+			}
+			if strings.Contains(out, "link_unverifiable") {
+				t.Fatalf("broken link must not be duplicated as link_unverifiable:\n%s", out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Make `graph --check` discard the per-record `link_unverifiable` resolution verdict, just as it already discards `link_resolve`. Add real CLI regression coverage for unique, missing, and ambiguous basename-fallback targets.

## Related issue

Closes #147

## Why

`graph --check` owns a full-tree index, but `collectLinkCheckIssues` was retaining the no-index checker's `link_unverifiable` warning. A uniquely resolvable basename link therefore failed even after `PrepareLinks` and `BrokenLinks` had resolved it.

## How

- Filter `link_unverifiable` alongside `link_resolve` in `collectLinkCheckIssues`.
- Keep `PrepareLinks` plus `BrokenLinks` as the sole resolution authority.
- Preserve `link_anchor` and `link_encoding` findings and the single-file validate warning.
- Verify missing and ambiguous fallbacks appear only under `Broken links`.

### TDD evidence

RED:

```text
go test ./cmd/rootline -run TestGraphCheck_BasenameFallbackUniqueLinkDoesNotReportUnverifiable -count=1
--- FAIL: TestGraphCheck_BasenameFallbackUniqueLinkDoesNotReportUnverifiable
output: Link check failures: 1 ... (link_unverifiable)
FAIL
```

GREEN:

```text
go test ./cmd/rootline -run TestGraphCheck_BasenameFallbackUniqueLinkDoesNotReportUnverifiable -count=1
ok github.com/pablontiv/rootline/cmd/rootline
```

### Acceptance evidence

Original three-file reproduction after the fix:

```text
rootline graph --check <fixture>
No cycles or broken links found.
exit=0
```

Additional gates:

```text
go test ./cmd/rootline -run '<targeted graph and validate tests>' -count=1
ok github.com/pablontiv/rootline/cmd/rootline

just check
0 issues.

go test ./... -race
ok (all 16 packages)

go vet ./...
(exit 0)
```

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing (not applicable; bounded defect fix, no docs changed)
- [x] Linked to its issue with a closing keyword
