### PR TITLE
docs: reconcile active references with shipped contracts

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -117,7 +117,7 @@ rootline validate --all <dir> -o json
 
 ### Validate and Query Markdown Links (multi-style)
 
-Link extraction always parses both `[[wiki-links]]` and markdown links `[text](target)`. Each link carries `style` (`wikilink`/`markdown`) and optional `anchor`. The `.stem` governs which link styles participate in validation, graph, and query link-traversal operations:
+Rootline can parse both `[[wiki-links]]` and markdown links `[text](target)`. Each link carries `style` (`wikilink`/`markdown`) and optional `anchor`. The `.stem` `links.styles` replacement set governs which link styles participate in validation, graph, and query link-traversal operations; omitted means `[wikilink]`:
 
 ```yaml
 version: 2
@@ -147,9 +147,9 @@ links:
 
 **`graph --check` runs the declared checks too**: with `links.checks` set it reports `link_anchor` and `link_encoding` alongside cycles and broken links, matching `validate`. Resolution failures appear once, as broken links.
 
-**One resolver**: `validate`, `graph` and `query` traversal share one resolver, so they agree on which links are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches a uniquely-named record anywhere. A resolved target is never broken even when `scope.match`/`.stemignore` excludes it: the schema declares what is governed, not what exists.
+**One resolver**: `validate`, `graph` and `query` traversal share one resolver. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, and `/x.md` resolves against the scan root. A path-less target matches a uniquely named record anywhere only when `links.basename_fallback: true`; `graph` and query traversal can decide that with their full index, while `validate` reports `link_unverifiable` rather than guessing. A resolved target is never broken even when `scope.match`/`.stemignore` excludes it: the schema declares what is governed, not what exists.
 
-**Query link traversal**: `--has-inbound` and `--has-outbound` predicates search both wiki-link and markdown-link styles (governed by `.stem links.styles`). Combine with `--inbound-type` / `--outbound-type` to restrict to one link type.
+**Query link traversal**: `--has-inbound` and `--has-outbound` predicates search the styles governed by `.stem links.styles` (default `[wikilink]`; use `[wikilink, markdown]` for both). Combine with `--inbound-type` / `--outbound-type` to restrict to one link type.
 
 **Graph**: `graph` respects the governed link styles from `.stem`. For `graph --check`: `--fail-cycles` overrides the `.stem` cycle opt-in per run (both directions), and `--quiet-cycles` collapses informational cycles to a single summary line (ignored when cycles are failing; JSON output unaffected).
 

--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -65,7 +65,7 @@ anything, in any section — not `schema:`, not `derive:`, not `aggregate:`.
 | Intent | Command | Canonical form |
 |---|---|---|
 | Validate files | `validate` | file: `rootline validate file.md -o json`; dir/all: `rootline validate --all <dir> -o json` |
-| Repair validation issues | `fix` | dir/all: `rootline fix --all <dir> --dry-run -o json > <dir>/repairs.json` (save inside `<dir>`: `repair apply` resolves record paths relative to the report's directory); file: `rootline fix file.md --dry-run` |
+| Repair validation issues | `fix` | dir/all: `rootline fix --all <dir> --dry-run -o json > repairs.json` (`repair apply` resolves paths by `--root`, then report `root`, then report `path`, then the report directory for legacy reports); file: `rootline fix file.md --dry-run` |
 | Inspect schema | `describe` | `rootline describe <path> -o json` |
 | Create document | `new` | `rootline new <file.md> --dry-run` then `rootline new <file.md>` |
 | Set fields | `set` | `rootline set --dry-run file.md field=value` then apply without `--dry-run` |

--- a/.claude/skills/rootline/ref-advanced.md
+++ b/.claude/skills/rootline/ref-advanced.md
@@ -2,7 +2,7 @@
 
 ## graph
 
-Use `graph` for repository-level link topology, cycle checks, and broken-link checks. Edges come from `[[wiki-links]]` and, when the effective `.stem` declares `links.styles: [markdown]`, from markdown links `[text](target)`; without that declaration only wikilinks appear (backcompat default). Markdown targets resolve with the same semantics as `validate`'s link checks (v1.13.0+): `%20` decoding, case-sensitive path walk, directory targets → their `README.md`, root-anchored `/x.md` against the scan root; unresolvable targets surface as broken links in `--check` (no basename fallback for markdown, unlike wikilinks).
+Use `graph` for repository-level link topology, cycle checks, and broken-link checks. Edges come from the effective `.stem` `links.styles` replacement set: omitted means `[wikilink]`; use `[wikilink, markdown]` to include both wikilinks and markdown links. Markdown targets resolve literally with `%20` decoding, case-sensitive path walk, directory targets → their `README.md`, and root-anchored `/x.md` against the scan root. Path-less basename fallback is opt-in via `links.basename_fallback: true` and uses the graph/query index; unresolvable targets surface as broken links in `--check`.
 
 ### Usage
 
@@ -21,7 +21,9 @@ Default global output is JSON, so `--format dot|mermaid` only produces diagram t
 | Flag | Use |
 |---|---|
 | `--format dot|mermaid` | diagram syntax when output is table |
-| `--check` | report cycles and broken links, exit non-zero on problems |
+| `--check` | report cycles and broken links; broken links fail, cycles are informational unless hardened |
+| `--fail-cycles` | treat cycles as check failures for this run |
+| `--quiet-cycles` | suppress per-cycle enumeration when cycles are informational |
 | `--where "expr"` | filter records before graph construction |
 
 ### JSON Shape
@@ -193,11 +195,6 @@ comments survive and a one-field change produces a one-field diff. Inter-token
 whitespace and nested indentation are normalized by the encoder — do not expect a
 byte-identical block for untouched fields.
 
-**Legacy mixed apply** (preserved for backward compatibility):
-```bash
-rootline apply report.json
-```
-
 Always inspect proposals before applying and validate after:
 ```bash
 rootline validate --all <dir> -o json
@@ -215,5 +212,4 @@ rootline hooks uninstall
 rootline completion bash
 rootline completion zsh
 rootline completion fish
-rootline completion powershell
 ```

--- a/.claude/skills/rootline/ref-query.md
+++ b/.claude/skills/rootline/ref-query.md
@@ -12,7 +12,7 @@ rootline query <dir> --where "body contains 'migration'"
 rootline query <dir> --where "tags != nil"
 ```
 
-Supported operators: `==`, `!=`, `in`, `contains`, `&&`, `||`. Use `field != nil` for existence checks. Built-in fields include `path`, `body`, `type`, `sections`, and `isIndex` where available. The `type` field refers to the record type (e.g., `"markdown"`); it is not a function call.
+Supported operators: `==`, `!=`, `in`, `not in`, `contains`, `&&`, `||`. Use `field != nil` or `field not in [nil]` for existence checks. Built-in fields include `path`, `body`, `type`, `sections`, and `isIndex` where available. The `type` field refers to the record type (e.g., `"markdown"`); it is not a function call.
 
 ## query
 
@@ -62,8 +62,7 @@ Without `--select` (full records):
     {
       "path": "docs/T001-task.md",
       "frontmatter": { "estado": "Pending" },
-      "derived": {},
-      "aggregated": {}
+      "derived": {}
     }
   ],
   "meta": { "count": 1 }
@@ -172,7 +171,7 @@ Rules:
 
 ## tree
 
-Use `tree` to show hierarchy and completion counts.
+Use `tree` to show hierarchy and recursive record totals.
 
 ```bash
 rootline tree <dir> -o table
@@ -180,7 +179,7 @@ rootline tree <dir> --where "estado != 'Completed'" -o table
 rootline tree <dir> --where "isIndex == false" -o json
 ```
 
-Use table output for humans and JSON for programmatic handling. Table format (`-o table`) renders ASCII brackets with the lifecycle field value (e.g., `[Completed]`, `[In Progress]`). The field name is resolved from the stem schema — not hardcoded to `"estado"`. JSON output (`-o json`) is the default and returns version 2 with `frontmatter` and derived fields on each node.
+Use table output for humans and JSON for programmatic handling. Table format (`-o table`) renders ASCII brackets with the lifecycle field value (e.g., `[Completed]`, `[In Progress]`). The field name is resolved from the stem schema — not hardcoded to `"estado"`. JSON output (`-o json`) is the default and returns version 2. Leaf document nodes carry `frontmatter` with derived/aggregate values merged into it; directory nodes carry `children` and recursive `total`, not `frontmatter`.
 
 ## stats
 
@@ -195,7 +194,7 @@ JSON contains counts grouped by `estado`, `tipo`, and total records.
 
 ## explain
 
