### PR TITLE
fix(repair): stabilize rollback validation reasons

### DIFF
--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -332,6 +332,7 @@ func validateWrittenTarget(ctx context.Context, tgt *repairTarget) []string {
 	for _, e := range rules.Validate(ctx, record, effective) {
 		msgs = append(msgs, fmt.Sprintf("%s: %s", e.Field, e.Message))
 	}
+	sort.Strings(msgs)
 	return msgs
 }
 

--- a/internal/fix/repair_rollback_test.go
+++ b/internal/fix/repair_rollback_test.go
@@ -75,6 +75,70 @@ func TestApplyRepair_RollsBackOnPostValidationFailure(t *testing.T) {
 	}
 }
 
+func TestApplyRepair_RollbackValidationErrorsAreDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".stem"), []byte(`version: 2
+root: true
+scope:
+  match: "*.md"
+schema:
+  status:
+    type: enum
+    required: true
+    values: [Pending, Completed]
+  priority:
+    type: enum
+    required: true
+    values: [Low, High]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const original = "---\nstatus: Pending\npriority: Low\n---\n\n# Doc\n"
+	path := filepath.Join(dir, "a.md")
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	proposals := []proposal.Proposal{
+		{Type: proposal.CorrectValue, Field: "status", Paths: []string{"a.md"}, From: "Pending", To: "Broken"},
+		{Type: proposal.CorrectValue, Field: "priority", Paths: []string{"a.md"}, From: "Low", To: "Urgent"},
+	}
+	want := []string{
+		"priority: value Urgent is not in allowed values: [Low, High]",
+		"status: value Broken is not in allowed values: [Pending, Completed]",
+	}
+
+	for i := 0; i < 64; i++ {
+		result, err := ApplyRepair(proposals, false, dir, false)
+		if err != nil {
+			t.Fatalf("ApplyRepair run %d failed: %v", i, err)
+		}
+		if len(result.RolledBack) != 1 {
+			t.Fatalf("run %d rolled_back = %#v, want one entry", i, result.RolledBack)
+		}
+		got := result.RolledBack[0].Errors
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("run %d errors = %#v, want %#v", i, got, want)
+		}
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("bytes after repeated rollback = %q, want %q", got, original)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode after repeated rollback = %o, want 600", info.Mode().Perm())
+	}
+}
+
 func TestApplyRepair_RolledBackFileIsNotReportedAsChanged(t *testing.T) {
 	dir := newRollbackFixture(t, map[string]string{
 		"a.md": "---\nestado: Pending\n---\n\n# A\n",


### PR DESCRIPTION
[rootline-team]

Closes #227

## Problem

`repair apply` preserved every rollback validation reason but returned them in Go map iteration order. Identical inputs could therefore produce different version 1 JSON bytes and different table output.

## Change

Canonicalize each written target's formatted validation messages before adding its `RolledBackFile` entry.

The change does not alter validation semantics, diagnostic text, rollback policy, path ordering, the `.stem` contract, or the JSON envelope version.

## Acceptance coverage

- Each `RolledBackFile.Errors` slice is lexicographically stable.
- Existing path ordering remains unchanged.
- A regression executes the same two-error rollback 64 times and requires the same order every time.
- The regression also verifies restoration of original bytes and mode `0600`.
- External JSON and table runs preserve `exit 1`, `complete:false`, all reasons, and an empty `changed` list.

## TDD evidence

Before the implementation, the new regression failed on run 1:

```
errors = ["status: ..." "priority: ..."]
want   = ["priority: ..." "status: ..."]
```

After the one-line canonicalization, it passes.

## Local verification

Isolated checkout of `master` at `c93b71d492de12bf399856b3b2042c7d675f7a22`, Linux x86_64, official Go 1.27.1. The Go tarball SHA-256 matched the value currently published by go.dev: `63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445`.

Implementation complete at `70f2c5b6caed4538ce040a0b384b850a1b5cb639`.

- `go test ./... -race` — pass.
- `go test ./... -coverprofile=coverage.out` plus `pkcov report/check` — pass; 90.0% total, all package floors satisfied.
- `gofmt`, `go build ./...`, `go mod tidy`, and `git diff --check` — pass; no module diff.
- `golangci-lint v2.13.1 run` — 0 issues.
- `sh tests/installers/install-sh-test.sh` — pass.
- Development binary validation of all 126 roadmap documents — pass.
- Real binary SHA-256: `9303c678793006e450b3aceaec0ea60e7298f787547f8dbd7430ebf56712f61d`.
- 24 JSON and 24 table invocations each produced one unique stdout hash; the document retained SHA-256 `ee114010b98c2b0d4a7fc69d26d81cb7a03881b792994fa191d51775092279c4` and mode `0600`.

`just` and `pwsh` were unavailable locally, so the Just recipes were executed through their underlying current commands. Remote CI #841 then executed and passed build, tests with race and coverage, tidy, lint, govulncheck, gitleaks, docs validation, and installer tests on Linux, macOS, and Windows.

## QA reproduction

Use the two-enum fixture and two invalid `correct_value` proposals from #227. Build the exact SHA with a dev version, then run `repair apply --report report.json -o json` and `-o table` repeatedly as external processes. Check stable bytes, both reasons, `exit 1`, `complete:false`, rollback restoration, permissions, and no Git dependency.

## Handoff

The implementation is complete at `70f2c5b6caed4538ce040a0b384b850a1b5cb639`. CI #841 is successful. This PR is draft only while waiting for independent `[rootline-team/qa]` validation of this exact SHA; no implementation or CI work is pending.