### PR TITLE
fix(rules): honor descendant scope matches

### DIFF
--- a/.claude/skills/rootline/ref-validate.md
+++ b/.claude/skills/rootline/ref-validate.md
@@ -66,7 +66,7 @@ empty index, and the scan-failure path. Never branch on the flags; the keys are 
   ],
   "stem_health": [
     { "path": "sub/.stem", "check": "scope-match",
-      "severity": "warn", "message": "scope.match \"*.txt\" matches no files in directory" }
+      "severity": "warn", "message": "scope.match \"*.txt\" matches no files in governed subtree" }
   ],
   "drift_warnings": [],
   "notices": [ { "severity": "warn", "code": "no_records", "message": "no records found in scope" } ],

--- a/.claude/skills/rootline/ref-validate.md
+++ b/.claude/skills/rootline/ref-validate.md
@@ -87,7 +87,9 @@ Reading it:
   `query --count` on the same path. Directory verdicts from `structural:` rules are in
   `structural[]` (trailing-slash paths; the scan root is `"/"`).
 - `.stem` diagnostics are in `stem_health`, keyed by `check`, with `severity` `error`,
-  `warn` or `info`. `info` (e.g. `nested-root-marker`) never fails `--strict`.
+  `warn` or `info`. Ancestor scopes include inheriting descendants but exclude files
+  filtered by `.stemignore`; overrides and nested roots own their matches. `info` (e.g.
+  `nested-root-marker`) never fails `--strict`.
 - `notices` carries run-level diagnostics by stable `code`: `scan_failed`,
   `schema_resolution_failed`, `stem_health_unavailable`, `no_records`.
 - A tree with no `.stem`, or one that is malformed or semantically refused, still emits this envelope —

--- a/cmd/rootline/validate_test.go
+++ b/cmd/rootline/validate_test.go
@@ -533,6 +533,30 @@ func TestValidateAll_StemHealthWarnings(t *testing.T) {
 	}
 }
 
+func TestValidateAllStrict_DescendantScopeMatchesAreHealthy(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":               "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\nschema:\n  id:\n    type: string\n    required: true\n",
+		"proxmox/CONTRACT.md": "---\nid: proxmox\n---\n# Proxmox\n",
+		"runtime/CONTRACT.md": "---\nid: runtime\n---\n# Runtime\n",
+	})
+	mustChdir(t, root)
+
+	stdout, err := executeValidate(t, "--all", "--strict")
+	if err != nil {
+		t.Fatalf("validate --all --strict error = %v, want nil\noutput: %s", err, stdout)
+	}
+
+	env := decodeEnvelope(t, stdout)
+	if got := env["summary"].(map[string]any)["total"].(float64); got != 2 {
+		t.Fatalf("summary.total = %v, want 2", got)
+	}
+	for _, diagnostic := range stemHealthChecks(t, env) {
+		if diagnostic["check"] == "scope-match" {
+			t.Fatalf("unexpected scope-match diagnostic: %#v", diagnostic)
+		}
+	}
+}
+
 // TestValidateAll_NoSchemaAnywhere tests that validate --all exits non-zero
 // when no .stem files exist in the tree.
 func TestValidateAll_NoSchemaAnywhere(t *testing.T) {

--- a/cmd/rootline/validate_test.go
+++ b/cmd/rootline/validate_test.go
@@ -557,6 +557,33 @@ func TestValidateAllStrict_DescendantScopeMatchesAreHealthy(t *testing.T) {
 	}
 }
 