-Use `explain` when the user asks why a field has a value, where a field is defined, or how derived/aggregated values are computed.
+Use `explain` when the user asks why a field has a value, where a schema-backed field is defined, or how derived/aggregate values are computed.
 
 ```bash
 rootline explain <file.md> -o json
@@ -203,10 +202,10 @@ rootline explain <file.md> -o json
 
 Report:
 
-- `stem_chain`
+- `stem_chain` (root-to-leaf order)
 - each field name/value
 - origin: frontmatter, derived, aggregate, schema
-- logical `source` when present and defined_in `.stem`
-- expression when present
+- logical `source` and defined_in `.stem` provenance when present on schema-backed fields
+- expression when present on derive/aggregate fields; current output does not include `defined_in` for those computed fields
 - errors
 

--- a/.claude/skills/rootline/ref-schema.md
+++ b/.claude/skills/rootline/ref-schema.md
@@ -201,13 +201,10 @@ Two deliberate differences from `repair apply`:
   emits absolute `.stem` targets, so the propose→apply contract needs them to keep working.
   `repair apply` uses `PolicyRejectAbsolute` because its report paths are root-relative by
   construction.
-- **Policy refusals go to `rejected[]`** (overwrite without `--force`, unknown operations).
-  Containment violations go to `errors[]` (operational failures).
+- **Schema policy refusals go to `rejected[]`** (overwrite without `--force`, unknown operations,
+  and containment violations); operational failures such as scan or write errors go to `errors[]`.
 
-`--dry-run` adds the same additive `resolved_targets: {accepted, rejected}` envelope that
-`repair apply` emits (`fix.ResolvedTargetsBreakdown`); omitted otherwise, contract stays
-version 1. `fix.ContainmentReason(err)` is exported so both apply commands unwrap
-`ContainmentError` through one implementation.
+For schema-proposals reports, `--dry-run` adds the additive `resolved_targets: {accepted, rejected}` envelope; analyze-report dry runs omit it. The key is omitted outside dry-run and the contract stays version 1. `fix.ContainmentReason(err)` is exported so both apply commands unwrap `ContainmentError` through one implementation.
 
 ## Fix All Schema Safety
 
@@ -223,7 +220,7 @@ version 1. `fix.ContainmentReason(err)` is exported so both apply commands unwra
 - Rejects schema proposals (extend_enum, add_aggregate, remove_stem_field, etc.); appear in output under Rejected
 - Never creates, deletes, or modifies `.stem` files
 - Supports `--dry-run` for preview without writes
-- Emits JSON: version 1, kind "rootline/repair", with Changed/Skipped/Rejected/Errors
+- Emits JSON: version 1, kind `"rootline/repair"`, with lowercase `changed`, `skipped`, `rejected`, `errors`, plus `complete`, `dry_run`, and `root`
 
 **Path containment.** Report paths are untrusted. Every path is checked against the scan root
 before any file is opened, so an escaping (`../..`) or absolute path is never read or written.

--- a/.claude/skills/rootline/ref-validate.md
+++ b/.claude/skills/rootline/ref-validate.md
@@ -194,12 +194,37 @@ Use `fix` to apply Rootline proposals. Always preview first.
 {
   "version": 1,
   "kind": "rootline/proposals",
-  "proposals": [],
-  "summary": {}
+  "path": "docs/",
+  "root": "/abs/path/to/docs",
+  "proposals": null,
+  "schema_suggestions": [
+    { "type": "extend_enum", "field": "estado", "paths": ["a.md"], "value": "Blocked" }
+  ],
+  "summary": {
+    "total": 1,
+    "extend_enum": 1,
+    "migrate_value": 0,
+    "correct_value": 0,
+    "extract_body": 0,
+    "infer_from_children": 0,
+    "add_field": 0,
+    "infer_from_siblings": 0,
+    "correct_outlier": 0,
+    "correct_link": 0,
+    "add_aggregate": 0,
+    "remove_stem_field": 0,
+    "propagate_aggregate": 0,
+    "schema_evolution": 0,
+    "remove_field": 0,
+    "loosen_required": 0,
+    "change_type": 0,
+    "replace_enum_values": 0,
+    "loosen_severity": 0
+  }
 }
 ```
 
-`type_findings` is omitted when empty; when present, treat it as unresolved validation work.
+`proposals` is `null` when no data repairs are available. `schema_suggestions` is an array in dry-run JSON when schema work is withheld; apply JSON reports it as an integer count. `type_findings` is omitted when empty; when present, treat it as unresolved validation work.
 
 ### Batch Apply JSON
 
@@ -232,7 +257,7 @@ For a file target, replace each `--all <dir>` command with the file form shown a
 
 ### Mutation Scope
 
-`fix --all` may update documents and `.stem` files through proposals such as `add_field`, `correct_value`, `migrate_value`, `extend_enum`, `remove_stem_field`, `add_aggregate`, and `propagate_aggregate`. Report this scope before applying unless the user already authorized repairs.
+`fix --all` writes document frontmatter only through data-repair proposals such as `add_field`, `correct_value`, `migrate_value`, `extract_body`, `set_field`, `set_section`, and `propagate_aggregate`. It never writes `.stem` files; schema-surface work (`extend_enum`, `remove_stem_field`, `add_aggregate`) is withheld in `schema_suggestions` for `schema apply` or manual review. Report document-mutation scope before applying unless the user already authorized repairs.
 
 ### Missing required fields are reported, not invented
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 
 - `schema apply` now rejects invalid prospective `.stem` hierarchies before publishing actions or writing files, while preserving version-1 `stem_health[]` diagnostics and atomic per-file `.stem` replacement for accepted writes.
 - `schema apply` now converges proposal and analyze writes on a bound physical target: internal aliases are supported, escaping aliases are rejected, malformed external governing ancestors surface as structured relative `yaml-valid` diagnostics in `stem_health[]`, and schema proposal targets must use the literal basename `.stem` so case-insensitive basename aliases are rejected before resolution.
-- **Compatibility correction (unreleased):** active schemas and guidance use canonical strict types (`string`, `list`, `enum`, `sequence`, `link`, `boolean`, `integer`) with no coercion. Historical `type: section` plus `heading:`/`ordered:` declarations migrate to `type: string` plus `source: body.section["## Heading"]`; `type: bool` migrates to `type: boolean`; historical `enum:` keys migrate to `values:`. Empty-present sections satisfy presence, duplicate matching headings fail, inherited source bindings remain stable, and public validation error sources are governance-root-relative. See `docs/UPGRADE.md` for paired before/after examples; ancestor-qualified selectors remain deferred to #190.
 
 ### Added
 
@@ -68,6 +67,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 - False-green validation: `validate --all` on a directory outside any schema now correctly exits with an error instead of succeeding with zero validated records.
 - Schema discovery boundary violations: walking up the filesystem no longer accidentally collects `.stem` files from outside the project (e.g., from home directory).
 - Working directory dependence: schema resolution is now stable regardless of where commands are invoked from.
+
+## [v9.12.2] - 2026-08-21
+
+### Changed
+
+- **Compatibility correction** (formerly documented as `Compatibility correction (unreleased)`): active schemas and guidance use canonical strict types (`string`, `list`, `enum`, `sequence`, `link`, `boolean`, `integer`) with no coercion. Historical `type: section` plus `heading:`/`ordered:` declarations migrate to `type: string` plus `source: body.section["## Heading"]`; `type: bool` migrates to `type: boolean`; historical `enum:` keys migrate to `values:`. Empty-present sections satisfy presence, duplicate matching headings fail, inherited source bindings remain stable, and public validation error sources are governance-root-relative. See `docs/UPGRADE.md` for paired before/after examples; ancestor-qualified selectors remain deferred to #190.
 
 ## [v0.10.0] - 2026-05
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ rootline fix doc.md --dry-run    # Preview proposed changes
 rootline fix --all               # Fix all files in scope
 ```
 
-Proposals include: correct misspelled enum values (Levenshtein matching), extend `.stem` enums for new valid values, migrate values with wiki-link insertion, and infer fields from child documents.
+Proposals include: correct misspelled enum values (Levenshtein matching), withheld `.stem` enum-extension suggestions for review, migrate values with wiki-link insertion, and aggregate propagation when configured.
 
 ### Explain
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Keep your Markdown consistent, connected, and queryable as it grows.
 
-Rootline treats your documentation as structured data. **`.stem` files define schemas** (what fields must exist, their types, allowed values). **Validation rules** enforce consistency. **Queries** retrieve relevant records without reading every file. **Field provenance** shows where every value came from and how it was computed. Humans, automation, and AI agents all consume the same governed outputs.
+Rootline treats your documentation as structured data. **`.stem` files define schemas** (what fields must exist, their types, allowed values). **Validation rules** enforce consistency. **Queries** retrieve relevant records without reading every file. **Field inspection** shows where frontmatter and source-backed values came from and how computed fields were produced. Humans, automation, and AI agents all consume the same governed outputs.
 
 ---
 
@@ -87,7 +87,7 @@ rootline new docs/task-001.md
 rootline explain docs/task-001.md
 ```
 
