### PR TITLE
fix(repair): label rejected outcomes neutrally

### DIFF
--- a/cmd/rootline/render_tables_test.go
+++ b/cmd/rootline/render_tables_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -47,6 +48,53 @@ func TestRenderRepairTable_AllSections(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in output, got: %s", want, out)
 		}
+	}
+}
+
+func TestRenderRepairTable_RejectionsUseNeutralHeading(t *testing.T) {
+	tests := []struct {
+		name     string
+		rejected []string
+	}{
+		{
+			name:     "containment only",
+			rejected: []string{`containment violation: path "../outside.md" escapes root`},
+		},
+		{
+			name:     "schema only",
+			rejected: []string{"estado: add Obsolete (surface=schema)"},
+		},
+		{
+			name: "mixed",
+			rejected: []string{
+				`containment violation: path "../outside.md" escapes root`,
+				"estado: add Obsolete (surface=schema)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, buf := newRenderTestCmd()
+			result := &fix.RepairResult{Rejected: tt.rejected}
+			if err := renderRepairTable(cmd, result); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			out := buf.String()
+			wantHeading := fmt.Sprintf("Rejected (%d):", len(tt.rejected))
+			if !strings.Contains(out, wantHeading) {
+				t.Errorf("expected neutral heading %q, got: %s", wantHeading, out)
+			}
+			if strings.Contains(out, "Rejected (schema proposals") {
+				t.Errorf("heading misclassifies rejection list: %s", out)
+			}
+			for _, rejection := range tt.rejected {
+				if !strings.Contains(out, rejection) {
+					t.Errorf("expected rejection %q in output, got: %s", rejection, out)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/rootline/repair.go
+++ b/cmd/rootline/repair.go
@@ -127,7 +127,7 @@ func renderRepairTable(cmd *cobra.Command, result *fix.RepairResult) error {
 	}
 
 	if len(result.Rejected) > 0 {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nRejected (schema proposals, %d):\n", len(result.Rejected))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nRejected (%d):\n", len(result.Rejected))
 		for _, r := range result.Rejected {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", r)
 		}


### PR DESCRIPTION
[rootline-team]

Closes #143

## Problem

`repair apply -o table` labels every policy rejection as `Rejected (schema proposals, N)`, even when the list contains path-containment violations. The JSON envelope and containment behavior are already correct; the table heading is misleading.

## Change

- Render the shared rejection bucket with the neutral heading `Rejected (N):`.
- Add regression coverage for containment-only, schema-only, and mixed rejection lists.
- Preserve rejection details, JSON v1 output, exit status, and all repair/containment behavior.

## Verification

TDD evidence:
- RED: `go test ./cmd/rootline -run TestRenderRepairTable_RejectionsUseNeutralHeading -count=1` failed for all three cases with the old `Rejected (schema proposals, N)` heading.
- GREEN: `go test ./cmd/rootline -run 'TestRenderRepairTable' -count=1` passed.

Fresh full checks on Linux amd64 with Go 1.27.1:
- format check, `golangci-lint run`, and `go build ./...`
- `go test ./... -race`
- `go mod tidy` with no module diff
- coverage gate: every measured package >= 85%; total 90.0%
- `govulncheck ./...`: no vulnerabilities found
- gitleaks directory scan: no leaks found
- built CLI `validate --all docs/roadmap/`: 126/126 valid
- `sh tests/installers/install-sh-test.sh`

Real CLI containment fixture:
```sh
go build -ldflags '-X main.version=dev' -o rootline ./cmd/rootline
./rootline repair apply --report scan/report.json --root scan -o table
./rootline repair apply --report scan/report.json --root scan -o json
```
The report contains a `correct_value` proposal targeting `../outside.md`. Both commands exited 0; table output was `Rejected (1):` with the containment reason; JSON remained `rootline/repair` version 1; the outside file SHA-256 was unchanged before/after. Tested binary SHA-256: `7919fc78d89a717858741cb8e7087df54abe065c83a546360b57076c626f9eed`.

## QA handoff

Build the exact PR SHA with version `dev`. Exercise a containment-only rejection and a schema-only rejection through the external CLI, verify the neutral heading and preserved per-entry reason, JSON parseability/version, exit status 0 for rejection-only results, and no file writes outside the root. A mixed rejection fixture is also covered at renderer level and is useful as a boundary case.

## Limitations and risk

- PowerShell installer tests were not available locally; CI must run the repository's Linux/macOS/Windows installer matrix.
- This PR intentionally does not address rollback diagnostics from #220.
- User-visible change is limited to the table heading; machine-readable output is unchanged.
