### PR TITLE
fix(query): render selected fields as table

### DIFF
--- a/cmd/rootline/output_test.go
+++ b/cmd/rootline/output_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -136,6 +137,59 @@ func TestOutput_QueryAcceptsEveryAdvertisedFormat(t *testing.T) {
 		if _, err := runCmd(t, "query", docs, "--select", "path,estado", "-o", f); err != nil {
 			t.Errorf("query --select -o %s: unexpected error: %v", f, err)
 		}
+	}
+}
+
+func TestOutput_QuerySelectTableUsesSelectedColumns(t *testing.T) {
+	docs := setupFormatProject(t)
+
+	out, err := runCmd(t, "query", docs, "--select", "nonexistent,path,estado", "-o", "table")
+	if err != nil {
+		t.Fatalf("query --select -o table: unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("expected header, separator, and two data rows; got %d lines:\n%s", len(lines), out)
+	}
+	if got := strings.Fields(lines[0]); !slices.Equal(got, []string{"nonexistent", "path", "estado"}) {
+		t.Fatalf("header fields = %v, want selected order; output:\n%s", got, out)
+	}
+	pathColumn := strings.Index(lines[0], "path")
+	estadoColumn := strings.Index(lines[0], "estado")
+	if pathColumn <= 0 || estadoColumn <= pathColumn {
+		t.Fatalf("could not locate selected columns in header %q", lines[0])
+	}
+	for _, line := range lines[2:] {
+		if got := strings.TrimSpace(line[:pathColumn]); got != "" {
+			t.Errorf("missing selected field rendered as %q, want empty cell; row %q", got, line)
+		}
+		if got := strings.TrimSpace(line[pathColumn:estadoColumn]); got == "" {
+			t.Errorf("path cell is empty in row %q", line)
+		}
+		if got := strings.TrimSpace(line[estadoColumn:]); got == "" {
+			t.Errorf("estado cell is empty in row %q", line)
+		}
+	}
+	if strings.Contains(out, `"kind":"rootline/query"`) {
+		t.Fatalf("table output fell back to JSON:\n%s", out)
+	}
+}
+
+func TestOutput_QuerySelectTableEmptyResultKeepsHeader(t *testing.T) {
+	docs := setupFormatProject(t)
+
+	out, err := runCmd(t, "query", docs, "--where", "estado == 'Never'", "--select", "estado,path", "-o", "table")
+	if err != nil {
+		t.Fatalf("empty query --select -o table: unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected only header and separator, got %d lines:\n%s", len(lines), out)
+	}
+	if got := strings.Fields(lines[0]); !slices.Equal(got, []string{"estado", "path"}) {
+		t.Fatalf("header fields = %v, want selected order; output:\n%s", got, out)
 	}
 }
 

--- a/cmd/rootline/query.go
+++ b/cmd/rootline/query.go
@@ -200,9 +200,10 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 
 	// Apply projection if --select is given
+	var selectFields []string
 	if querySelect != "" {
-		fields := parseSelectFields(querySelect)
-		result, err = projectQueryResult(result, fields)
+		selectFields = parseSelectFields(querySelect)
+		result, err = projectQueryResult(result, selectFields)
 		if err != nil {
 			return fmt.Errorf("applying projection: %w", err)
 		}
@@ -210,20 +211,19 @@ func runQuery(cmd *cobra.Command, args []string) error {
 
 	// Handle output formats
 	if outputFormat == "table" {
-		return renderQueryTable(cmd, result)
+		return renderQueryTable(cmd, result, selectFields)
 	}
 	if outputFormat == "jsonl" {
 		if querySelect == "" {
 			return fmt.Errorf("jsonl output requires --select flag")
 		}
-		return outputQueryJSONL(cmd, result, parseSelectFields(querySelect))
+		return outputQueryJSONL(cmd, result, selectFields)
 	}
 	if outputFormat == "csv" {
 		if querySelect == "" {
 			return fmt.Errorf("csv output requires --select flag")
 		}
-		fields := parseSelectFields(querySelect)
-		return outputQueryCSV(cmd, result, fields)
+		return outputQueryCSV(cmd, result, selectFields)
 	}
 	return outputJSON(cmd, result, false)
 }
@@ -294,7 +294,22 @@ func scanForTraversal(ctx context.Context, absQueryRoot string) ([]*extract.Reco
 	return candidates, g, prefix, nil
 }
 
-func renderQueryTable(cmd *cobra.Command, result any) error {
+func renderQueryTable(cmd *cobra.Command, result any, selectedFields []string) error {
+	if projected, ok := result.(*query.ProjectedQueryResult); ok {
+		rows := make([][]string, len(projected.Rows))
+		for i, projectedRow := range projected.Rows {
+			row := make([]string, len(selectedFields))
+			for j, field := range selectedFields {
+				if value, present := projectedRow[field]; present && value != nil {
+					row[j] = fmt.Sprintf("%v", value)
+				}
+			}
+			rows[i] = row
+		}
+		renderTable(cmd.OutOrStdout(), selectedFields, rows)
+		return nil
+	}
+
 	qr, ok := result.(*query.QueryResult)
 	if !ok {
 		return outputJSON(cmd, result, false)


### PR DESCRIPTION
[rootline-team]

Closes #221

## Problem

`query --select ... -o table` projected rows before rendering, but the table renderer only recognized the unprojected result type and silently fell back to the JSON envelope.

## Change

- render projected query rows as a table using the exact `--select` column order;
- keep missing or nil selected values as empty cells;
- keep selected headers for empty result sets without fabricating rows;
- parse the selection once and preserve the existing JSON, JSONL, CSV, and unselected-table paths;
- add CLI regressions for populated and empty projected tables.

The production path remains field-agnostic and does not change the versioned JSON schema.

## Verification

Implementation SHA: `e348c445b7b518efef27ffe6b0fd57f3faefca6c`
Base: `master` `28c5fdecfcfbb6894ee76bf01acdac0c689adabc`
Platform: Linux 6.18.35 x86_64, official Go 1.27.1 (official SHA-256 verified).

Executed locally:

- focused red/green regression: `go test ./cmd/rootline -run 'TestOutput_QuerySelectTable' -count=1`;
- `go test ./... -race`;
- `gofmt -l .`, golangci-lint v2.13.1, and `go build ./...` (the commands behind `just check`);
- `go test ./... -coverprofile=coverage.out` plus `pkcov report` and `pkcov check`: 90.0% total, all package floors pass;
- `rootline validate --all docs/roadmap/ -o json`: 126/126 valid;
- `sh tests/installers/install-sh-test.sh`: pass;
- real dev binary on a no-Git fixture: selected table order, empty cells, deterministic empty header, exit 0, and no fixture writes;
- byte-for-byte output comparison against the base binary for unselected table, JSON, selected JSON, JSONL, and CSV: unchanged;
- `go mod tidy`, `git diff --check`: clean.

Local PowerShell was unavailable. The unchanged installer surface still requires the Windows installer job in CI.

## QA handoff

Implementation is complete and ready for independent QA at the SHA above. Build a dev binary to avoid auto-update:

```sh
go build -o /tmp/rootline ./cmd/rootline
/tmp/rootline query <governed-fixture> --select owner,path,status -o table
/tmp/rootline query <governed-fixture> --where "status == 'no-match'" --select owner,path,status -o table
```

Please verify selected order, empty cells for missing/nil values, empty-result headers, no JSON fallback, no writes in this read-only flow, and unchanged JSON/JSONL/CSV plus unselected table behavior.

## Pending

CI run [34001144652](https://github.com/pablontiv/rootline/actions/runs/34001144652) passed build, race/coverage, tidy, lint, vulnerability scan, gitleaks, docs validation, and installer tests on Linux/macOS/Windows for the current SHA. Draft now remains only for independent `[rootline-team/qa]` validation. No implementation work remains. The reviewer may mark ready after QA passes for this SHA.