-Most commands output JSON by default. Use `--output table` for human-readable tables. (`graph --check` reports cycles and broken links as text plus an exit code.)
+Data and inspection commands output JSON by default when they have a machine-readable envelope. Use `--output table` for supported human-readable tables. (`graph --check` reports cycles and broken links as text plus an exit code.)
 
 ---
 
@@ -99,7 +99,7 @@ Most commands output JSON by default. Use `--output table` for human-readable ta
 - **Inherited rules**: `.stem` files define schemas; rules flow from parent to child via top-down merge.
 - **Derived fields**: Expressions compute fields (slugify, concatenate, filter); aggregates roll up from children to parents.
 - **Links**: Documents reference each other via `[[wiki-links]]` by default and `[markdown](links)` when `links.styles` includes `markdown`, forming a queryable dependency graph.
-- **Queryable outputs**: Every command returns stable JSON; records can be filtered, sorted, and projected.
+- **Queryable outputs**: Data and inspection commands return stable JSON; records can be filtered, sorted, and projected where the command supports those flags.
 
 ### How Schema Inheritance Works
 
@@ -156,7 +156,7 @@ Violations are reported as errors; the command exits with code 1. Use `--strict`
 Queries retrieve relevant records without scanning entire documents:
 
 - Declarative filtering: `--where 'estado == "published" && tipo == "epic"'`
-- Metadata projection: `--select path,estado,title` returns compact rows
+- Metadata projection: `--select path,estado` returns compact rows
 - Graph traversal: `--has-inbound` / `--has-outbound` with link predicates
 - Counted results: `--count` returns summary statistics
 
@@ -166,7 +166,7 @@ These outputs are JSON, suitable for piping to automation and AI consumers.
 
 ## Command Capabilities
 
-Rootline ships as a **single static Go binary** with no dependencies. Commands are grouped by use case. Most commands support `--where 'expr'` (expr-lang syntax) to filter records before processing.
+Rootline ships as a **single static Go binary** with no dependencies. Commands are grouped by use case. Traversal/data commands such as `query`, `stats`, `tree`, `graph`, and `validate --all` support `--where 'expr'` (expr-lang syntax) to filter records before processing.
 
 ### Validate & Govern
 
@@ -181,7 +181,7 @@ Check documents against inherited schemas and trace field origins.
   - `rootline describe <path>` — Merged schema with all inherited rules
 
 - **`explain`** — Trace field origins, derivations, and errors
-  - `rootline explain <file>` — See where every value came from
+  - `rootline explain <file>` — Inspect field origins and computed expressions
 
 ### Query & Traverse
 
@@ -190,14 +190,14 @@ Find records and visualize dependencies.
 - **`query`** — Search by metadata using declarative filters
   - `rootline query [path] --where 'expr'` — Filter records
   - `rootline query --where 'expr' --count` — Summary count
-  - `rootline query --where 'expr' --select path,estado,title` — Compact row output
+  - `rootline query --where 'expr' --select path,estado` — Compact row output
   - `rootline query --where 'expr' --has-inbound '<sub-expr>'` — Records with inbound links
   - `rootline query --where 'expr' --has-outbound '<sub-expr>'` — Records with outbound links
 
-- **`tree`** — Hierarchical view with completion counts
+- **`tree`** — Hierarchical view with recursive record totals
   - `rootline tree [path] [--where 'expr']` — Directory structure with metadata
 
-- **`graph`** — Dependency graph from wiki-links and markdown links
+- **`graph`** — Dependency graph from governed link styles
   - `rootline graph [path]` — Dependency graph as JSON (default)
   - `rootline graph [path] --format dot|mermaid -o table` — Render a diagram
   - `rootline graph [path] --check` — Validate cycles and broken links (text report + exit code)
@@ -261,16 +261,16 @@ Analyze patterns and manage schema evolution.
   - `rootline hooks status` — Check installation status
   - `rootline hooks uninstall` — Remove hook
 
-All commands support `--output json|table` and `--field` for dot-path extraction, including array projection:
+Commands with JSON envelopes support `--output json` and `--field` for dot-path extraction; `query` also supports `jsonl` and `csv` with `--select`. Commands that emit only human text or write files reject `--field`:
 
 ```bash
 # Dot-path extraction
 rootline describe docs/prd/ --field schema.id.next
 # "T004"
 
-# Simple field projection from query
-rootline query --where 'estado == "Pending"' --field path
-# docs/projects/P01/tasks/T005-deploy-grafana.md
+# Query field extraction uses the rows array
+rootline query --where 'estado == "Pending"' --field 'rows[].path'
+# ["docs/projects/P01/tasks/T005-deploy-grafana.md", ...]
 
 # Array projection: extract fields from arrays (rows, edges, etc.)
 rootline query --field 'rows[].path'
@@ -283,17 +283,17 @@ rootline graph docs/ --field 'edges[].source'
 # ["docs/api/auth.md", ...]
 
 # Compact query projections with --select (JSON, JSONL, CSV)
-rootline query --select path,estado,title
-# {"rows": [{"path": "...", "estado": "Pending", "title": "..."}, ...]}
+rootline query --select path,estado
+# {"rows": [{"path": "...", "estado": "Pending"}, ...]}
 
 rootline query --select path,estado --output jsonl
 # {"path": "...", "estado": "Pending"}
 # {"path": "...", "estado": "In Progress"}
 
-rootline query --select path,estado,title --output csv
-# path,estado,title
-# docs/api/auth.md,Pending,Authentication Guide
-# docs/api/endpoints.md,In Progress,Endpoint Reference
+rootline query --select path,estado --output csv
+# path,estado
+# docs/api/auth.md,Pending
+# docs/api/endpoints.md,In Progress
 
 # Filtering across commands
 rootline tree docs/epics/ --where 'estado != "Completed"'
@@ -326,7 +326,7 @@ aggregate:
   completed: 'len(filter(descendants, .estado == "Completed"))'
 ```
 
-Derived and aggregated fields appear alongside frontmatter in query results and tree output.
+Derived and aggregate fields appear in query results. In `tree` JSON they are merged into leaf nodes' `frontmatter`; directory nodes carry recursive `total` counts and child nodes, not frontmatter.
 
 ### Dependency Graph
 
