### PR TITLE
fix(query): reject count with select

### DIFF
--- a/cmd/rootline/output_test.go
+++ b/cmd/rootline/output_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -137,6 +138,41 @@ func TestOutput_QueryAcceptsEveryAdvertisedFormat(t *testing.T) {
 		if _, err := runCmd(t, "query", docs, "--select", "path,estado", "-o", f); err != nil {
 			t.Errorf("query --select -o %s: unexpected error: %v", f, err)
 		}
+	}
+}
+
+func TestOutput_QueryCountSelectRejectsBeforeScanningForEveryFormat(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	const want = "--select cannot be used with --count"
+
+	for _, format := range []string{"json", "table", "jsonl", "csv"} {
+		t.Run(format, func(t *testing.T) {
+			resetFlags()
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(stderr)
+			rootCmd.SetArgs([]string{
+				"query", missing,
+				"--count",
+				"--select", "path,estado",
+				"--output", format,
+			})
+
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected conflicting flags to be rejected")
+			}
+			if err.Error() != want {
+				t.Fatalf("error = %q, want %q", err, want)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty output", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("stderr = %q, want diagnostic %q", stderr.String(), want)
+			}
+		})
 	}
 }
 

--- a/cmd/rootline/query.go
+++ b/cmd/rootline/query.go
@@ -63,6 +63,10 @@ func init() {
 }
 
 func runQuery(cmd *cobra.Command, args []string) error {
+	if queryCount && querySelect != "" {
+		return fmt.Errorf("--select cannot be used with --count")
+	}
+
 	ctx := cmd.Context()
 
 	// Determine scan root


### PR DESCRIPTION
[rootline-team]

Closes #223

## Problem

Combining `query --count` with a non-empty `--select` had format-dependent behavior: JSON/table silently ignored the projection, while JSONL/CSV leaked internal result-type errors after scanning.

## Change

Reject the incompatible flags at the beginning of `runQuery`, before path resolution, scanning, query execution, projection, or rendering:

```
--select cannot be used with --count
```

No JSON schema, version, `.stem`, documentation, Git requirement, or valid single-flag behavior changes.

## Acceptance coverage

- The conflict returns exit code 1 and the same diagnostic for JSON, table, JSONL, and CSV.
- Stdout remains empty in every format.
- A nonexistent target still returns the flag conflict, proving fail-fast behavior before scanning.
- Existing `--count` and `--select` paths remain available.
- Automated CLI regression covers the four output formats.

## Verification

Implementation complete at `b33b394bd08cf4a73143729fb3dc9a9b53697a86`.

Local isolated checkout, Linux x86_64, official Go 1.27.1 (download SHA-256 `63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445`):

- Regression first failed on `master` because all formats attempted to scan the missing target.
- `go test ./... -race` — pass.
- Coverage gate — pass, 90.0% total and every package floor satisfied.
- `golangci-lint v2.13.1 run` — 0 issues.
- `go build ./...` — pass.
- `go mod tidy` — no diff.
- `sh tests/installers/install-sh-test.sh` — pass.
- Development binary validation of all 126 roadmap documents — pass.

Real binary SHA-256: `46d50c15b8b4c8f44e8e8a8a885ea2bb7c10a09c77dc9803323ca64b353fd2d6`.

External no-Git fixture checks observed for each `-o json|table|jsonl|csv`: exit 1, empty stdout, stderr `Error: --select cannot be used with --count`, and no fixture-byte changes. Control runs returned the unchanged versioned `rootline/count` v1 envelope and a projected table.

## Handoff

The implementation is complete. This PR is draft only while waiting for CI on the remote SHA and independent `[rootline-team/qa]` validation. No implementation work is pending.