### PR TITLE
fix(validate): stabilize schema error ordering

### DIFF
--- a/cmd/rootline/validate_order_test.go
+++ b/cmd/rootline/validate_order_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateSchemaErrorsHaveStableSerializedOrder(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":   "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  status:\n    type: enum\n    required: true\n    values: [Pending, Completed]\n  priority:\n    type: enum\n    required: true\n    values: [Low, High]\n",
+		"task.md": "---\ntitle: Example\n---\n\n# Example\n",
+	})
+	mustChdir(t, root)
+
+	tests := []struct {
+		name   string
+		args   []string
+		format string
+	}{
+		{name: "single JSON", args: []string{filepath.Join(root, "task.md"), "-o", "json"}, format: "json"},
+		{name: "all JSON", args: []string{"--all", ".", "-o", "json"}, format: "json"},
+		{name: "single table", args: []string{filepath.Join(root, "task.md"), "-o", "table"}, format: "table"},
+		{name: "all table", args: []string{"--all", ".", "-o", "table"}, format: "table"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var first string
+			for run := 0; run < 64; run++ {
+				stdout, err := executeValidate(t, tt.args...)
+				if err != ErrValidationFailed {
+					t.Fatalf("run %d: err = %v, want ErrValidationFailed\nstdout=%s", run, err, stdout)
+				}
+				if run == 0 {
+					first = stdout
+				} else if stdout != first {
+					t.Fatalf("run %d: output changed\nfirst:\n%s\ncurrent:\n%s", run, first, stdout)
+				}
+
+				if tt.format == "json" {
+					env := decodeEnvelope(t, stdout)
+					if env["version"] != float64(2) || env["kind"] != "rootline/validate-batch" {
+						t.Fatalf("run %d: unexpected envelope contract: version=%v kind=%v", run, env["version"], env["kind"])
+					}
+					errs := firstResult(t, stdout)["errors"].([]any)
+					if len(errs) != 2 || errs[0].(map[string]any)["field"] != "priority" || errs[1].(map[string]any)["field"] != "status" {
+						t.Fatalf("run %d: error order = %#v, want priority then status", run, errs)
+					}
+					continue
+				}
+
+				priority := strings.Index(stdout, `required field "priority" is missing`)
+				status := strings.Index(stdout, `required field "status" is missing`)
+				if priority < 0 || status < 0 || priority >= status {
+					t.Fatalf("run %d: table errors not ordered priority then status:\n%s", run, stdout)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/validate.go
+++ b/internal/rules/validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pablontiv/picokit/fuzzy"
@@ -92,7 +93,13 @@ func Validate(_ context.Context, record *extract.Record, effective *StemFile) []
 	fieldContractFailed := make(map[string]bool)
 
 	// Phase 1: Schema auto-checks.
-	for name, field := range effective.Schema {
+	schemaFields := make([]string, 0, len(effective.Schema))
+	for name := range effective.Schema {
+		schemaFields = append(schemaFields, name)
+	}
+	sort.Strings(schemaFields)
+	for _, name := range schemaFields {
+		field := effective.Schema[name]
 		// Skip if severity is "off"
 		if field.Severity == "off" {
 			continue

--- a/internal/rules/validate_test.go
+++ b/internal/rules/validate_test.go
@@ -380,6 +380,33 @@ func TestValidate_MultipleErrors(t *testing.T) {
 	}
 }
 
+func TestValidate_SchemaAutoChecksHaveStableFieldOrder(t *testing.T) {
+	stem := &StemFile{
+		Schema: map[string]SchemaField{
+			"status":   {Type: "enum", Required: true, Source: "root/.stem"},
+			"priority": {Type: "enum", Required: true, Source: "root/.stem"},
+		},
+		Validate: []ValidationRule{
+			{Field: "zeta", Rule: "non_empty", Source: "root/.stem"},
+			{Field: "alpha", Rule: "non_empty", Source: "root/.stem"},
+		},
+	}
+	record := makeRecord(map[string]any{})
+	want := []string{"priority", "status", "zeta", "alpha"}
+
+	for run := 0; run < 128; run++ {
+		errs := Validate(context.Background(), record, stem)
+		if len(errs) != len(want) {
+			t.Fatalf("run %d: got %d errors, want %d: %+v", run, len(errs), len(want), errs)
+		}
+		for i, field := range want {
+			if errs[i].Field != field {
+				t.Fatalf("run %d: error fields out of order at index %d: got %q, want %q; errors=%+v", run, i, errs[i].Field, field, errs)
+			}
+		}
+	}
+}
+
 func TestValidate_ExplicitEnumRule(t *testing.T) {
 	stem := &StemFile{
 		Schema: map[string]SchemaField{


### PR DESCRIPTION
[rootline-team]

Closes #231

## Problem

`validate` appended schema-derived diagnostics while iterating the effective `schema` map. Identical inputs could therefore change the ordering and bytes of both `rootline/validate-batch` v2 JSON and table output.

## Change

- sort effective schema field names before Phase 1 auto-checks;
- keep the existing phase boundaries and the declared order of explicit `validate:` rules;
- add a unit regression for schema auto-check order and explicit-rule preservation;
- add CLI regressions for JSON/table and single-file/`--all` entry points.

No envelope, diagnostic, severity, source, summary, path-order, validation-semantic, or write behavior changes.

## TDD evidence

Before the implementation, the new tests failed with both `status → priority` and `priority → status`:

```
TestValidate_SchemaAutoChecksHaveStableFieldOrder: got "status", want "priority"
TestValidateSchemaErrorsHaveStableSerializedOrder: JSON and table output changed between runs
```

After the fix, the focused tests pass with `-count=5`.

## Verification

Commit: `36e0c61a25b0fb5bb98cd6d26043df8d765716df`

Local, Linux x86_64, official Go 1.27.1 (archive SHA-256 verified against go.dev):

- `just check` — PASS
- `just test` — PASS (race)
- `just coverage-check` — PASS (90.0% total; all package floors pass)
- `just validate` — PASS (126/126 roadmap records)
- `just test-install` — PASS for shell installer; PowerShell skipped locally because `pwsh` is unavailable
- `go mod tidy` with no diff — PASS
- `govulncheck ./...` — PASS
- staged `gitleaks` scan — PASS
- real dev binary SHA-256: `82199fa0c7924248a010750ee914207a658669109062ae5512f4f708727821c3`
- 64 fresh processes for each of JSON/table × single/`--all`: one byte hash per case, `exit 1`, errors ordered `priority → status`, fixture bytes unchanged

## QA reproduction

Build a dev binary so auto-update stays disabled:

```sh
go build -o /tmp/rootline ./cmd/rootline
cd <fixture>
/tmp/rootline validate task.md -o json
/tmp/rootline validate --all . -o json
/tmp/rootline validate task.md -o table
/tmp/rootline validate --all . -o table
```

Use the two-required-field fixture from #231 and repeat each command as a fresh process. Expected: `exit 1`, JSON v2 remains parseable, both diagnostics are present in lexical field order, repeated bytes are stable, and no file changes.

## Status

Implementation is complete and available for independent QA at the SHA above. The PR remains draft only while current CI and QA are pending.