@@ -360,7 +360,7 @@ Proposals include: correct misspelled enum values (Levenshtein matching), withhe
 rootline explain docs/projects/P01/F01/README.md
 ```
 
-Shows each field's origin (frontmatter, schema default, derived, or aggregate) with logical `source` directives, physical `defined_in` schema provenance, and expressions.
+Shows each field's origin (`frontmatter`, `schema`, `derived`, or `aggregate`). Frontmatter/source-backed schema fields carry `defined_in` and logical `source` directives when available; computed derive/aggregate fields carry expressions and currently do not report `.stem` provenance.
 
 ---
 
@@ -387,7 +387,7 @@ Rootline is designed as a **structured knowledge source for AI assistants**. Dat
 
 ### CLI-first automation
 
-AI assistants and automation should call the Rootline CLI directly and consume stable JSON output from commands such as `query`, `validate`, `describe`, `tree`, `stats`, `explain`, `fix`, `graph`, `set`, and `new`.
+AI assistants and automation should call the Rootline CLI directly and consume stable JSON output from commands that emit envelopes, such as `query`, `validate`, `describe`, `tree`, `stats`, `explain`, `fix --all --dry-run`, and `graph` JSON mode. Commands such as `set`, `new`, `init`, and `graph --check` emit human text or perform writes instead of a JSON envelope.
 
 ### Engine vs. agent: division of labor
 
@@ -417,7 +417,7 @@ same as that one? — are not guessed: `analyze` marks those proposals
 | [Fix & Proposals](docs/fix.md) | Auto-repair, enum correction, field inference |
 | [Analyze](docs/analyze.md) | Infer schemas and patterns from documents |
 | [Explain](docs/explain.md) | Field origin tracing, derivation chain, error diagnosis |
-| [Tree](docs/tree.md) | Hierarchical view with completion counts |
+| [Tree](docs/tree.md) | Hierarchical view with recursive record totals |
 | [Stats](docs/stats.md) | Total record counts, optionally filtered |
 | [Dependency Graph](docs/graph.md) | Wiki-links, link schema, cycle detection, DOT/Mermaid |
 | [Derivation Engine](docs/derivation.md) | Derive and aggregate expressions, builtins, linked fields |

--- a/README.md
+++ b/README.md
@@ -372,10 +372,9 @@ Git is optional. Rootline works in any directory, with or without version contro
 
 Rootline integrates with Git for continuous validation and collaborative workflows:
 
-- **Staged validation** — The `.githooks/pre-commit` hook runs `validate --staged` automatically, catching schema violations before commit
-- **CI validation** — GitHub Actions workflows in `.github/workflows/` run full validation and lint on every push
-- **Merge conflict detection** — Rootline's graph analyzer can detect when `.stem` file changes conflict with document mutations
-- **Diff-aware reviews** — Queries and validation support `--where` filters, making it easy to review only changed documents
+- **Manual staged validation** — `rootline validate --staged` is available when you want to check staged Markdown files
+- **CI validation** — GitHub Actions workflows in `.github/workflows/` run tests and repository checks
+- **Diff-aware reviews** — Queries and validation support `--where` filters, making it easy to review focused record subsets
 
 These workflows are optional enhancements, not product requirements. You can use Rootline without Git by running commands manually.
 
@@ -392,7 +391,7 @@ AI assistants and automation should call the Rootline CLI directly and consume s
 ### Engine vs. agent: division of labor
 
 Rootline's engine decides everything resolvable **from form** — frequency
-thresholds (a field present in ≥80% of records is `required`), unanimous or
+thresholds (a field present in >80% of records is inferred as `required`), unanimous or
 majority value agreement, and structural conventions (directory naming, type
 consistency). Decisions that need **meaning** — is this value semantically the
 same as that one? — are not guessed: `analyze` marks those proposals

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Most commands output JSON by default. Use `--output table` for human-readable ta
 - **Directory hierarchy**: Directories are tables; files are records.
 - **Inherited rules**: `.stem` files define schemas; rules flow from parent to child via top-down merge.
 - **Derived fields**: Expressions compute fields (slugify, concatenate, filter); aggregates roll up from children to parents.
-- **Links**: Documents reference each other via `[[wiki-links]]` and `[markdown](links)`, forming a queryable dependency graph.
+- **Links**: Documents reference each other via `[[wiki-links]]` by default and `[markdown](links)` when `links.styles` includes `markdown`, forming a queryable dependency graph.
 - **Queryable outputs**: Every command returns stable JSON; records can be filtered, sorted, and projected.
 
 ### How Schema Inheritance Works
@@ -330,7 +330,7 @@ Derived and aggregated fields appear alongside frontmatter in query results and 
 
 ### Dependency Graph
 
-Documents reference each other via `[[wiki-links]]` in their body. Rootline extracts these links and builds a directed graph:
+Documents reference each other via `[[wiki-links]]` by default, or via both wikilinks and markdown links when `.stem` sets `links.styles: [wikilink, markdown]`. Rootline extracts the governed styles and builds a directed graph:
 
 ```bash
 rootline graph docs/                            # Dependency graph as JSON (default)

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -39,9 +39,7 @@ optional parsing mode.
 types, back references, cross references, section patterns, invariants,
 formal dependencies, traceability links, structural rules.
 
-**Governance:** schema coverage (directories without a `.stem`), validation
-gaps (enum without values, untyped fields, incomplete sequences, required
-understatement).
+**Governance:** schema coverage (directories without a `.stem`) and validation gaps. Validation-gap reporting is de-duplicated against data-detector coverage: untyped fields are reported directly, enum-without-values gaps surface when no record value already produced enum-value coverage, sequence gaps mean missing `prefix`/`digits` in the `.stem` declaration rather than skipped observed numbers, and required-understatement is only reachable at the narrow boundary not already covered by required-field inference.
 
 ### Data Detectors
 
@@ -56,7 +54,7 @@ understatement).
 | Cross Reference Detection | Detect broken document-internal cross-references |
 | Body Section Patterns | Identify section headings in markdown bodies |
 | Invariant Extraction | Extract `INV\d+` identifiers from bodies |
-| Formal Dependency Extraction | Extract wiki-link dependencies from bodies |
+| Formal Dependency Extraction | Extract semantic wiki-link dependencies with the built-in prefixes `blocks`, `relates`, and `extends` |
 | Traceability Link Extraction | Identify traceability field claims (`Contribuye a`, `Cubre`, `Satisface`) |
 | Structural Rule Detection | Infer directory naming patterns and hierarchy rules |
 
@@ -65,7 +63,7 @@ understatement).
 | Detector | Description |
 |----------|-------------|
 | Schema Coverage | Directories without an owning `.stem` file |
-| Validation Gaps | Missing enum values, untyped fields, sequence incompleteness, required field understatement |
+| Validation Gaps | De-duplicated governance gaps: untyped fields, reachable enum-without-values cases, incomplete sequence declarations (`prefix`/`digits`), and the required-understatement boundary case |
 
 ## JSON Output
 
@@ -147,7 +145,7 @@ For identical inputs and flags, `analyze -o json` emits each category's `inferen
 - `kind` — `rootline/analyze` (distinguishes from other report kinds).
 - `path` — the scanned directory (as specified on the command line).
 - `categories[]` — one per detector: `id`, `name`, `inference_count`, `inferences[]`.
-  - Each inference carries: `type`, `field`, `value`, `message`, `requires_agent`.
+  - Each inference carries `type`, `message`, and `requires_agent`; `field`, `value`, and `source` are type-dependent and omitted when not meaningful.
   - `requires_agent: true` marks inferences needing human or agent disambiguation (not automatically applied by fix/schema commands).
 - `summary`:
   - `total_inferences` — count of all inferences across all detectors.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -1,6 +1,6 @@
 # Auto-update — Staged Async Pattern
 
