### PR TITLE
fix(rules): report unknown link rule keys

### DIFF
--- a/cmd/rootline/validate_envelope_test.go
+++ b/cmd/rootline/validate_envelope_test.go
@@ -289,6 +289,66 @@ func TestValidateAll_CorruptStemStillEmitsEnvelope(t *testing.T) {
 	}
 }
 
+func TestValidateAll_UnknownLinkRuleKeysWarningStrictness(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem": "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nlinks:\n  blocks:\n    target: \"../tasks/*.md\"\n    targte: \"../tasks/*.md\"\n",
+		"a.md":  "---\ntitle: A\n---\n# A\n",
+	})
+	mustChdir(t, root)
+
+	normalOut, normalErr := executeValidate(t, "--all")
+	if normalErr != nil {
+		t.Fatalf("normal validate must not fail on warning-only unknown-link-rule-keys: %v\noutput: %s", normalErr, normalOut)
+	}
+	normalEnv := decodeEnvelope(t, normalOut)
+	if got := normalEnv["summary"].(map[string]any)["invalid"].(float64); got != 0 {
+		t.Fatalf("normal invalid count = %v, want 0; output: %s", got, normalOut)
+	}
+
+	foundNormal := false
+	for _, h := range stemHealthChecks(t, normalEnv) {
+		if h["check"] != "unknown-link-rule-keys" {
+			continue
+		}
+		foundNormal = true
+		if h["field"] != "targte" {
+			t.Errorf("normal unknown-link-rule-keys field = %v, want targte", h["field"])
+		}
+		if h["severity"] != "warn" {
+			t.Errorf("normal unknown-link-rule-keys severity = %v, want warn", h["severity"])
+		}
+		msg := h["message"].(string)
+		if !strings.Contains(msg, "links.blocks") {
+			t.Errorf("normal unknown-link-rule-keys message = %q, want links.blocks context", msg)
+		}
+		if !strings.Contains(msg, `did you mean "target"?`) {
+			t.Errorf("normal unknown-link-rule-keys message = %q, want fuzzy suggestion", msg)
+		}
+	}
+	if !foundNormal {
+		t.Fatalf("normal validate missing unknown-link-rule-keys warning: %v", normalEnv["stem_health"])
+	}
+
+	strictOut, strictErr := executeValidate(t, "--all", "--strict")
+	if strictErr != ErrValidationFailed {
+		t.Fatalf("--strict err = %v, want ErrValidationFailed\noutput: %s", strictErr, strictOut)
+	}
+	strictEnv := decodeEnvelope(t, strictOut)
+	if got := strictEnv["summary"].(map[string]any)["invalid"].(float64); got != 0 {
+		t.Fatalf("strict invalid count = %v, want 0; output: %s", got, strictOut)
+	}
+
+	foundStrict := false
+	for _, h := range stemHealthChecks(t, strictEnv) {
+		if h["check"] == "unknown-link-rule-keys" {
+			foundStrict = true
+		}
+	}
+	if !foundStrict {
+		t.Fatalf("strict validate missing unknown-link-rule-keys warning: %v", strictEnv["stem_health"])
+	}
+}
+
 func hasNotice(t *testing.T, env map[string]any, code string) bool {
 	t.Helper()
 	notices, ok := env["notices"].([]any)

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -72,6 +72,10 @@ type LinkSchema struct {
 	// UnknownCheckKeys lists keys found under links.checks that no check
 	// consumes. Diagnostic only — surfaced by stem health, never serialized.
 	UnknownCheckKeys []string `json:"-"`
+
+	// UnknownRuleKeys lists unknown keys found under links.<type> rules.
+	// Diagnostic only — surfaced by stem health, never serialized.
+	UnknownRuleKeys []UnknownLinkRuleKey `json:"-"`
 }
 
 // LinkChecks enables filesystem-backed link checks (ADO code-wiki conventions).
@@ -100,6 +104,10 @@ func (ls LinkSchema) ShouldResolve() bool {
 // struct fields.
 var knownCheckKeys = []string{"resolve", "anchors", "encoding", "cycles"}
 
+// knownLinkRuleKeys lists the keys LinkRule consumes; keep in sync with its
+// struct fields.
+var knownLinkRuleKeys = []string{"target", "field", "value_field"}
+
 // EffectiveStyles returns the link styles governed by this schema.
 // An empty declaration defaults to wikilink-only for backward compatibility.
 func (ls LinkSchema) EffectiveStyles() []string {
@@ -114,6 +122,12 @@ type LinkRule struct {
 	Target     string `yaml:"target" json:"target,omitempty"`
 	Field      string `yaml:"field" json:"field,omitempty"`
 	ValueField string `yaml:"value_field" json:"value_field,omitempty"`
+}
+
+// UnknownLinkRuleKey identifies one unknown key under links.<type>.
+type UnknownLinkRuleKey struct {
+	RuleType string
+	Key      string
 }
 
 // UnmarshalYAML implements custom unmarshaling for LinkSchema.
@@ -167,6 +181,15 @@ func (ls *LinkSchema) UnmarshalYAML(value *yaml.Node) error {
 				}
 			}
 			continue
+		}
+
+		if val.Kind == yaml.MappingNode {
+			for j := 0; j+1 < len(val.Content); j += 2 {
+				ruleKey := val.Content[j].Value
+				if !slices.Contains(knownLinkRuleKeys, ruleKey) {
+					ls.UnknownRuleKeys = append(ls.UnknownRuleKeys, UnknownLinkRuleKey{RuleType: key, Key: ruleKey})
+				}
+			}
 		}
 
 		var rule LinkRule

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -735,5 +736,56 @@ links:
 	}
 	if len(stem.Links.UnknownCheckKeys) != 0 {
 		t.Errorf("UnknownCheckKeys = %v, want empty", stem.Links.UnknownCheckKeys)
+	}
+}
+
+func TestLinkSchema_UnknownRuleKeysCapturedOrderedAndExcludingValidKeys(t *testing.T) {
+	src := `
+links:
+  blocks:
+    target: "../tasks/*.md"
+    targte: "../tasks/*.md"
+    field: blocked_by
+    valeu_field: blocked_by
+    value_field: blocked_by
+    custom: true
+  references:
+    field: refs
+    feld: refs
+`
+	var stem StemFile
+	if err := yaml.Unmarshal([]byte(src), &stem); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	meta := reflect.ValueOf(stem.Links).FieldByName("UnknownRuleKeys")
+	if !meta.IsValid() {
+		t.Fatal("LinkSchema must capture ordered unknown keys for links.<type> rules")
+	}
+
+	got := make([]string, 0, meta.Len())
+	for i := 0; i < meta.Len(); i++ {
+		entry := meta.Index(i)
+		ruleType := entry.FieldByName("RuleType")
+		key := entry.FieldByName("Key")
+		if !ruleType.IsValid() || !key.IsValid() {
+			t.Fatalf("unknown rule key metadata entry %d must expose RuleType and Key fields", i)
+		}
+		got = append(got, ruleType.String()+"."+key.String())
+	}
+
+	want := []string{
+		"blocks.targte",
+		"blocks.valeu_field",
+		"blocks.custom",
+		"references.feld",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("unknown rule key metadata length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unknown rule key metadata[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
 	}
 }

--- a/internal/rules/stemhealth.go
+++ b/internal/rules/stemhealth.go
@@ -17,6 +17,8 @@ const (
 	SeverityError = "error"
 	SeverityWarn  = "warn"
 	SeverityInfo  = "info"
+
+	unknownLinkRuleKeysCheckName = "unknown-link-rule-keys"
 )
 
 // StemHealthCheck represents a single stem-health diagnostic result.
@@ -418,7 +420,25 @@ func EvaluateStemState(ctx context.Context, state *StemState) (*StemHealthResult
 		}
 	}
 
