### PR TITLE
fix(rules): clarify null-field remediation

### DIFF
--- a/.claude/skills/rootline/SKILL.md
+++ b/.claude/skills/rootline/SKILL.md
@@ -41,9 +41,11 @@ anything, in any section — not `schema:`, not `derive:`, not `aggregate:`.
 - Setting a key to `null` in a child does not delete it. In `derive:` and
   `aggregate:` the parent's value survives; a `null` field in `schema:` is
   refused when the file is read, with one message naming the field.
-- Needing a field gone means the structure is wrong. Remove it from the `.stem`
-  that declares it, or move the records out from under that `.stem`. Never
-  propose a `null` override to make a validation error go away.
+- If a field should not apply to some records, stop governing those records
+  with the `.stem` that declares it: narrow that stem's `scope.match` or move
+  the records outside its scope. Remove the declaration only when the field
+  should disappear everywhere that `.stem` governs. Never propose a `null`
+  override to make a validation error go away.
 - The reason is the guarantee: a parent `.stem` promises a floor to everything
   beneath it. A child that drops a declaration lowers that floor silently for
   every record in the subtree, which is what hierarchical governance exists to

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -458,7 +458,7 @@ func ParseStem(path string, content []byte) (*StemFile, error) {
 	// read keeps a zero-valued declaration out of the pipeline entirely.
 	for _, name := range sortedSchemaFieldNames(stem.Schema) {
 		if stem.Schema[name].declaration.NullField {
-			return nil, fmt.Errorf("parsing %s: schema field %q is null — a child .stem never removes an inherited field; if the field should not exist, remove it from the .stem that declares it", path, name)
+			return nil, fmt.Errorf("parsing %s: schema field %q is null — a child .stem never removes an inherited field; to stop governing these records with that .stem, narrow its scope.match or move the records outside its scope; to remove the field everywhere, remove it from the .stem that declares it", path, name)
 		}
 	}
 

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -140,6 +140,29 @@ schema:
 	}
 }
 
+func TestParseStem_NullFieldMessageNamesScopedAndGlobalExits(t *testing.T) {
+	content := []byte(`
+version: 2
+schema:
+  removed: null
+`)
+
+	_, err := ParseStem("child/.stem", content)
+	if err == nil {
+		t.Fatal("expected null schema field to be rejected")
+	}
+
+	for _, want := range []string{
+		"narrow its scope.match",
+		"move the records outside its scope",
+		"remove it from the .stem that declares it",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name exit %q", err, want)
+		}
+	}
+}
+
 func TestParseStem_UnknownSectionsIgnored(t *testing.T) {
 	content := []byte(`
 version: 2


### PR DESCRIPTION
## What

Clarify the error emitted when a child `.stem` tries to remove an inherited schema field with `null`.

The message now distinguishes scoped remedies—narrowing the declaring stem's `scope.match` or moving records outside its scope—from removing the declaration globally. The Rootline skill carries the same guidance.

## Related issue

Closes #200

## Why

The previous message named only global removal. For the common subtree-scoped case, that advice could remove governance from every record beneath the declaring stem instead of only the affected records.

## How

- Preserve the existing null-field rejection and diagnostic shape.
- Name both scoped exits and the global exit in the `ParseStem` error.
- Add a direct regression test against the real parser behavior.
- Synchronize `.claude/skills/rootline/SKILL.md` without including #199 diagnostic metadata changes.

## Checklist

- [x] Tests pass (`go test ./... -race` via `just test`)
- [x] Code is clean (`go vet ./...`; `just check` reports 0 lint issues and builds successfully)
- [x] Changes are documented if user-facing
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)

Additional verification: `just coverage-check` passes at 90.5% total coverage.
