### PR TITLE
fix(rules): suppress derivative diagnostics for invalid fields

### DIFF
--- a/internal/rules/stemhealth.go
+++ b/internal/rules/stemhealth.go
@@ -175,6 +175,8 @@ func EvaluateStemState(ctx context.Context, state *StemState) (*StemHealthResult
 		return nil, ctx.Err()
 	}
 
+	invalidFieldsByStem := invalidSchemaFieldsByStem(parsedStems)
+
 	// Check 2: Orphan scopes (scope.match doesn't match any file in directory)
 	for _, sf := range sortedStemPaths(parsedStems) {
 		stem := parsedStems[sf]
@@ -215,6 +217,9 @@ func EvaluateStemState(ctx context.Context, state *StemState) (*StemHealthResult
 			continue
 		}
 		for _, fieldName := range sortedSchemaFieldNames(stem.Schema) {
+			if stemFieldIsInvalid(invalidFieldsByStem, sf, fieldName) {
+				continue
+			}
 			childField := stem.Schema[fieldName]
 			parentField, exists := parentMerged.Schema[fieldName]
 			if !exists {
@@ -404,6 +409,10 @@ func EvaluateStemState(ctx context.Context, state *StemState) (*StemHealthResult
 			if conflict.StemPath != sf || monotonicConflictIsType(conflict) {
 				continue
 			}
+			fieldName, _ := monotonicField(conflict.Field)
+			if stemFieldIsInvalid(invalidFieldsByStem, conflict.StemPath, fieldName) {
+				continue
+			}
 			identity := layerConflictIdentity{StemPath: conflict.StemPath, Field: conflict.Field, Operation: conflict.Operation}
 			if _, exists := emittedMonotonic[identity]; exists {
 				continue
@@ -577,6 +586,32 @@ func fieldDeclarationChecks(absRoot string, parsedStems map[string]*StemFile) []
 		}
 	}
 	return checks
+}
+
+func invalidSchemaFieldsByStem(parsedStems map[string]*StemFile) map[string]map[string]struct{} {
+	invalid := make(map[string]map[string]struct{}, len(parsedStems))
+	for _, stemPath := range sortedStemPaths(parsedStems) {
+		stem := parsedStems[stemPath]
+		for _, fieldName := range sortedSchemaFieldNames(stem.Schema) {
+			if len(ValidateFieldDeclaration(fieldName, stem.Schema[fieldName])) == 0 {
+				continue
+			}
+			if invalid[stemPath] == nil {
+				invalid[stemPath] = make(map[string]struct{})
+			}
+			invalid[stemPath][fieldName] = struct{}{}
+		}
+	}
+	return invalid
+}
+
+func stemFieldIsInvalid(invalidByStem map[string]map[string]struct{}, stemPath, fieldName string) bool {
+	fields := invalidByStem[stemPath]
+	if len(fields) == 0 {
+		return false
+	}
+	_, exists := fields[fieldName]
+	return exists
 }
 
 func sortedStemPaths(parsedStems map[string]*StemFile) []string {

--- a/internal/rules/stemhealth_test.go
+++ b/internal/rules/stemhealth_test.go
@@ -1348,6 +1348,48 @@ titulo: Hello World
 	}
 }
 
+func TestValidateStemHealth_EmptyMapSchemaFieldReportsOnlyFieldDeclaration(t *testing.T) {
+	dir := t.TempDir()
+
+	mustWriteStemTestFile(t, filepath.Join(dir, ".stem"), []byte(`version: 2
+root: true
+schema:
+  removed:
+    type: string
+    required: true
+`))
+
+	mustWriteStemTestFile(t, filepath.Join(dir, "child", ".stem"), []byte(`version: 2
+schema:
+  removed: {}
+`))
+
+	result, err := ValidateStemHealth(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var removedFailures []StemHealthCheck
+	for _, check := range result.Checks {
+		if check.Status == "fail" && check.Field == "removed" {
+			removedFailures = append(removedFailures, check)
+		}
+	}
+
+	if len(removedFailures) != 1 {
+		t.Fatalf("failures for field removed = %d, want 1: %+v", len(removedFailures), removedFailures)
+	}
+	if removedFailures[0].Name != "field-declaration" {
+		t.Fatalf("failure check = %q, want field-declaration", removedFailures[0].Name)
+	}
+	if !strings.Contains(removedFailures[0].Message, "incomplete-type") {
+		t.Fatalf("failure message = %q, want incomplete-type", removedFailures[0].Message)
+	}
+
+	assertNoStemHealthCheck(t, result, "type-consistency", "removed")
+	assertNoStemHealthCheck(t, result, "monotonic-violations", "removed")
+}
+
 // TestValidateStemHealth_TypeWideningStillDetected is an adversarial control:
 // verify that real type widening (not null removal) still produces errors.
 func TestValidateStemHealth_TypeWideningStillDetected(t *testing.T) {


### PR DESCRIPTION
## What

Suppress derivative inheritance diagnostics when a local `.stem` schema field declaration is already invalid.

## Related issue

Closes #201

## Why

An empty map declaration such as `removed: {}` already produces the actionable `field-declaration` / `incomplete-type` error. Feeding that zero-valued field into inherited compatibility checks added misleading `required` loosening and empty-type change errors for the same mistake.

## How

- Index fields with local declaration issues per `.stem`.
- Keep the existing primary `field-declaration` diagnostics.
- Exclude those fields from `type-consistency` and `monotonic-violations` comparisons for the same owning stem.
- Add a regression test requiring exactly one error for the empty-map reproduction while preserving valid widening and null-field controls.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing (not applicable; behavior is covered by regression tests)
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)

Additional verification: `just check`, `just coverage-check` (90.5% total; all package floors pass), and the issue reproduction against a freshly built binary.