+func TestValidateAllStrict_IgnoredDescendantDoesNotSatisfyAncestorScope(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":               "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+		".stemignore":         "ignored/CONTRACT.md\n",
+		"ignored/CONTRACT.md": "# Ignored\n",
+		"nested/.stem":        "version: 2\nroot: true\nscope:\n  match: \"README.md\"\nschema:\n  id:\n    type: string\n    required: true\n",
+		"nested/README.md":    "---\nid: nested\n---\n# Nested\n",
+	})
+	mustChdir(t, root)
+
+	stdout, err := executeValidate(t, "--all", "--strict")
+	if err != ErrValidationFailed {
+		t.Fatalf("validate --all --strict error = %v, want ErrValidationFailed\noutput: %s", err, stdout)
+	}
+
+	env := decodeEnvelope(t, stdout)
+	var found bool
+	for _, diagnostic := range stemHealthChecks(t, env) {
+		if diagnostic["check"] == "scope-match" && diagnostic["path"] == ".stem" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing outer scope-match diagnostic: %s", stdout)
+	}
+}
+
 // TestValidateAll_NoSchemaAnywhere tests that validate --all exits non-zero
 // when no .stem files exist in the tree.
 func TestValidateAll_NoSchemaAnywhere(t *testing.T) {

--- a/docs/adr/0009-resolver-scope-matches-mediante-cadena-de-gobierno.md
+++ b/docs/adr/0009-resolver-scope-matches-mediante-cadena-de-gobierno.md
@@ -1,0 +1,22 @@
+---
+tipo: adr
+estado: accepted
+fecha: '2026-08-29'
+contexto: 'Stem health evaluaba scope.match solo contra archivos inmediatos, aunque el descubrimiento recursivo gobierna descendientes y --strict fallaba sobre corpus válidos.'
+decision: 'Derivar para cada archivo inventariado el stem propietario del scope.match efectivo mediante Chain; la herencia alcanza descendientes y los overrides o root:true anidados conservan propiedad exclusiva.'
+alternativas: 'Se descartó buscar por prefijo recursivo porque atravesaría overrides y raíces anidadas; se descartó pasar records descubiertos porque acoplaría el evaluador puro a Scan y ampliaría innecesariamente el alcance hacia el filesystem inyectable.'
+consecuencias: 'Los diagnósticos coinciden con la cadena real de gobierno; el cálculo recorre una cadena por archivo y no añade estado, flags ni otra autoridad de resolución.'
+---
+# 0009. Resolver scope matches mediante cadena de gobierno
+
+## Contexto
+Stem health evaluaba scope.match solo contra archivos inmediatos, aunque el descubrimiento recursivo gobierna descendientes y --strict fallaba sobre corpus válidos.
+
+## Decisión
+Derivar para cada archivo inventariado el stem propietario del scope.match efectivo mediante Chain; la herencia alcanza descendientes y los overrides o root:true anidados conservan propiedad exclusiva.
+
+## Alternativas descartadas
+Se descartó buscar por prefijo recursivo porque atravesaría overrides y raíces anidadas; se descartó pasar records descubiertos porque acoplaría el evaluador puro a Scan y ampliaría innecesariamente el alcance hacia el filesystem inyectable.
+
+## Consecuencias
+Los diagnósticos coinciden con la cadena real de gobierno; el cálculo recorre una cadena por archivo y no añade estado, flags ni otra autoridad de resolución.

--- a/docs/adr/0009-resolver-scope-matches-mediante-cadena-de-gobierno.md
+++ b/docs/adr/0009-resolver-scope-matches-mediante-cadena-de-gobierno.md
@@ -1,11 +1,12 @@
 ---
 tipo: adr
-estado: accepted
+estado: superseded
 fecha: '2026-08-29'
 contexto: 'Stem health evaluaba scope.match solo contra archivos inmediatos, aunque el descubrimiento recursivo gobierna descendientes y --strict fallaba sobre corpus válidos.'
 decision: 'Derivar para cada archivo inventariado el stem propietario del scope.match efectivo mediante Chain; la herencia alcanza descendientes y los overrides o root:true anidados conservan propiedad exclusiva.'
 alternativas: 'Se descartó buscar por prefijo recursivo porque atravesaría overrides y raíces anidadas; se descartó pasar records descubiertos porque acoplaría el evaluador puro a Scan y ampliaría innecesariamente el alcance hacia el filesystem inyectable.'
 consecuencias: 'Los diagnósticos coinciden con la cadena real de gobierno; el cálculo recorre una cadena por archivo y no añade estado, flags ni otra autoridad de resolución.'
+superseded_by: 0010-distinguir-inventario-fisico-y-elegibilidad-de-scope
 ---
 # 0009. Resolver scope matches mediante cadena de gobierno
 

--- a/docs/adr/0010-distinguir-inventario-fisico-y-elegibilidad-de-scope.md
+++ b/docs/adr/0010-distinguir-inventario-fisico-y-elegibilidad-de-scope.md
@@ -1,0 +1,24 @@
+---
+tipo: adr
+estado: proposed
+fecha: '2026-08-29'
+contexto: 'La revisión adversarial demostró que un descendiente excluido por .stemignore podía satisfacer el scope ancestro porque StemState no distinguía presencia física de pertenencia gobernada.'
+decision: 'Conservar todas las entradas físicas en StemState, marcar su elegibilidad mediante StemStateEntry.Ignored con la semántica existente de .stemignore y excluir las ignoradas al atribuir scope.match por Chain.'
+alternativas: 'Se descartó pasar records de Scan porque acoplaría la evaluación pura al scanner; se descartó eliminar entradas del snapshot porque perdería inventario físico útil para overlays; se descartó importar internal/index porque crearía un ciclo de dependencias.'
+consecuencias: 'Stem health comparte la pertenencia observable del scanner sin perder pureza ni inventario; la detección añade una comprobación de ignore por archivo y exige mantener sincronizada la semántica duplicada de .stemignore.'
+---
+# 0010. Distinguir inventario fisico y elegibilidad de scope
+
+Reemplaza a 0009-resolver-scope-matches-mediante-cadena-de-gobierno.
+
+## Contexto
+La revisión adversarial demostró que un descendiente excluido por .stemignore podía satisfacer el scope ancestro porque StemState no distinguía presencia física de pertenencia gobernada.
+
+## Decisión
+Conservar todas las entradas físicas en StemState, marcar su elegibilidad mediante StemStateEntry.Ignored con la semántica existente de .stemignore y excluir las ignoradas al atribuir scope.match por Chain.
+
+## Alternativas descartadas
+Se descartó pasar records de Scan porque acoplaría la evaluación pura al scanner; se descartó eliminar entradas del snapshot porque perdería inventario físico útil para overlays; se descartó importar internal/index porque crearía un ciclo de dependencias.
+
+## Consecuencias
+Stem health comparte la pertenencia observable del scanner sin perder pureza ni inventario; la detección añade una comprobación de ignore por archivo y exige mantener sincronizada la semántica duplicada de .stemignore.

--- a/docs/adr/0010-distinguir-inventario-fisico-y-elegibilidad-de-scope.md
+++ b/docs/adr/0010-distinguir-inventario-fisico-y-elegibilidad-de-scope.md
@@ -1,6 +1,6 @@
 ---
 tipo: adr
-estado: proposed
+estado: accepted
 fecha: '2026-08-29'
 contexto: 'La revisión adversarial demostró que un descendiente excluido por .stemignore podía satisfacer el scope ancestro porque StemState no distinguía presencia física de pertenencia gobernada.'
 decision: 'Conservar todas las entradas físicas en StemState, marcar su elegibilidad mediante StemStateEntry.Ignored con la semántica existente de .stemignore y excluir las ignoradas al atribuir scope.match por Chain.'

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -253,7 +253,8 @@ root.total` and `stats --field total` all reported 3 on the same path.
 
 A scope declared by an ancestor is healthy when it matches a descendant file that
 inherits that declaration. A nested `root: true` boundary or a descendant `scope.match`
-override owns its own matches and does not satisfy the ancestor's scope.
+override owns its own matches and does not satisfy the ancestor's scope. Files excluded
+by `.stemignore` do not participate and therefore cannot satisfy any scope.
 
 `severity` is `error`, `warn` or `info`. `info` is a real level, not a demoted warning:
 `nested-root-marker` describes a supported configuration and must not fail `--strict`.

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -247,9 +247,13 @@ root.total` and `stats --field total` all reported 3 on the same path.
   "path": "docs/sub/.stem",
   "check": "scope-match",
   "severity": "warn",
-  "message": "scope.match \"*.txt\" matches no files in directory"
+  "message": "scope.match \"*.txt\" matches no files in governed subtree"
 }
 ```
+
+A scope declared by an ancestor is healthy when it matches a descendant file that
+inherits that declaration. A nested `root: true` boundary or a descendant `scope.match`
+override owns its own matches and does not satisfy the ancestor's scope.
 
 `severity` is `error`, `warn` or `info`. `info` is a real level, not a demoted warning:
 `nested-root-marker` describes a supported configuration and must not fail `--strict`.

--- a/internal/rules/stem_state.go
+++ b/internal/rules/stem_state.go
@@ -208,34 +208,38 @@ func (s *StemState) EvaluatedStemPaths() []string {
 	return paths
 }
 
-// MatchingFiles returns immediate, non-directory entries in dir whose basename
-// matches pattern. Results are state-local and deterministic.
-func (s *StemState) MatchingFiles(dir, pattern string) []string {
+// EffectiveScopeMatches reports which .stem declaration owns at least one
+// matching file in the state inventory. The closest non-empty scope.match in a
+// file's governing chain owns that match, so inheritance, overrides, and nested
+// root boundaries follow the same resolution semantics as record discovery.
+func (s *StemState) EffectiveScopeMatches() map[string]bool {
+	matches := make(map[string]bool)
 	if s == nil {
-		return nil
+		return matches
 	}
 
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		absDir = filepath.Clean(dir)
-	} else {
-		absDir = filepath.Clean(absDir)
-	}
-
-	var matches []string
 	for path, entry := range s.Entries {
-		if entry.IsDir || filepath.Dir(path) != absDir {
+		if entry.IsDir || filepath.Base(path) == stemFileName {
 			continue
 		}
-		ok, err := filepath.Match(pattern, filepath.Base(path))
-		if err != nil {
-			return nil
+
+		owner := ""
+		pattern := ""
+		for _, stemEntry := range s.Chain(path) {
+			if stemEntry.Stem != nil && stemEntry.Stem.Scope.Match != "" {
+				owner = stemEntry.Path
+				pattern = stemEntry.Stem.Scope.Match
+			}
 		}
-		if ok {
-			matches = append(matches, path)
+		if owner == "" {
+			continue
+		}
+
+		matched, err := filepath.Match(pattern, filepath.Base(path))
+		if err == nil && matched {
+			matches[owner] = true
 		}
 	}
-	sort.Strings(matches)
 	return matches
 }
 

--- a/internal/rules/stem_state.go
+++ b/internal/rules/stem_state.go
@@ -28,7 +28,8 @@ type StemState struct {
 
 // StemStateEntry records the state-local inventory for a discovered path.
 type StemStateEntry struct {
-	IsDir bool
+	IsDir   bool
+	Ignored bool
 }
 
 // DiscoverStemState walks root once, preserving both parseable .stem files and
@@ -51,6 +52,7 @@ func DiscoverStemState(ctx context.Context, root string) (*StemState, error) {
 		ParseErrors: make(map[string]error),
 		Entries:     make(map[string]StemStateEntry),
 	}
+	var ignores []stemIgnoreScope
 
 	scanRoot, err := os.OpenRoot(absRoot)
 	if err != nil {
@@ -70,9 +72,17 @@ func DiscoverStemState(ctx context.Context, root string) (*StemState, error) {
 			return filepath.SkipDir
 		}
 
-		state.Entries[path] = StemStateEntry{IsDir: info.IsDir()}
+		if info.IsDir() {
+			state.Entries[path] = StemStateEntry{IsDir: true}
+			if patterns, loadErr := parseStemIgnore(filepath.Join(path, ".stemignore")); loadErr == nil {
+				ignores = append(ignores, stemIgnoreScope{dir: path, patterns: patterns})
+			}
+			return nil
+		}
 
-		if !info.IsDir() && info.Name() == stemFileName {
+		state.Entries[path] = StemStateEntry{Ignored: stemIsIgnored(path, ignores)}
+
+		if info.Name() == stemFileName {
 			content, err := readStemStateFileThroughRoot(scanRoot, absRoot, path)
 			if err != nil {
 				return err
@@ -219,7 +229,7 @@ func (s *StemState) EffectiveScopeMatches() map[string]bool {
 	}
 
 	for path, entry := range s.Entries {
-		if entry.IsDir || filepath.Base(path) == stemFileName {
+		if entry.IsDir || entry.Ignored || filepath.Base(path) == stemFileName {
 			continue
 		}
 

--- a/internal/rules/stem_state_test.go
+++ b/internal/rules/stem_state_test.go
@@ -286,26 +286,6 @@ func TestStemStateEvaluatedPathsAreSorted(t *testing.T) {
 	})
 }
 
-func TestStemStateMatchingFilesUsesImmediateNonDirectoryEntries(t *testing.T) {
-	root := t.TempDir()
-	dir := filepath.Join(root, "docs")
-	state := &StemState{
-		Root: filepath.Clean(root),
-		Entries: map[string]StemStateEntry{
-			filepath.Join(dir, "a.md"):           {IsDir: false},
-			filepath.Join(dir, "b.txt"):          {IsDir: false},
-			filepath.Join(dir, "nested", "c.md"): {IsDir: false},
-			filepath.Join(dir, "draft.md"):       {IsDir: true},
-			filepath.Join(dir, "z.md"):           {IsDir: false},
-		},
-	}
-
-	requireStemStatePaths(t, state.MatchingFiles(dir, "*.md"), []string{
-		filepath.Join(dir, "a.md"),
-		filepath.Join(dir, "z.md"),
-	})
-}
-
 func mustWriteStemStateFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/rules/stemhealth.go
+++ b/internal/rules/stemhealth.go
@@ -177,25 +177,18 @@ func EvaluateStemState(ctx context.Context, state *StemState) (*StemHealthResult
 
 	invalidFieldsByStem := invalidSchemaFieldsByStem(parsedStems)
 
-	// Check 2: Orphan scopes (scope.match doesn't match any file in directory)
+	// Check 2: Orphan scopes (scope.match doesn't match any file in its governed subtree)
+	effectiveScopeMatches := state.EffectiveScopeMatches()
 	for _, sf := range sortedStemPaths(parsedStems) {
 		stem := parsedStems[sf]
 		if stem.Scope.Match == "" {
 			continue
 		}
-		hasMatch := false
-		for _, match := range state.MatchingFiles(filepath.Dir(sf), stem.Scope.Match) {
-			if filepath.Base(match) == stemFileName {
-				continue
-			}
-			hasMatch = true
-			break
-		}
-		if !hasMatch {
+		if !effectiveScopeMatches[sf] {
 			checks = append(checks, StemHealthCheck{
 				Name:    "scope-match",
 				Status:  "warn",
-				Message: fmt.Sprintf("scope.match %q matches no files in directory", stem.Scope.Match),
+				Message: fmt.Sprintf("scope.match %q matches no files in governed subtree", stem.Scope.Match),
 				Path:    stemHealthRelPath(absRoot, sf),
 			})
 		}

--- a/internal/rules/stemhealth_test.go
+++ b/internal/rules/stemhealth_test.go
@@ -129,9 +129,18 @@ func TestValidateStemHealth_ScopeMatchUsesEffectiveGovernedSubtree(t *testing.T)
 			wantPaths: nil,
 		},
 		{
+			name: "ignored descendant does not satisfy ancestor scope",
+			files: map[string]string{
+				".stem":               "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+				".stemignore":         "ignored/CONTRACT.md\n",
+				"ignored/CONTRACT.md": "# Ignored\n",
+			},
+			wantPaths: []string{".stem"},
+		},
+		{
 			name: "child scope override does not satisfy ancestor scope",
 			files: map[string]string{
-				".stem":                   "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+				".stem":                   "version: 2\nroot: true\nscope:\n  match: \"*.md\"\n",
 				"component/.stem":         "version: 2\nscope:\n  match: \"README.md\"\n",
 				"component/api/README.md": "# Component\n",
 			},

--- a/internal/rules/stemhealth_test.go
+++ b/internal/rules/stemhealth_test.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -109,6 +110,65 @@ scope:
 		if c.Name == "scope-match" {
 			t.Error("unexpected scope-match check when files match")
 		}
+	}
+}
+
+func TestValidateStemHealth_ScopeMatchUsesEffectiveGovernedSubtree(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     map[string]string
+		wantPaths []string
+	}{
+		{
+			name: "ancestor scope is inherited by descendant records",
+			files: map[string]string{
+				".stem":                     "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+				"component/.stem":           "version: 2\n",
+				"component/api/CONTRACT.md": "# Contract\n",
+			},
+			wantPaths: nil,
+		},
+		{
+			name: "child scope override does not satisfy ancestor scope",
+			files: map[string]string{
+				".stem":                   "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+				"component/.stem":         "version: 2\nscope:\n  match: \"README.md\"\n",
+				"component/api/README.md": "# Component\n",
+			},
+			wantPaths: []string{".stem"},
+		},
+		{
+			name: "nested root does not satisfy outer scope",
+			files: map[string]string{
+				".stem":                     "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+				"component/.stem":           "version: 2\nroot: true\nscope:\n  match: \"CONTRACT.md\"\n",
+				"component/api/CONTRACT.md": "# Contract\n",
+			},
+			wantPaths: []string{".stem"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for path, content := range tt.files {
+				mustWriteStemTestFile(t, filepath.Join(dir, path), []byte(content))
+			}
+
+			result, err := ValidateStemHealth(context.Background(), dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var gotPaths []string
+			for _, diagnostic := range StemHealthDiagnostics(result) {
+				if diagnostic.Check == "scope-match" {
+					gotPaths = append(gotPaths, diagnostic.Path)
+				}
+			}
+			if !reflect.DeepEqual(gotPaths, tt.wantPaths) {
+				t.Fatalf("scope-match diagnostic paths = %v, want %v", gotPaths, tt.wantPaths)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

- make stem-health `scope-match` recognize matching files in descendant directories governed by an ancestor `.stem`
- preserve ownership boundaries for descendant `scope.match` overrides and nested `root: true` stems
- update validation documentation, managed skill guidance, and ADR 0009

## Related issue

Closes #214

## Why

`validate --all` recursively discovered and validated descendant `CONTRACT.md` records, while stem health inspected only files beside the declaring `.stem`. Under `--strict`, that mismatch produced exit 1 for an otherwise valid corpus.

## How

`StemState.EffectiveScopeMatches` derives the closest non-empty `scope.match` owner from each inventoried file's existing governance `Chain`. `EvaluateStemState` consumes that state-local presence map, keeping prospective overlay evaluation pure and avoiding a second filesystem/resolution authority.

Regression coverage includes inherited descendant matches, child overrides, nested roots, direct matches, true orphan scopes, and the exact two-descendant `validate --all --strict` acceptance case.

## Verification

- `just check`
- `just test`
- `just coverage-check` — 89.9% total; every package floor passed
- `just validate` — 126/126 roadmap records valid
- exact CLI acceptance — 2 valid descendant records, 0 scope warnings, exit 0
- independent final review of `85e84a5..21a4fd5` — READY, no Critical/Important findings

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing
- [x] Linked to its issue with a closing keyword, or deliberately left unlinked (intermediate PR of a chain)