-rootline updates itself automatically using a **staged async** pattern: the new binary is downloaded in the background during run N, and applied at the start of run N+1. The update is transparent — no prompts, no interruptions, no downtime.
+rootline updates itself automatically using a **staged async** pattern within its compatibility boundary: the new binary is downloaded in the background during run N, and an eligible staged binary is applied at the start of run N+1. Same-major stable releases are eligible. Cross-major releases are deliberately withheld, leave the staged binary in place, and print a stderr notice instructing the user to run the installer for a deliberate upgrade.
 
 The implementation lives upstream in [`github.com/pablontiv/picokit/autoupdate`](https://pkg.go.dev/github.com/pablontiv/picokit/autoupdate); rootline wires it from `cmd/rootline/main.go` via `autoupdate.New("pablontiv/rootline", "rootline")`.
 
@@ -9,17 +9,18 @@ The implementation lives upstream in [`github.com/pablontiv/picokit/autoupdate`]
 ```
 Run N:
   1. ApplyStagedIfAvailable()  — sync: checks ~/.cache/rootline/staged/ for a newer binary
-     → if found: atomic rename over current binary, re-exec (process is replaced)
+     → if found, newer, and same-major compatible: atomic rename over current binary, re-exec (process is replaced)
+     → if found and newer but outside the compatibility boundary: keep staged binary, print a notice, continue
      → if not found or not newer: continues normally
   2. go FetchAndStage(version) — goroutine: downloads next release in background
      → writes to ~/.cache/rootline/staged/<tag>/rootline
      → exits silently on any error
 
 Run N+1:
-  → staged binary is detected, applied, and rootline re-execs with the new version
+  → eligible staged binary is detected, applied, and rootline re-execs with the new version
 ```
 
-The user-visible effect is that the version shown by `rootline --version` changes on the second invocation after a new release.
+For same-major releases, the user-visible effect is that the version shown by `rootline --version` changes on the second invocation after a new release. For cross-major releases, the version does not change automatically; reinstall deliberately with the installer command for the new major.
 
 ## Staging Directory
 
@@ -44,26 +45,28 @@ Applying an update renames the staged binary over the running one, so the binary
 
 ## Version Comparison
 
-Only `major.minor.patch` participates. `parseSemver` truncates the version at the first `-` or `+`, and `isNewer` then compares with a strict `>`. Pre-release and build metadata are invisible to the comparison:
+Only `major.minor.patch` participates in ordering. `parseSemver` truncates the version at the first `-` or `+`, and `isNewer` then compares with a strict `>`. Ordering is necessary but not sufficient: a release must also satisfy the same-major compatibility policy. Pre-release and build metadata are invisible to the comparison:
 
 | Installed | Released | Replaced? | Why |
 |-----------|----------|-----------|-----|
 | `v4.0.8` | `v4.0.9` | yes | `4.0.9 > 4.0.8` |
 | `v4.0.8-3-gabc123` | `v4.0.9` | yes | truncates to `4.0.8` |
 | `v4.0.9+local.abc123` | `v4.0.9` | no | tie, and the test is `>` not `>=` |
-| `v4.0.9+local.abc123` | `v4.1.0` | yes | `4.1.0 > 4.0.9` |
+| `v4.0.9+local.abc123` | `v4.1.0` | yes | `4.1.0 > 4.0.9` and same major |
+| `v4.0.9` | `v5.0.0` | no | newer, but cross-major; withheld for deliberate reinstall |
 
 This is why `just install` versions a local build as `<highest known tag>+local.<sha>` rather than using `git describe`. From a fully synced checkout describe yields the release version and ties safely — but it drops *below* the release whenever tags are stale or `HEAD` predates the newest tag. The release then outranks it and the freshly installed binary is replaced on the very next run. Taking the highest known tag is deterministic regardless of where `HEAD` sits.
 
 Clearing the staging directory does **not** prevent that: every invocation re-stages in a background goroutine, so the next one applies it.
 
-## When Auto-update Does NOT Run
+## When Auto-update Does NOT Apply
 
 | Condition | Effect |
 |-----------|--------|
 | `version == "dev"` | Auto-update is always disabled — local builds (without ldflags) never touch network or cache |
+| Staged release crosses the same-major compatibility boundary | The update is withheld, the staged binary remains in cache, a stderr notice is printed, and the current command continues with the installed binary |
 
-There is no opt-out environment variable. The only way to disable auto-update is to build locally without ldflags (produces `version == "dev"`).
+There is no opt-out environment variable. The only way to disable all auto-update activity is to build locally without ldflags (produces `version == "dev"`). To cross a major-version boundary, run the installer deliberately.
 
 ## Behavior by OS
 
@@ -75,7 +78,7 @@ There is no opt-out environment variable. The only way to disable auto-update is
 
 ## Silent Failure Policy
 
-All auto-update errors are suppressed — the current command is never interrupted:
+Most auto-update failures are suppressed — the current command is never interrupted. Compatibility-boundary withholding is the deliberate exception: it prints a notice so the user knows to reinstall intentionally.
 
 - **Network errors** during download: silently skip; staging directory is not created.
 - **SHA256 mismatch**: returns an error internally; no file is written to the staging directory.
@@ -86,12 +89,13 @@ All auto-update errors are suppressed — the current command is never interrupt
 **The binary is not updating:**
 
 1. Verify the installed binary is a release build: `rootline --version` should show a semver tag, not `dev`. A `dev` binary was built without ldflags — reinstall with `just install`.
-2. Check that PATH resolves to a single binary: `just doctor-install`. A stale copy shadowing the real one in another directory is the most common cause of "the version never changes".
-3. Check the staging directory for your OS (see the table above) — if it stays empty after a run, connectivity or permissions may be blocking.
-4. Verify the installed binary sits in a directory you own. Applying an update to a root-owned path such as `/usr/local/bin` fails silently and leaves the old version in place.
-5. Verify network access to `api.github.com` and `github.com`.
+2. Check stderr for `incompatible update withheld`. If present, the newest staged release crosses the compatibility boundary; run the installer deliberately to move to that major version.
+3. Check that PATH resolves to a single binary: `just doctor-install`. A stale copy shadowing the real one in another directory is another common cause of "the version never changes".
+4. Check the staging directory for your OS (see the table above) — if it stays empty after a run, connectivity or permissions may be blocking. If it contains a newer cross-major release, the boundary is working as designed.
+5. Verify the installed binary sits in a directory you own. Applying an eligible update to a root-owned path such as `/usr/local/bin` fails silently and leaves the old version in place.
+6. Verify network access to `api.github.com` and `github.com`.
 
-**Force an update now:**
+**Force an eligible same-major update now:**
 
 ```bash
 rm -rf ~/Library/Caches/rootline/staged/   # macOS — see the table above for other OSes

--- a/docs/derivation.md
+++ b/docs/derivation.md
@@ -46,11 +46,11 @@ When documents use wiki-links (`[[blocks:T003-task]]`), the derivation engine re
 # .stem links section defines field mapping
 links:
   blocks:
-    fields:
-      estado: estado  # inject linked record's "estado" into expression env
+    field: blocked_by       # variable injected into the expression env
+    value_field: estado     # target-record field collected into blocked_by
 ```
 
-This enables derived state from dependencies — e.g., a task is blocked if any linked blocker has `estado != "Completed"`.
+This enables derived state from dependencies — e.g., a task can evaluate `any(blocked_by, {# != "Completed"})` when `blocked_by` was injected from linked records.
 
 ## Built-in Derived Fields
 

--- a/docs/derivation.md
+++ b/docs/derivation.md
@@ -29,7 +29,7 @@ aggregate:
 
 | Function | Description | Example |
 |----------|-------------|---------|
-| `slugify(s)` | URL-friendly slug | `slugify("Mi Título")` → `"mi-titulo"` |
+| `slugify(s)` | Lowercase ASCII slug; runs outside `[a-z0-9]` become hyphens, with no accent transliteration | `slugify("Mi Título")` → `"mi-t-tulo"` |
 | `lower(s)` | Lowercase | `lower("ABC")` → `"abc"` |
 | `upper(s)` | Uppercase | `upper("abc")` → `"ABC"` |
 | `trim(s)` | Trim whitespace | `trim("  hi  ")` → `"hi"` |

--- a/docs/describe.md
+++ b/docs/describe.md
@@ -94,7 +94,7 @@ absolute; they are shortened here for readability.
 
 ## Field Extraction
 
-The `--field` flag extracts values by dot-path. Most commands support both simple object paths and array projection:
+The `--field` flag extracts values by dot-path from commands that emit JSON envelopes. It supports both simple object paths and array projection:
 
 ```bash
 # Simple dot-path
@@ -113,12 +113,14 @@ rootline graph docs/ --field 'edges[].source'
 # ["docs/api/auth.md", "docs/api/validate.md"]
 
 rootline graph docs/ --field 'broken_links'
-# [{"link": "[[NonExistent]]", "source": "docs/api/auth.md"}, ...]
+# [{"source": "docs/api/auth.md", "target": "NonExistent", "type": "reference", "line": 12}, ...]
 ```
 
-Array projection syntax `field[].subfield` works for:
-- Query results: `rows[].path`, `rows[].frontmatter.*`, `rows[].derived.*`
-- Graph results: `edges[]`, `broken_links[]`
+Array projection syntax `field[].subfield` works for explicit paths such as:
+- Query results: `rows[].path`, `rows[].frontmatter.estado`, `rows[].derived.slug`
+- Graph results: `edges[]`, `edges[].source`, `broken_links[]`, `broken_links[].target`
+
+Wildcard projections such as `rows[].frontmatter.*` are not supported; name the field explicitly.
 
 ### Repeating `--field`
 

--- a/docs/explain.md
+++ b/docs/explain.md
@@ -3,7 +3,7 @@ estado: Completed
 ---
 # Explain
 
-`rootline explain` traces the origin of every field in a document: which `.stem` defined it, whether it came from frontmatter, derivation, or aggregation, and what expressions produced the value.
+`rootline explain` traces each effective field in a document: whether it came from frontmatter, a schema default/source extraction, derivation, or aggregation, and what expression produced computed values. Current output reports `.stem` `defined_in` provenance for schema-backed fields; derive and aggregate fields expose their `expression` but not the `.stem` path that declared it.
 
 ## CLI Usage
 
@@ -86,7 +86,7 @@ For documents with derived and aggregated fields, each field shows its expressio
 }
 ```
 
-The `stem_chain` shows the walk-up discovery order from the target up to the `root: true` marker. A chain that reaches the filesystem root without one has no declared boundary; the preflight stops governed commands there and asks for the marker. The `origin` field is one of: `frontmatter`, `schema` (default value), `derived`, or `aggregate`.
+The `stem_chain` is emitted in resolution order, root-to-target/leaf. A chain that reaches the filesystem root without a `root: true` marker has no declared boundary; the preflight stops governed commands there and asks for the marker. The `origin` field is one of: `frontmatter`, `schema` (default value), `derived`, or `aggregate`.
 
 For a source-backed field, `source` is the logical directive and `defined_in` is the physical `.stem` declaration. Explain resolves the same effective value as validation and query; frontmatter remains an override, empty-present sections remain present, and duplicate matching headings are reported as errors.
 

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -60,13 +60,19 @@ Rootline categorizes issues into specific proposal types to preserve semantic me
 | **add_field** | Adds a missing required field with a default or inferred value | Adding `estado: Pending` to a file without it |
 | **infer_from_siblings** | Uses statistical majority of a directory to fill missing values | Setting `tipo: software` because 90% of files are software |
 | **correct_outlier** | Identifies values that differ from a strong consensus in a folder | Flagging a task as "manual" in a "deploy" folder |
-| **infer_from_children** | Rolls up status from child records to an index file | README becomes "Completed" if all tasks are done |
-| **correct_link** | Fixes broken wiki-links by resolving to the closest valid target | `[[T099]]` → `[[T001]]` |
-| **add_aggregate** | Generates aggregate expressions for index files missing them | Adding `estado: len(filter(...))` to README |
+| **infer_from_children** | Historical type retained in the JSON counters, but no detector currently emits it; configure parent rollups with `.stem` `aggregate:` expressions instead | Summary counter remains `0` |
+| **correct_link** | Historical proposal type; current `fix` reports link problems under `link_findings` and does not rewrite link bodies | Human reviews the `link_resolve` suggestion |
+| **add_aggregate** | Schema-surface suggestion to add an aggregate expression to a `.stem`; current generation uses a conservative quoted default, not semantic `len(filter(...))` logic | Adding `estado: "Completed"` to `.stem` for review |
 | **remove_stem_field** | Removes invalid fields from `.stem` detected by stem health checks | Removing a field that references a non-existent type |
 | **propagate_aggregate** | Detects stale aggregate values in index files and corrects them | Updating `completed` count after child status changes |
-| **set_field** | Sets a frontmatter field to a specific value via the `rootline set` pipeline | Setting `estado: Completed` after all children are done |
-| **set_section** | Sets or replaces a section body via the `rootline set` pipeline | Populating an empty `## Summary` section with inferred content |
+| **set_field** | Sets a frontmatter field to a specific value via the `rootline set` pipeline | Setting `estado: Completed` explicitly |
+| **set_section** | Sets, appends to, or creates a section body via the `rootline set` pipeline | Replacing `## Summary` with inferred content |
+| **schema_evolution** | Explicit migration marker for destructive schema evolution | Recording a reviewed incompatible schema change |
+| **remove_field** | Explicit field removal from schema during migration | Removing a deprecated schema field |
+| **loosen_required** | Explicit required→optional change during migration | Making `owner` optional |
+| **change_type** | Explicit incompatible type change during migration | Changing `priority` from string to integer |
+| **replace_enum_values** | Explicit replacement of an enum's value set during migration | Replacing legacy lifecycle values |
+| **loosen_severity** | Explicit validation-severity reduction during migration | Lowering a rule from error to warning |
 
 ## Proposal Struct
 
