### PR TITLE
fix(query): preserve selected field order in JSONL output

### DIFF
--- a/cmd/rootline/commands_test.go
+++ b/cmd/rootline/commands_test.go
@@ -1344,28 +1344,68 @@ func TestQueryOutputCSVNoSelect(t *testing.T) {
 
 func TestQueryOutputJSONLColumnOrder(t *testing.T) {
 	dir := setupTestDir(t)
-	out, err := runCmd(t, "query", "--from", dir, "--select", "estado,path", "--output", "jsonl")
+	for _, tc := range []struct {
+		selectFields string
+		want         string
+	}{
+		{
+			selectFields: "path,estado,tipo",
+			want: "{\"path\":\"doc1.md\",\"estado\":\"Pending\",\"tipo\":\"test\"}\n" +
+				"{\"path\":\"doc2.md\",\"estado\":\"Completed\",\"tipo\":\"prod\"}\n",
+		},
+		{
+			selectFields: "tipo,path,estado",
+			want: "{\"tipo\":\"test\",\"path\":\"doc1.md\",\"estado\":\"Pending\"}\n" +
+				"{\"tipo\":\"prod\",\"path\":\"doc2.md\",\"estado\":\"Completed\"}\n",
+		},
+		{
+			selectFields: "tipo,missing,path,tipo,links,estado",
+			want: "{\"tipo\":\"test\",\"path\":\"doc1.md\",\"estado\":\"Pending\"}\n" +
+				"{\"tipo\":\"prod\",\"path\":\"doc2.md\",\"estado\":\"Completed\"}\n",
+		},
+		{selectFields: "missing,links", want: "{}\n{}\n"},
+	} {
+		t.Run(tc.selectFields, func(t *testing.T) {
+			out, err := runCmd(t, "query", dir, "--select", tc.selectFields, "--sort", "path:asc", "-o", "jsonl")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if out != tc.want {
+				t.Errorf("JSONL output = %q, want %q", out, tc.want)
+			}
+			for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+				if !json.Valid([]byte(line)) {
+					t.Errorf("invalid JSONL line: %q", line)
+				}
+			}
+		})
+	}
+}
+
+func TestQueryOutputJSONLPreservesValuesAndEscaping(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, ".stem"), []byte("version: 2\nroot: true\nscope:\n  match: '*.md'\nschema: {}\n"), 0o644)
+	mustWriteFile(t, filepath.Join(dir, "doc.md"), []byte(`---
+text: "line one\n\"quoted\" \\ café <tag>"
+'quoted"key': value
+empty: null
+enabled: false
+count: 0
+items: [one, two]
+object: {nested: true}
+---
+# Document
+`), 0o644)
+	out, err := runCmd(t, "query", dir, "--select", `text,quoted"key,empty,enabled,count,items,object,path,missing,links`, "-o", "jsonl")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) == 0 {
-		t.Fatal("expected JSONL output lines")
+	want := `{"text":"line one\n\"quoted\" \\ café \u003ctag\u003e","quoted\"key":"value","empty":null,"enabled":false,"count":0,"items":["one","two"],"object":{"nested":true},"path":"doc.md"}` + "\n"
+	if out != want {
+		t.Errorf("JSONL output = %q, want %q", out, want)
 	}
-
-	// Parse first line and check field order is preserved in the JSON object
-	var obj map[string]any
-	if err := json.Unmarshal([]byte(lines[0]), &obj); err != nil {
-		t.Fatalf("first line not valid JSON: %v", err)
-	}
-
-	// Both fields should exist in the projected row
-	if _, ok := obj["estado"]; !ok {
-		t.Errorf("expected 'estado' field in JSONL object")
-	}
-	if _, ok := obj["path"]; !ok {
-		t.Errorf("expected 'path' field in JSONL object")
+	if !json.Valid([]byte(out)) {
+		t.Errorf("invalid JSONL output: %q", out)
 	}
 }
 

--- a/cmd/rootline/query.go
+++ b/cmd/rootline/query.go
@@ -216,7 +216,7 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		if querySelect == "" {
 			return fmt.Errorf("jsonl output requires --select flag")
 		}
-		return outputQueryJSONL(cmd, result)
+		return outputQueryJSONL(cmd, result, parseSelectFields(querySelect))
 	}
 	if outputFormat == "csv" {
 		if querySelect == "" {
@@ -392,18 +392,38 @@ func projectQueryResult(result any, fields []string) (any, error) {
 }
 
 // outputQueryJSONL outputs a ProjectedQueryResult as JSON Lines (one JSON object per line).
-func outputQueryJSONL(cmd *cobra.Command, result any) error {
+// Present keys follow --select order instead of encoding/json's map-key order.
+func outputQueryJSONL(cmd *cobra.Command, result any, fields []string) error {
 	pqr, ok := result.(*query.ProjectedQueryResult)
 	if !ok {
 		return fmt.Errorf("expected ProjectedQueryResult for jsonl output")
 	}
 
 	for _, row := range pqr.Rows {
-		b, err := json.Marshal(row)
-		if err != nil {
-			return fmt.Errorf("marshaling row to JSON: %w", err)
+		var b strings.Builder
+		b.WriteByte('{')
+		seen := make(map[string]bool, len(fields))
+		for _, field := range fields {
+			value, present := row[field]
+			if !present || seen[field] {
+				continue
+			}
+			encodedValue, err := json.Marshal(value)
+			if err != nil {
+				return fmt.Errorf("marshaling row to JSON: %w", err)
+			}
+			// A string key always marshals successfully; preserve JSON escaping.
+			encodedKey, _ := json.Marshal(field)
+			if len(seen) > 0 {
+				b.WriteByte(',')
+			}
+			b.Write(encodedKey)
+			b.WriteByte(':')
+			b.Write(encodedValue)
+			seen[field] = true
 		}
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(b)); err != nil {
+		b.WriteByte('}')
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), b.String()); err != nil {
 			return fmt.Errorf("writing JSONL line: %w", err)
 		}
 	}


### PR DESCRIPTION
[rootline-team]

Closes #171

## Problem and scope

The documented JSONL contract promises `--select` key order, but the writer marshaled projected maps, silently sorting keys alphabetically. This violates the serialization contract in [docs/query.md](https://github.com/pablontiv/rootline/blob/8c46f8dc6f588520ce0c61bd361c089f3b4616a0/docs/query.md).

This change passes the selection sequence to the JSONL writer and writes each present key/value in that sequence using standard JSON escaping. It keeps duplicate selections collapsed, missing fields and empty links omitted, explicit null/false/zero values preserved, and nested values unchanged. Each complete row is buffered before writing.

Only the JSONL writer/call site and regression tests change. CSV, regular versioned JSON, selection/projection semantics, domain independence, optional Git and .stem contracts are unchanged. No documentation change is necessary because the existing documented behavior is restored. Does not include #221 or Scorecard #219.

## Acceptance and executed verification

- Two distinct non-alphabetic selections now have exact serialized-output assertions for both rows.
- Covered omissions, duplicate fields, empty projected objects, explicit null, false, zero, arrays/objects, Unicode, newline/quote/backslash and JSON-escaped keys.
- RED: new order/escaping assertions failed on the base writer; GREEN: the same regressions and related query format/source-backed projection tests passed after this fix.
- `just check`: passed (golangci-lint 2.13.1: 0 issues, build).
- `just test`: passed, all 17 packages with race detector.
- `just coverage-check`: passed every per-package floor, 90.0% total; cmd/rootline 87.6%.
- `go mod tidy` then `git diff --exit-code -- go.mod go.sum`: passed, no dependency changes.
- `govulncheck ./...`: no vulnerabilities found.
- `gitleaks dir cmd/rootline --redact`: no leaks.
- `sh tests/installers/install-sh-test.sh`: passed on Linux. Native macOS/Windows checks remain CI's responsibility, not claimed locally.
- Built dev CLI and `rootline validate --all docs/roadmap/`: 126/126 valid, zero errors/warnings.
- Real external CLI comparison on a valid two-record, no-Git fixture: base always emits `owner,path,status`; fix emits `path,status,owner` or `status,path,owner` as requested. Both produce 2 valid JSON lines, exit 0. CSV header and JSON `version:1, kind:rootline/query, meta.count:2` preserved. Fixture SHA-256 hashes unchanged after read commands.

After publication, a clean checkout of the exact head SHA was rebuilt and the focused regressions and real CLI fixture checks passed again. Published-SHA dev binary SHA-256: `882601f15e3fe531835ba7d67376491aec8b925f4fe9fa2e47e931003091d728`.

Platform: Linux/amd64; official temporary Go 1.27.1 archive verified against its published SHA-256. Tests ran on tree `c8f5a1a9f586d9388bdca6a495837437643c9298`, exactly matching published commit `aab08d438cdbe209429e173710b7a1613f54f7e8`; base `8c46f8dc6f588520ce0c61bd361c089f3b4616a0`.

## Reproduce with the real CLI (for independent QA)

Implementation is complete. [Published-SHA CI #829](https://github.com/pablontiv/rootline/actions/runs/33980933330) passed and independent QA issued [QA_PASS](https://github.com/pablontiv/rootline/pull/222#issuecomment-5553598038) for the current SHA. The PR is ready for reviewer integration. Developer checks do not substitute for QA.

Checkout head `aab08d438cdbe209429e173710b7a1613f54f7e8` in an isolated directory, use Go compatible with go.mod, and build a dev binary:

```sh
go build -o /tmp/rootline-171 ./cmd/rootline/
go test ./cmd/rootline -run '^(TestQueryOutput|TestTask9QueryFormatsPreserveSourceBackedOrderAndCounts)' -count=1
```

Create an isolated directory `<fixture>` with no Git and these three files:

`.stem`:
```yaml
version: 2
root: true
scope:
  match: '*.md'
schema:
  status:
    type: string
  owner:
    type: string
```

`a.md`:
```markdown
---
status: Pending
owner: Alice
---
# A
```

`b.md`:
```markdown
---
status: Done
owner: Bob
---
# B
```

Run:
```sh
/tmp/rootline-171 validate --all <fixture>
/tmp/rootline-171 query <fixture> --select path,status,owner --sort path:asc -o jsonl
/tmp/rootline-171 query <fixture> --select status,path,owner --sort path:asc -o jsonl
/tmp/rootline-171 query <fixture> --select status,missing,path,status,links,owner --sort path:asc -o jsonl
/tmp/rootline-171 query <fixture> --select missing,links -o jsonl
/tmp/rootline-171 query <fixture> --select status,path,owner -o csv
/tmp/rootline-171 query <fixture> --select status,path,owner -o json
```

Expected: validation valid=2; first command's first row `{"path":"a.md","status":"Pending","owner":"Alice"}`; second and third first row `{"status":"Pending","path":"a.md","owner":"Alice"}`; fourth exactly two `{}` lines. CSV header `status,path,owner`; ordinary JSON retains its versioned envelope. All exit 0 and no file changes. Additional escaped/nested/null fixture is durable in `TestQueryOutputJSONLPreservesValuesAndEscaping`.

Risk: low, bounded serialization fix; no migration or destructive writes. Squash title is a compatible patch-release fix. Current-SHA CI and QA gates are satisfied; the reviewer must recheck the head, rules and checks immediately before squash merge.