-	// Check 12: nested-root-marker (INFO level)
+	// Check 12: unknown keys under links.<type> rules (silently inert otherwise)
+	for _, sf := range sortedStemPaths(parsedStems) {
+		stem := parsedStems[sf]
+		for _, unknown := range stem.Links.UnknownRuleKeys {
+			msg := fmt.Sprintf("unknown key %q in links.%s", unknown.Key, unknown.RuleType)
+			if match := fuzzy.Match(unknown.Key, knownLinkRuleKeys); match != "" {
+				msg += fmt.Sprintf(" (did you mean %q?)", match)
+			}
+			checks = append(checks, StemHealthCheck{
+				Name:    unknownLinkRuleKeysCheckName,
+				Status:  "warn",
+				Message: msg,
+				Path:    stemHealthRelPath(absRoot, sf),
+				Field:   unknown.Key,
+			})
+		}
+	}
+
+	// Check 13: nested-root-marker (INFO level)
 	// Detect when a directory declares root: true and has an ancestor also with root: true
 	for _, sf := range sortedStemPaths(parsedStems) {
 		stem := parsedStems[sf]

--- a/internal/rules/stemhealth_test.go
+++ b/internal/rules/stemhealth_test.go
@@ -967,6 +967,56 @@ links:
 	}
 }
 