@@ -83,7 +89,7 @@ Each proposal in the output has the following fields:
 | `value_source` | string | Optional provenance for `add_field` values (`schema_default`, `enum_first`, or `empty`) |
 | `from_representation` | string | Optional evidence for type representation repairs (`timestamp`, `boolean`, or `integer`) |
 | `heading` | string | For `set_section` proposals: the Markdown heading to mutate |
-| `mode` | string | For `set_section` proposals: `set` (replace) or `append` |
+| `mode` | string | For `set_section` proposals: `replace` (default), `append`, or `create` |
 
 `heading` and `mode` are only populated on `set_section` proposals. `set_field` reuses the existing `applySetField` pipeline from `rootline set`.
 
@@ -96,11 +102,11 @@ Rootline provides **three separate commands** for different repair scenarios. Ch
 **Deprecated.** Use `rootline repair apply` instead (see below).
 
 ```bash
-rootline fix --all --dry-run   # Preview proposals (data-only)
-rootline fix --all             # Apply data-only repairs
+rootline fix --all --dry-run   # Preview data repairs and withheld schema suggestions
+rootline fix --all             # Apply data-only repairs to documents
 ```
 
-`fix` combines proposal generation and application in one step. It applies only **data-only repairs** to frontmatter and skips schema-surface proposals, which appear in the `schema_suggestions` field of the output.
+`fix` combines proposal generation and application in one step. It writes document frontmatter only. Schema-surface proposals such as `extend_enum`, `add_aggregate`, and `remove_stem_field` are withheld for review: in dry-run JSON they appear as a `schema_suggestions` array, while apply JSON reports a `schema_suggestions` integer count.
 
 ### 2. `rootline repair apply` — Data-Only Bulk Repair (Current)
 
@@ -173,7 +179,7 @@ failing run stays machine-readable; the short `Error: apply failed: ...` line go
 |---------|-------|------|-----|
 | Applied cleanly | `changed[]` | `0` | The command did what it was asked. |
 | Refused on policy | `rejected[]` | `0` | A deliberate refusal, already reported — a containment violation, a schema proposal handed to `repair apply`, an existing `.stem` without `--force`. |
-| Deferred | `skipped[]` | `0` | Nothing was attempted; `requires_agent` work is left for a human. |
+| Deferred | `skipped[]` | `0` | Nothing was attempted; for `schema apply` this includes `requires_agent` work, while for `repair apply` it includes engine-chosen missing-field values withheld unless `--fill-missing` is passed. |
 | Could not be done | `errors[]` | `1` | An unreadable path, a failed write, an unresolvable target. |
 | Written, then reverted | `rolled_back[]` | `1` | Post-validation rejected the result and the pre-write bytes were restored. The caller asked for a change that could not be made, so a tidy revert is still a failure. |
 
@@ -252,7 +258,7 @@ is already correct. Take a `--dry-run` first if you want to see what remains.
 - set_field
 - set_section
 
-Schema proposals (extend_enum, add_aggregate, remove_stem_field) are **silently rejected** — use `rootline schema apply` instead.
+Schema proposals (extend_enum, add_aggregate, remove_stem_field) are rejected visibly in `rejected[]` — use `rootline schema apply` instead.
 
 **Path containment.** A report is untrusted input, so every path it names is checked against
 the scan root before any file is opened. A path that escapes the root — `../../../etc/shadow`
@@ -289,7 +295,9 @@ write would have landed and why any were refused before committing to the run:
 
 Flags:
 - `--dry-run` — Preview changes without modifying files
+- `--fill-missing` — Also apply `add_field` proposals whose value was engine-chosen rather than schema-declared
 - `--report <file>` — Path to proposals JSON file (required)
+- `--root <dir>` — Absolute scan-root override; takes precedence over report `root`/`path`
 
 ### 3. `rootline schema apply` — Schema Mutation
 
@@ -316,7 +324,7 @@ rootline schema apply --report proposals.json
 - create_stem
 - extend_enum (analyze path only)
 
-Data-only repairs (correct_value, add_field, etc.) are **ignored** — use `rootline repair apply` instead.
+Data-only repairs (correct_value, add_field, etc.) are rejected visibly in `rejected[]` — use `rootline repair apply` instead.
 
 **What propose proposes is what apply writes.** Each `create_stem` proposal carries a `patch`
 field holding the complete inferred YAML, and `schema apply` writes those bytes verbatim. It does
@@ -341,17 +349,16 @@ target is checked against the scan root before a `.stem` is written, so a report
 staying valid — they are accepted and then confined, not refused outright. That is the one
 difference from `repair apply`, which rejects absolute paths as malformed input.
 
-The second difference is where refusals land. `schema apply` has a `rejected[]` field for policy refusals (overwrite without `--force`, unknown operations) and `errors[]` for operational failures (containment violations, scan errors):
+The second difference is where refusals land. `schema apply` reports policy refusals such as overwrite without `--force`, unknown operations, and containment violations in `rejected[]`; operational failures such as scan or write errors remain in `errors[]`:
 
 ```bash
 rootline schema apply --report proposals.json
 # rejected: ".stem already exists in /docs (use --force to overwrite)"
 # OR
-# errors: containment violation: path "/tmp/outside/.stem" escapes root (root "/abs/scan")
+# rejected: containment violation: path "/tmp/outside/.stem" escapes root (root "/abs/scan")
 ```
 
