### PR TITLE
fix(schema): suppress redundant governed bootstrap proposal

### DIFF
--- a/cmd/rootline/schema.go
+++ b/cmd/rootline/schema.go
@@ -1010,7 +1010,12 @@ func generateSchemaProposals(ctx context.Context, root string, records []*extrac
 	if incremental && resolve != nil && generatedStem != nil {
 		// Convert schema fields to inferences for filtering
 		inferences := schemaToInferences(generatedStem)
-		if len(inferences) > 0 {
+		if len(inferences) == 0 && existingStem != nil {
+			// An empty generated schema has nothing to add to an already
+			// governed tree. Keep the bootstrap proposal only when no stem
+			// exists yet.
+			proposals = nil
+		} else if len(inferences) > 0 {
 			// Filter inferences using per-scope resolver
 			filtered := infer.FilterCoveredInferences(inferences, records, root, resolve)
 			// If all inferences are covered, don't propose

--- a/cmd/rootline/schema_test.go
+++ b/cmd/rootline/schema_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -143,6 +144,81 @@ func TestSchemaProposeIncremental(t *testing.T) {
 				t.Error("in incremental mode with existing .stem, bootstrap create_stem should be filtered")
 			}
 		}
+	}
+}
+
+// TestSchemaProposeIncrementalSkipsGovernedZeroInferenceBootstrap catches a
+// redundant create_stem proposal when records contain no inferable fields but
+// an existing stem already governs the tree.
+func TestSchemaProposeIncrementalSkipsGovernedZeroInferenceBootstrap(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem": "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  kind:\n    type: enum\n    required: false\n    values: [note, memo]\n",
+		"a.md":  "# Alpha\n\nBody only.\n",
+		"b.md":  "# Beta\n\nBody only.\n",
+	})
+
+	initialFiles := listFilesWithContent(t, root)
+	stemPath := filepath.Join(root, ".stem")
+	initialStem, err := os.Stat(stemPath)
+	if err != nil {
+		t.Fatalf("stat .stem before proposal: %v", err)
+	}
+
+	stdout, err := executeSchemaPropose(t, "--incremental", root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report SchemaProposalsReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, stdout)
+	}
+	if !report.Incremental {
+		t.Error("expected incremental flag to be true")
+	}
+	if len(report.Proposals) != 0 {
+		t.Fatalf("expected no proposals for governed zero-inference tree, got %#v", report.Proposals)
+	}
+	if report.Summary != (ProposalsSummary{}) {
+		t.Errorf("expected empty summary, got %#v", report.Summary)
+	}
+
+	finalFiles := listFilesWithContent(t, root)
+	if !reflect.DeepEqual(finalFiles, initialFiles) {
+		t.Errorf("schema propose modified fixture files\nbefore: %#v\nafter:  %#v", initialFiles, finalFiles)
+	}
+	finalStem, err := os.Stat(stemPath)
+	if err != nil {
+		t.Fatalf("stat .stem after proposal: %v", err)
+	}
+	if !finalStem.ModTime().Equal(initialStem.ModTime()) {
+		t.Error("schema propose changed .stem timestamp")
+	}
+}
+
+func TestSchemaProposeIncrementalKeepsZeroInferenceBootstrapWithoutStem(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		"a.md": "# Alpha\n\nBody only.\n",
+		"b.md": "# Beta\n\nBody only.\n",
+	})
+
+	stdout, err := executeSchemaPropose(t, "--incremental", root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report SchemaProposalsReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, stdout)
+	}
+	if len(report.Proposals) != 1 {
+		t.Fatalf("expected one bootstrap proposal for ungoverned zero-inference tree, got %#v", report.Proposals)
+	}
+	if report.Proposals[0].ID != "bootstrap-flat" || report.Proposals[0].Operation != "create_stem" {
+		t.Errorf("expected bootstrap-flat create_stem proposal, got %#v", report.Proposals[0])
+	}
+	if report.Summary.Total != 1 || report.Summary.EngineResolved != 1 || report.Summary.RequiresAgent != 0 {
+		t.Errorf("unexpected summary: %#v", report.Summary)
 	}
 }
 


### PR DESCRIPTION
[rootline-team]

Closes #145

## Problem

`schema propose --incremental` emitted a `bootstrap-flat/create_stem` proposal targeting an existing root `.stem` when the scanned records produced no inferred schema fields. That made an already-governed, valid tree look actionable.

## Change

- Suppress the empty bootstrap proposal only when incremental mode finds an existing effective stem and the generated schema contains no inferences.
- Preserve bootstrap generation for an ungoverned tree with the same body-only records.
- Preserve non-incremental behavior, report version/kind, summary accounting, and read-only semantics.

## Acceptance coverage

- Governed body-only records: zero proposals and an empty summary.
- Existing `.stem` bytes and timestamp, plus record bytes, remain unchanged.
- Ungoverned body-only records: one `bootstrap-flat/create_stem` proposal.
- Non-incremental governed run: existing bootstrap behavior remains.
- Existing covered/uncovered and per-scope incremental tests remain green.

## Verification

Published head: `2e5e7592e978288b65445a5050f8baeceb747c83`
Tree verified locally and published unchanged: `dfa6c46ba47e987e91873d0264cdca622dee5e22`

TDD evidence:

- The new governed zero-inference regression first failed because it received `bootstrap-flat`.
- After the minimal eligibility change, both the governed and no-stem controls passed.

Executed successfully:

- `just check` — gofmt, golangci-lint (0 issues), build.
- `just test` — full suite with race detector.
- `just coverage-check` — all package floors passed; total 90.0%, `cmd/rootline` 87.6%.
- `just test-install` — POSIX installer tests passed; PowerShell was unavailable locally and skipped. Installer behavior is not changed.
- `just validate` — 126/126 roadmap records valid.
- `gitleaks dir --no-banner --redact .` — no leaks.
- Focused `TestSchemaPropose*` suite — passed.

Real CLI fixture on Linux x86_64, Go 1.27.1, binary SHA-256 `cca7a6917db76da9059d3975f12416250fffb777fd2af5cdf1474d51ac9c3d77`:

- Governed incremental run: `proposals: null`, `summary.total: 0`.
- Ungoverned incremental run: one `bootstrap-flat/create_stem`.
- Governed non-incremental run: one `bootstrap-flat/create_stem`.
- Fixture hashes and mtimes were identical before and after.

## QA instructions

Implementation is complete and ready for independent QA at the exact head SHA.

1. Build `./cmd/rootline` from `2e5e7592e978288b65445a5050f8baeceb747c83`.
2. Create two body-only Markdown records under a valid version-2 root `.stem`.
3. Confirm `validate --all <root> -o json` reports both records valid.
4. Confirm `schema propose --incremental <root> -o json` returns version 1 `rootline/schema-proposals`, zero proposals, and zeroed summary.
5. Hash and stat the fixture before/after to confirm no writes.
6. Remove the `.stem` (or use a separate ungoverned fixture) and confirm incremental mode still emits one bootstrap proposal.
7. Confirm non-incremental mode on the governed fixture retains the bootstrap proposal.

## Limitations and risk

The change is confined to incremental proposal eligibility. It does not alter schema application, filesystem writes, inference heuristics, output versions, or field semantics. The main regression risk is suppressing first-time bootstrap; the explicit no-stem control covers it.

Local PowerShell installer testing was unavailable, but this PR does not touch installers. CI and independent `QA_PASS` for the current head remain required before review/merge.