+func TestValidateStemHealth_UnknownLinkRuleKeys(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteStemTestFile(t, filepath.Join(dir, ".stem"), []byte(`version: 2
+links:
+  blocks:
+    target: "../tasks/*.md"
+    targte: "../tasks/*.md"
+    field: blocked_by
+    valeu_field: blocked_by
+    value_field: blocked_by
+`))
+
+	result, err := ValidateStemHealth(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := map[string]StemHealthCheck{}
+	for _, c := range result.Checks {
+		if c.Name == "unknown-link-rule-keys" {
+			found[c.Field] = c
+		}
+		if c.Name == "unknown-link-rule-keys" && (c.Field == "target" || c.Field == "field" || c.Field == "value_field") {
+			t.Fatalf("valid link rule key unexpectedly reported as unknown: %+v", c)
+		}
+	}
+
+	if len(found) != 2 {
+		t.Fatalf("unknown-link-rule-keys count = %d, want 2; checks=%+v", len(found), result.Checks)
+	}
+
+	targte, ok := found["targte"]
+	if !ok {
+		t.Fatalf("missing unknown-link-rule-keys diagnostic for targte: %+v", found)
+	}
+	if targte.Status != "warn" {
+		t.Errorf("targte status = %q, want warn", targte.Status)
+	}
+	if !strings.Contains(targte.Message, `links.blocks`) {
+		t.Errorf("targte message = %q, want links.blocks context", targte.Message)
+	}
+	if !strings.Contains(targte.Message, `did you mean "target"?`) {
+		t.Errorf("targte message = %q, want target suggestion", targte.Message)
+	}
+
+	if got := found["valeu_field"].Message; !strings.Contains(got, `links.blocks`) {
+		t.Errorf("valeu_field message = %q, want links.blocks context", got)
+	}
+}
+
 // Slice 2: Nested-root-marker health check
 func TestValidateStemHealth_NestedRootMarker(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## What

Report unknown keys inside each `links.<type>` rule as ordered stem-health warnings instead of silently discarding them.

## Related issue

Closes #174

## Why

`yaml.Node.Decode` is non-strict. Misspellings such as `targett` or `feild` were dropped while decoding `LinkRule`, which could silently disable intended governance constraints and leave validation green.

## How

- Capture unknown mapping keys during `LinkSchema.UnmarshalYAML`, excluding `target`, `field`, and `value_field`.
- Keep the captured metadata parser-internal (`json:"-"`) and outside `IsEmpty`, describe, and merge behavior.
- Emit `unknown-link-rule-keys` stem-health warnings with the unknown key as `field`, `links.<type>` context, and fuzzy suggestions.
- Add parser, stem-health, and CLI acceptance regressions for normal and strict mode.

## Reproduction / acceptance

Built the current CLI and validated temporary corpora:

```text
warning-only typo corpus:
  rootline validate --all <dir>          exit 0
  rootline validate --all <dir> --strict exit 1
  targett -> did you mean "target"?
  feild   -> did you mean "field"?

valid target plus adjacent typo:
  rootline validate --all <dir>          exit 1
  link_target error remains enforced
  unknown-link-rule-keys warning is also emitted
```

## TDD evidence

RED before production changes:

```text
go test ./internal/rules -run 'TestLinkSchema_UnknownRuleKeysCapturedOrderedAndExcludingValidKeys|TestValidateStemHealth_UnknownLinkRuleKeys' -count=1
FAIL: LinkSchema must capture ordered unknown keys for links.<type> rules
FAIL: unknown-link-rule-keys count = 0, want 2

go test ./cmd/rootline -run TestValidateAll_UnknownLinkRuleKeysWarningStrictness -count=1
FAIL: normal validate missing unknown-link-rule-keys warning: []
```

GREEN and final verification:

```text
go test ./internal/rules -run 'TestLinkSchema_UnknownRuleKeysCapturedOrderedAndExcludingValidKeys|TestValidateStemHealth_UnknownLinkRuleKeys|TestStemHealthDocumentationDrift|TestMergeLinkSchema_|TestLinkSchema_UnmarshalStylesAndChecks|TestLinkSchema_UnknownCheckKeysCaptured|TestLinkSchema_KnownCheckKeysNotCaptured' -count=1
ok

go test ./cmd/rootline -run 'TestValidateAll_UnknownLinkRuleKeysWarningStrictness|TestValidateStrict_NestedRootMarkerDoesNotFail|TestValidateAll_StemHealthSeparatedFromRecords' -count=1
ok

just check
0 issues; build passed

just test
go test ./... -race: all packages passed
```

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`just check`)
- [x] Documentation changes are deliberately out of scope for this defect
- [x] Linked to its issue with a closing keyword