-With `--dry-run`, the output carries the same additive `resolved_targets` envelope that
-`repair apply` emits, so you can see where each `.stem` would land before writing:
+With schema-proposals reports, `--dry-run` carries an additive `resolved_targets` envelope so you can see where each `.stem` would land before writing. Analyze-report dry runs do not emit this key: they plan directly from in-memory inferences and report accepted/skipped actions instead.
 
 ```json
 {
@@ -366,7 +373,9 @@ With `--dry-run`, the output carries the same additive `resolved_targets` envelo
 
 Flags:
 - `--dry-run` — Preview changes without modifying files
-- `--report <file>` — Path to proposals JSON file (required)
+- `--force` — Overwrite existing `.stem` files when applying `create_stem` proposals
+- `--report <file>` — Path to schema proposals report JSON file (required)
+- `--root <dir>` — Absolute scan-root override; takes precedence over report `root`/`path`
 
 ## When to Use Each
 
@@ -380,7 +389,7 @@ Flags:
 
 ## YAML AST Preservation
 
-When Rootline modifies a `.stem` or a frontmatter block, it uses a YAML AST (Abstract Syntax Tree) parser. This **preserves your comments and formatting** while updating the data.
+When Rootline modifies a `.stem` or a frontmatter block, it rewrites through YAML nodes so comments and key order are preserved where possible. Inter-token whitespace, inline-comment spacing, and nested indentation are normalized by the YAML encoder; do not expect byte-identical formatting outside the edited value.
 
 ## Sibling Inference Logic
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -23,8 +23,8 @@ Format: `[[type:target]]` or `[[target]]` (untyped). Links inside fenced code bl
 links:
   blocks:
     target: "^T\\d{3}-"           # target must match pattern
-    fields:
-      estado: estado              # inject linked field into derive expressions
+    field: blocked_by             # variable injected into derive expressions
+    value_field: estado           # target-record field collected for that variable
   reference:
     target: ".*"                  # any target allowed
 ```
@@ -52,14 +52,14 @@ rootline graph docs/epics/ --check                     # Validate only: cycles +
 
 ### Link Styles
 
-Rootline extracts both `[[wiki-links]]` and `[markdown](links)` reference styles. The links recognized in graph building are configured in `.stem` via the `links.styles` field (default: `[wikilink]`).
+Rootline can extract `[[wiki-links]]` and `[markdown](links)` reference styles. The styles recognized in graph building are configured in `.stem` via the `links.styles` field; when omitted, the effective set is `[wikilink]`.
 
 To control which link styles are processed in the graph:
 
 ```yaml
 # .stem file
 links:
-  styles: [wikilink, markdown]  # Recognize both wiki-links and markdown links
+  styles: [wikilink, markdown]  # Replacement set; include both to recognize both styles
   checks:
     resolve: true              # Check that targets resolve (case-sensitive)
     anchors: true              # Validate heading anchors
@@ -67,7 +67,7 @@ links:
     cycles: true               # Fail graph --check if cycles found (optional)
 ```
 
-With `links.styles`, only listed styles are extracted and validated. The graph command respects this setting.
+`links.styles` replaces the default set; it does not add to it. For example, `styles: [markdown]` recognizes markdown links only and stops recognizing wikilinks until `wikilink` is listed as well. The graph command respects this setting.
 
 ### With --where
 
@@ -91,12 +91,7 @@ that asked for it, leaving unrelated cycles in never-opted-in subtrees informati
 
 ### How a link target resolves
 
-`graph` resolves links through the same engine `validate` uses, so the two agree on which links
-are broken. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown
-targets resolve literally, `/x.md` resolves against the scan root, and a path-less target matches
-a uniquely-named record anywhere. A resolved target is never reported broken **even when the
-schema does not govern it** — `scope.match` and `.stemignore` declare what is *governed*, not
-what *exists*, so such a link is an edge to a non-node. Unresolved targets are reported verbatim.
+`graph` resolves links through the same engine `validate` uses, so they agree when basename fallback is off. Wikilinks infer `.md` (`[[b]]`→`b.md`, `[[sub/README]]`→`sub/README.md`), markdown targets resolve literally, and `/x.md` resolves against the scan root. A path-less target matches a uniquely named record anywhere only when `links.basename_fallback: true`; `graph` and query traversal have the full index needed for that lookup, while `validate` reports `link_unverifiable` instead of guessing. A resolved target is never reported broken **even when the schema does not govern it** — `scope.match` and `.stemignore` declare what is *governed*, not what *exists*, so such a link is an edge to a non-node. Unresolved targets are reported verbatim.
 
 When the effective `.stem` declares `links.checks`, `--check` also reports the anchor and
 encoding failures `validate` reports, so a green `graph --check` now means what it looks like it
@@ -171,5 +166,6 @@ The `--field` flag applies to graph JSON output and supports:
 ## Target Resolution
 
 Links resolve targets by:
-1. Relative path from source document's directory
-2. Basename fallback — unique match across the scanned tree
+1. Relative path from the source document's directory.
+2. Root-anchored path (`/x.md`) against the scan root.
+3. Optional basename fallback — when `links.basename_fallback: true`, `graph` and query traversal can match a path-less target to one unique record in the scanned tree. The default is off.

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -114,7 +114,7 @@ the shape you get from `rootline migrate docs --dry-run -o json`:
 rootline migrate --rename status=estado
 ```
 
-Updates frontmatter in all affected markdown files and schema definitions in `.stem` files. Operations are logged to `.migration-log.json` (JSON Lines, append-only).
+Updates frontmatter in all affected markdown files and schema definitions in `.stem` files. Operations are logged to `.rootline-migrations` (JSON Lines, append-only).
 
 Each generated document or `.stem` is replaced atomically from a sibling staging
 file, so a failed write cannot leave that destination truncated. Migration runs

--- a/docs/query.md
+++ b/docs/query.md
@@ -69,7 +69,7 @@ Flags:
 - `--outbound-type <type>` — Restrict `--has-outbound` to links of this type
 - `--graph-root <path>` — Set the root for edge scanning (default: the query path). The query path must lie inside the graph root.
 
-**Link styles**: By default, link traversal searches both wiki-link (`[[target]]`) and markdown-link (`[text](target)`) styles. Styles can be configured in `.stem` via `links.styles` to restrict which types are recognized.
+**Link styles**: By default, link traversal searches wiki-link (`[[target]]`) styles only. Configure `.stem` `links.styles` as a replacement set, for example `[wikilink, markdown]`, to include markdown links (`[text](target)`).
 
 ### Compact Projections with `--select`
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -76,19 +76,18 @@ Flags:
 The `--select` flag produces compact output containing only specified fields:
 
 ```bash
-rootline query --select path,estado,title
-rootline query --select path,estado,title,links --output jsonl
-rootline query --where 'estado == "Pending"' --select path,title --output csv
+rootline query --select path,estado
+rootline query --select path,estado,links --output jsonl
+rootline query --where 'estado == "Pending"' --select path,estado --output csv
 ```
 
 `--select` accepts a comma-separated list of field names. Supported field names include:
 - `path` — document file path
-- `title` — first Markdown heading or first non-empty body line
 - Any frontmatter field name (e.g., `estado`, `prioridad`, `owner`)
 - Any derived field (defined in `.stem` `derive:` section)
 - `links` — document links extracted from wiki-link references
 
-**Without `--select`**, query results include full records with `frontmatter`, `body`, `links`, and `derived`.
+**Without `--select`**, query results include full records with `frontmatter`, `body`, `sections`/`body_sections`, and `derived`; `links` is present only when the record has extracted links.
 
 **With `--select`**, only specified fields are included in each row, reducing noise and making output suitable for shell pipelines.
 
@@ -120,10 +119,10 @@ rootline query --select path,estado --output jsonl
 # {"path": "...", "estado": "In Progress"}
 
 # CSV: RFC 4180 with quoted fields and escaping
-rootline query --select path,estado,title --output csv
-# path,estado,title
-# "docs/api/auth.md","Pending","Authentication Guide"
-# "docs/api/endpoints.md","In Progress","Endpoint Reference"
+rootline query --select path,estado --output csv
+# path,estado
+# "docs/api/auth.md","Pending"
+# "docs/api/endpoints.md","In Progress"
 
 # CSV with nil values (rendered as empty)
 rootline query --select path,estado,owner --output csv
@@ -138,10 +137,10 @@ Column order in `jsonl` and `csv` output follows the order specified in `--selec
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `frontmatter.*` | any | Any frontmatter key |
+| `frontmatter.<field>` | any | Any frontmatter key, addressed by explicit field name |
 | `body` | string | Full document body text |
 | `sections` | map[string]string | Map of heading → section body (requires AST extraction) |
-| `derived.*` | any | Computed derived fields from `.stem` `derive:` |
+| `derived.<field>` | any | Computed derived field addressed by explicit field name |
 
 ### Section Queries
 
