### PR TITLE
fix(repair): show rolled-back paths and validation reasons

### DIFF
--- a/.claude/skills/rootline/ref-advanced.md
+++ b/.claude/skills/rootline/ref-advanced.md
@@ -182,6 +182,10 @@ exit, and the short failure line goes to stderr, so `repair apply ... && deploy`
 failure while still giving you a parseable result. `--dry-run` follows the same rule: a preview
 that cannot resolve a path exits `1`, which makes it usable as a CI precondition check.
 
+`repair apply -o table` lists reverted files separately under `Rolled back (N)`,
+including each path and every validation reason. A rollback-only result is not a
+no-op and does not print `No repairs applied`. Dry runs do not report actual rollbacks.
+
 `repair apply` post-validates each file it writes, on its own, and restores the
 pre-write bytes when validation rejects the result. Reverted files come back in
 `rolled_back` (`{path, errors}`) and are withdrawn from `changed`, so a document is

--- a/cmd/rootline/repair.go
+++ b/cmd/rootline/repair.go
@@ -119,6 +119,16 @@ func renderRepairTable(cmd *cobra.Command, result *fix.RepairResult) error {
 		}
 	}
 
+	if len(result.RolledBack) > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nRolled back (%d):\n", len(result.RolledBack))
+		for _, file := range result.RolledBack {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", file.Path)
+			for _, reason := range file.Errors {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "    %s\n", reason)
+			}
+		}
+	}
+
 	if len(result.Skipped) > 0 {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nSkipped (%d):\n", len(result.Skipped))
 		for _, s := range result.Skipped {
@@ -140,7 +150,7 @@ func renderRepairTable(cmd *cobra.Command, result *fix.RepairResult) error {
 		}
 	}
 
-	if len(result.Changed) == 0 && len(result.Errors) == 0 && len(result.Rejected) == 0 {
+	if len(result.Changed) == 0 && len(result.RolledBack) == 0 && len(result.Errors) == 0 && len(result.Rejected) == 0 {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No repairs applied")
 	}
 

--- a/cmd/rootline/repair_rollback_output_test.go
+++ b/cmd/rootline/repair_rollback_output_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/fix"
+	"github.com/pablontiv/rootline/internal/proposal"
+)
+
+func TestRenderRepairTable_RolledBack(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		name := "rollback only"
+		if mixed {
+			name = "mixed outcomes"
+		}
+		t.Run(name, func(t *testing.T) {
+			result := &fix.RepairResult{
+				RolledBack: []fix.RolledBackFile{
+					{Path: "a.md", Errors: []string{"status: invalid value", "owner: required"}},
+					{Path: "b.md", Errors: []string{"title: empty"}},
+				},
+			}
+			if mixed {
+				result.Changed = []string{"correct status in kept.md"}
+				result.Skipped = []string{"skip pending.md"}
+				result.Rejected = []string{"schema proposal"}
+				result.Errors = []string{"missing.md: unreadable"}
+			}
+			cmd, buf := newRenderTestCmd()
+			if err := renderRepairTable(cmd, result); err != nil {
+				t.Fatal(err)
+			}
+			out := buf.String()
+			for _, want := range []string{"Rolled back (2):", "a.md", "b.md", "status: invalid value", "owner: required", "title: empty"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("missing %q in output: %s", want, out)
+				}
+			}
+			if strings.Contains(out, "No repairs applied") {
+				t.Errorf("rollback misreported as no-op: %s", out)
+			}
+			if mixed {
+				for _, want := range []string{"Changed (1):", "kept.md", "Skipped (1):", "pending.md", "Rejected (1):", "schema proposal", "Errors (1):", "missing.md: unreadable"} {
+					if !strings.Contains(out, want) {
+						t.Errorf("missing mixed outcome %q: %s", want, out)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRepairApply_RollbackOutput(t *testing.T) {
+	for _, format := range []string{"table", "json"} {
+		for _, dryRun := range []bool{false, true} {
+			name := format + "/apply"
+			if dryRun {
+				name = format + "/dry-run"
+			}
+			t.Run(name, func(t *testing.T) {
+				report := newExitStatusFixture(t, []proposal.Proposal{correctValueTo("task.md", "TOTALLY_INVALID")})
+				path := filepath.Join(filepath.Dir(report), "task.md")
+				before, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				args := []string{"--report", report, "-o", format}
+				if dryRun {
+					args = append(args, "--dry-run")
+				}
+				out, err := executeRepairApply(t, args...)
+				assertExitStatus(t, err, !dryRun)
+				if format == "table" {
+					if dryRun {
+						if !strings.Contains(out, "DRY RUN") || strings.Contains(out, "Rolled back") {
+							t.Errorf("dry run claimed an actual rollback: %s", out)
+						}
+					} else {
+						for _, want := range []string{"Rolled back (1):", "task.md", "estado:", "TOTALLY_INVALID", "allowed values"} {
+							if !strings.Contains(out, want) {
+								t.Errorf("missing rollback diagnostic %q: %s", want, out)
+							}
+						}
+						if strings.Contains(out, "No repairs applied") || strings.Contains(out, "Changed (") {
+							t.Errorf("rollback reported as no-op or successful change: %s", out)
+						}
+					}
+				} else {
+					result := decodeRepairResult(t, out)
+					if result.Version != 1 || result.Kind != "rootline/repair" || result.DryRun != dryRun || result.Complete != dryRun {
+						t.Errorf("unexpected JSON contract: %s", out)
+					}
+					if dryRun {
+						if len(result.RolledBack) != 0 {
+							t.Errorf("dry run contains rollback: %s", out)
+						}
+					} else if len(result.Changed) != 0 || len(result.RolledBack) != 1 || result.RolledBack[0].Path != "task.md" || len(result.RolledBack[0].Errors) != 1 {
+						t.Errorf("unexpected rollback payload: %s", out)
+					}
+				}
+				after, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(after) != string(before) {
+					t.Errorf("rollback or dry run changed document bytes: %q", after)
+				}
+			})
+		}
+	}
+}

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -186,6 +186,10 @@ failing run stays machine-readable; the short `Error: apply failed: ...` line go
 `rolled_back[]` is a separate condition, not a subset of `errors[]`: a successful revert leaves
 `errors[]` empty, so a script testing only `errors[]` would read that run as a success.
 
+With `repair apply -o table`, reverted files appear in a separate `Rolled back (N)`
+section with each path and all recorded validation reasons. They are not counted as
+successful changes, and a rollback-only result does not print `No repairs applied`.
+
 `--dry-run` is not an exception. A preview that cannot resolve a path reports it in `errors[]`
 and exits `1`, which makes `repair apply --report r.json --dry-run` usable as a CI precondition
 check. A dry run performs no writes, so it can never populate `rolled_back[]`.


### PR DESCRIPTION
[rootline-team]
[rootline-team/desarrollador] 2026-09-05T23:25:00Z

Closes #220

## Problem and change
`repair apply -o table` omitted `rolled_back[]`, presenting rollback-only runs as `No repairs applied`. Operators could not see the affected path or validation reason even though the engine restored the file correctly.

The renderer now prints a separate `Rolled back (N)` section with every path and every recorded reason. Rollbacks suppress the ordinary no-op message. Changed, Skipped, Rejected, and Errors retain their existing behavior.

No repair-engine, validation, containment, exit-status, or versioned JSON changes. Updated `docs/fix.md` and the existing agent reference.

## Implementation status / handoff
Implementation is COMPLETE at SHA `e3f319d5007014a122c455687c34d534fdf5e965` and available for independent QA. Published-SHA CI has passed. The ONLY remaining reason for draft is pending independent QA. Once those pass, the reviewer may mark this team PR ready and continue the authorized integration checks without another developer run. No developer QA verdict or formal approval is claimed.

Base: `master` `915da0475e32991fca0facfd9dcab6ca31026e4e`.
Published tree `5ce576d5559ca53b5fd1022eff6fe58a65ad89d4` exactly matches the locally tested tree. Terminal Git push lacked credentials; publication used the authorized GitHub connector, without force-push or changes to master/protections.

## Acceptance and executed evidence
- Renderer regressions: rollback-only; two reverted files with multiple reasons; mixed Changed/Skipped/Rejected/Errors.
- Governed CLI regressions: table + JSON, apply + dry-run; preserved document bytes and apply-failure sentinel.
- RED: new renderer cases and table/apply CLI case failed on the missing diagnostics before the production edit.
- GREEN: focused tests passed after the minimal renderer edit.
- Real dev CLI, isolated fixture without Git: base printed only `No repairs applied`; fixed binary prints the path and enum failure.
- Apply and JSON both exit 1; dry-run exits 0 and shows preview only.
- Original `task.md` SHA-256 stayed `e6bfd781078c78e3c2b912da0413f972e581db2b413646c980757bd8936c87c0`; Linux mode `0600` was preserved.
- Real mixed run retained a valid correction to `kept.md`, separately reported rollback of `task.md`, and exited 1.

## Local verification
Linux x86_64; official Go 1.27.1 compatible with go.mod. Download checksum verified against go.dev metadata:
`63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445`.

PASS:
- `just check` (gofmt, golangci-lint v2.13.1 as configured by current CI, build)
- `just test` (all packages with race detector)
- `just coverage-check`: total 90.0%; cmd/rootline 87.6%; all package floors pass
- `go vet ./...`
- `go mod tidy`, no go.mod/go.sum diff
- `rootline validate --all docs/roadmap/ -o json`: 126 valid / 126, no errors or warnings
- `sh tests/installers/install-sh-test.sh`
- `git diff --check`

Not executed locally: gitleaks (not installed), govulncheck, native macOS/Windows installer scenarios. Published CI must supply their applicable evidence; no skipped job counts as success.
The generic skill-creator validator rejected the pre-existing `updated` frontmatter key in unchanged `SKILL.md`; this PR edits only its linked reference and does not alter the existing metadata.

## Published-SHA CI and final binary
[CI run 33998639412](https://github.com/pablontiv/rootline/actions/runs/33998639412) passed all applicable PR jobs: Test & Build (race and 85% threshold), Tidy, Lint, Vulnerability check, gitleaks, docs-validate, and installer-tests on Linux/macOS/Windows. Build/test step logs were inspected; release and post-release installer-smoke are intentionally not applicable to this PR event, and their skipped jobs are not counted as validation.

Fetched the published SHA into the isolated checkout, confirmed its tree has zero diff against the locally tested commit, rebuilt the dev binary and reran focused tests with race plus the real rollback fixture. All passed; the fixture still exited 1 with the path/reason, identical bytes and mode 0600.
Published-SHA dev binary SHA-256: `9b8c673a4bd5d2ce54158f899dccf30a684066f5d7bbdfa284fb474aadc39863`.

## Reproduce / QA
Build the exact SHA, using a temporary output path and default dev version (no autoupdate):
```sh
git checkout --detach e3f319d5007014a122c455687c34d534fdf5e965
go build -o /tmp/rootline-220 ./cmd/rootline/
go test ./cmd/rootline -run 'TestRenderRepairTable|TestRepairApply' -count=1
```

In a separate temporary directory without Git, create:

`.stem`:
```yaml
version: 2
root: true
scope:
  match: "*.md"
schema:
  status:
    type: enum
    required: true
    values: [Pending, Completed]
```

`task.md`:
```markdown
---
status: Pending
---

# Task
```

`report.json`:
```json
{"version":1,"kind":"rootline/proposals","proposals":[{"type":"correct_value","field":"status","description":"invalid enum rollback diagnostic","paths":["task.md"],"from":"Pending","to":"TOTALLY_INVALID"}]}
```

Run from that fixture:
```sh
/tmp/rootline-220 validate task.md -o json
chmod 600 task.md
sha256sum task.md
/tmp/rootline-220 repair apply --report report.json -o table
# Expected exit 1, stdout below, short failure on stderr.
/tmp/rootline-220 repair apply --report report.json -o json
# Expected exit 1, version 1 rootline/repair, changed=[], rolled_back path/errors.
/tmp/rootline-220 repair apply --report report.json --dry-run -o table
# Expected exit 0, preview only, no actual rollback section.
sha256sum task.md
stat -c '%a' task.md
```

Expected applied table:
```text
Rolled back (1):
  task.md
    status: value TOTALLY_INVALID is not in allowed values: [Pending, Completed]
```

Mixed case: add `kept.md` with the same initial frontmatter and prepend a `correct_value` proposal for that path from Pending to Completed. Expected: Changed lists only kept.md; Rolled back lists task.md; exit 1, kept.md remains Completed and task.md remains Pending. Repeat rollback-only to check idempotence. Verify no unrelated fixture writes.

## Risk and exclusions
Low-risk, field-agnostic text-renderer change. JSON remains the stable machine interface. No installer/platform behavior change, schema migration, new policy, thresholds, permissions, or approval-rule changes. No merge performed.