@@ -248,7 +247,7 @@ Rows include `derived` when the effective `.stem` defines `derive:` or `aggregat
 {
   "version": 1,
   "kind": "rootline/count",
-  "meta": {},
+  "meta": { "count": 12 },
   "count": 12
 }
 ```
@@ -279,10 +278,10 @@ Some AI coding agents (notably Claude Code's Bash tool) pre-escape the `!` chara
    rootline query -o json | jq '.rows[] | select(.estado != "draft")'
    ```
 
-**Field existence check** (`!= nil`): There is no `not in` equivalent for field existence. Use the JSON pipeline approach:
+**Field existence check** (`!= nil`): use `field not in [nil]` when an agent cannot send `!= nil` safely:
 
 ```bash
-rootline query -o json | jq '.rows[] | select(.tags != null)'
+rootline query --where 'tags not in [nil]'
 ```
 
 This issue is not specific to rootline — it affects any CLI tool whose query syntax uses `!` when invoked through agents with this escaping behavior.

--- a/docs/set.md
+++ b/docs/set.md
@@ -74,29 +74,31 @@ rootline set docs/api/overview.md descripcion=@notes.txt
 rootline set docs/api/overview.md estado=Pending --dry-run
 ```
 
-### Skip validation (advanced)
+### Skip post-validation (advanced)
+
+`--no-validate` skips post-mutation validation only; enum/type pre-validation still runs. Use it only when you deliberately need to write a schema-valid value while leaving some other existing validation error unresolved.
 
 ```bash
-rootline set docs/api/overview.md estado=Custom --no-validate
+rootline set docs/api/overview.md estado=review --no-validate
 ```
 
 ## Error Messages
 
 | Situation | Message |
 |-----------|---------|
-| Invalid enum value | `pre-validation failed: field "estado": value "Custom" not in enum [draft, review, published]` |
-| Post-validation failure | `post-validation failed; changes rolled back: required field "tipo" is missing` |
-| File not found | `file not found: docs/api/missing.md (use 'rootline new' to scaffold a new document)` |
+| Invalid enum value | `Error: value "Custom" not in allowed values for estado: [draft, review, published]` |
+| Post-validation failure | `Error: post-mutation validation failed (rolled back): tipo: required field "tipo" is missing` |
+| File not found | `Error: file not found: /abs/path/docs/api/missing.md (use 'rootline new' to scaffold a new document)` |
 | Source-backed field | `set` writes a frontmatter override and does not edit the body section |
-| Source file not found (=@path) | `cannot read source file: @notes.txt: no such file` |
+| Source file not found (`=@path`) | `Error: resolving value for notes: reading notes.txt: open notes.txt: no such file or directory` |
 
 ## Dry Run Output
 
-With `--dry-run`, `rootline set` prints a diff-style preview without modifying any file:
+With `--dry-run`, `rootline set` prints the proposed assignment and exits before writing:
 
-```
-~ docs/api/overview.md
-  estado: "In Progress" → "Completed"
+```console
+$ rootline set docs/api/overview.md estado=Completed --dry-run
+would set estado = "Completed"
 ```
 
 ## Source-Backed Fields

--- a/docs/set.md
+++ b/docs/set.md
@@ -105,4 +105,4 @@ For `source: body.section["## Notes"]`, `set notes=override` writes a frontmatte
 
 ## Notes
 
-- YAML AST preservation: when writing frontmatter, Rootline uses the YAML AST parser to preserve existing comments and formatting.
+- YAML node rewriting preserves comments and key order where possible, but normalizes inter-token whitespace, inline-comment spacing, and nested indentation.

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -3,7 +3,7 @@ estado: Completed
 ---
 # Tree View
 
-`rootline tree` displays the document hierarchy with completion counts derived from `estado` fields. Leaf nodes count as completed when `estado == "Completed"`; directory nodes sum their children.
+`rootline tree` displays the document hierarchy with recursive record totals. Leaf nodes represent Markdown records; directory nodes sum descendant record counts.
 
 ## CLI Usage
 
@@ -24,21 +24,21 @@ rootline tree -o table                            # ASCII tree
 ## Table Output
 
 ```
-docs [10/20]
+docs [21]
 ├── derivation.md [Completed]
 ├── describe.md [Completed]
 ├── fix.md [Completed]
 ├── graph.md [Completed]
 ├── query.md [Completed]
-└── research [0/10]
+└── research [10]
     ├── intrinsic-hierarchy-principle.md [In Progress]
-    ├── kedral [0/4]
+    ├── kedral [4]
     │   ├── README.md [—]
     │   └── design.md [—]
     └── opportunity-areas.md [Pre-research]
 ```
 
-Records without `estado` show `[—]`. Directories show `[completed/total]`.
+Records without the lifecycle/status field selected from the schema show `[—]`. Directories show `[total]`, where `total` is the recursive record count.
 
 ## JSON Result
 
@@ -71,6 +71,6 @@ Records without `estado` show `[—]`. Directories show `[completed/total]`.
 }
 ```
 
-The `total` count includes all children recursively; leaf nodes have `total: 1`. Field values appear in the `frontmatter` object.
+The `total` count includes all children recursively; leaf nodes have `total: 1`. Leaf field values appear in the `frontmatter` object, with derived and aggregate values merged into that map. Directory nodes do not carry `frontmatter`.
 
 `tree` supports `-o json` and `-o table` only. `-o jsonl` and `-o csv` are rejected — see [Output Formats](output.md).


### PR DESCRIPTION
## What

Reconcile Rootline's active user and agent documentation with the contracts already shipped by the CLI.

The branch is documentation-only and organized into four reviewable commits:

1. repair/fix contracts;
2. link resolution and configuration;
3. query, explain, tree, and projection output;
4. miscellaneous command and release contracts.

No runtime, tests, workflows, schemas, roadmap records, or historical plans/specs changed.

## Related issue

### Repair and fix contracts
Closes #141
Closes #150
Closes #155
Closes #165
Closes #167

### Link contracts
Closes #157
Closes #158
Closes #161
Closes #162
Closes #173

### Query and inspection contracts
Closes #146
Closes #153
Closes #154
Closes #159
Closes #168
Closes #172
Closes #176
Closes #177
Closes #180
Closes #182

### Miscellaneous and release contracts
Closes #140
Closes #156
Closes #160
Closes #169
Closes #175
Closes #181
Closes #202

## Why

The CLI, tests, and parsers had become more precise while README, `docs/`, and `.claude/skills/rootline/` retained older or aspirational descriptions. These contradictions affected both human operators and agents: invalid commands, wrong JSON paths, overstated write scopes, unconditional basename fallback, additive `links.styles`, nonexistent completion counts, and release/update guidance that no longer matched shipped behavior.

Keeping these surfaces aligned in one documentation-only PR makes the binary the single authority without mixing in behavioral changes.

## How

- Verified every issue against current `origin/master`, command help, source contracts, tests, and focused scratch fixtures.
- Corrected all active occurrences across README, command docs, and Rootline skill references; historical plans/specs and roadmap records remain untouched.
- Preserved important command distinctions: repair vs schema apply, schema-proposal vs analyze reports, graph/query indexed resolution vs validate, schema provenance vs computed expressions, and leaf vs directory tree nodes.
- Moved the strict-type compatibility correction from Unreleased to the earliest containing release, `v9.12.2`; the previous wording remains quoted only as historical context because an existing documentation-contract test anchors it.

### Acceptance evidence

A scratch governed corpus was exercised with the branch binary:

- `query` emitted `meta.count`, conditional `links`, and `slug: "mi-t-tulo"`;
- `query --where 'estado not in [nil]'` returned native existence-filtered rows;
- `tree` emitted recursive totals, leaf frontmatter, and no directory frontmatter;
- `explain` emitted root-to-leaf `stem_chain`, `aggregate`/`derived` origins, expressions, and no computed `defined_in`;
- `graph` emitted broken links as `source`, `target`, `type`, and `line`;
- `fix --all --dry-run` emitted `proposals: null`, `path`, `root`, and fixed summary counters on a clean corpus;
- `set --dry-run` emitted `would set ...`.

## Verification

- `git diff --check origin/master...HEAD`
- `just check` — 0 lint issues; build passed
- `just test` — all 16 packages passed with `-race`
- `just coverage-check` — 90.5% total; every package above its floor
- `just validate` — 126/126 roadmap records valid
- Independent final review — no critical, important, or minor findings; no issue coverage gaps
- Scope check — only 18 approved Markdown files changed

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing
- [x] Linked to its issues with closing keywords
