### PR TITLE
fix(validate): stabilize aggregate error ordering

### DIFF
--- a/cmd/rootline/validate_order_test.go
+++ b/cmd/rootline/validate_order_test.go
@@ -59,3 +59,55 @@ func TestValidateSchemaErrorsHaveStableSerializedOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAggregateErrorsHaveStableSerializedOrder(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":     "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  total:\n    type: integer\n  completed:\n    type: integer\naggregate:\n  total: \"len(descendants)\"\n  completed: \"len(filter(descendants, .status == 'Completed'))\"\n",
+		"README.md": "---\ntotal: 99\ncompleted: 99\n---\n\n# Aggregate index\n",
+		"task.md":   "---\nstatus: Completed\n---\n\n# Task\n",
+	})
+	mustChdir(t, root)
+
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{name: "JSON", format: "json"},
+		{name: "table", format: "table"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var first string
+			for run := 0; run < 64; run++ {
+				stdout, err := executeValidate(t, "--all", ".", "-o", tt.format)
+				if err != ErrValidationFailed {
+					t.Fatalf("run %d: err = %v, want ErrValidationFailed\nstdout=%s", run, err, stdout)
+				}
+				if run == 0 {
+					first = stdout
+				} else if stdout != first {
+					t.Fatalf("run %d: output changed\nfirst:\n%s\ncurrent:\n%s", run, first, stdout)
+				}
+
+				if tt.format == "json" {
+					env := decodeEnvelope(t, stdout)
+					if env["version"] != float64(2) || env["kind"] != "rootline/validate-batch" {
+						t.Fatalf("run %d: unexpected envelope contract: version=%v kind=%v", run, env["version"], env["kind"])
+					}
+					errs := firstResult(t, stdout)["errors"].([]any)
+					if len(errs) != 2 || errs[0].(map[string]any)["field"] != "completed" || errs[1].(map[string]any)["field"] != "total" {
+						t.Fatalf("run %d: error order = %#v, want completed then total", run, errs)
+					}
+					continue
+				}
+
+				completed := strings.Index(stdout, `field "completed" is "99" but aggregate computes "1"`)
+				total := strings.Index(stdout, `field "total" is "99" but aggregate computes "1"`)
+				if completed < 0 || total < 0 || completed >= total {
+					t.Fatalf("run %d: table errors not ordered completed then total:\n%s", run, stdout)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/validate.go
+++ b/internal/rules/validate.go
@@ -150,7 +150,12 @@ func Validate(_ context.Context, record *extract.Record, effective *StemFile) []
 
 	// Phase 1b: Aggregate consistency — if a field has an aggregate expression
 	// and this is an index file, the frontmatter value must match the derived value.
+	aggregateFields := make([]string, 0, len(effective.Aggregate))
 	for name := range effective.Aggregate {
+		aggregateFields = append(aggregateFields, name)
+	}
+	sort.Strings(aggregateFields)
+	for _, name := range aggregateFields {
 		if !IsIndexFile(record.Path, effective) {
 			continue
 		}

--- a/internal/rules/validate_test.go
+++ b/internal/rules/validate_test.go
@@ -782,6 +782,35 @@ func TestValidate_AggregateConsistency_Mismatch(t *testing.T) {
 	}
 }
 
+func TestValidate_AggregateConsistency_StableFieldOrder(t *testing.T) {
+	stem := &StemFile{
+		Path: "test/.stem",
+		Aggregate: map[string]any{
+			"total":     `len(descendants)`,
+			"completed": `len(filter(descendants, {.status == "Completed"}))`,
+		},
+	}
+	record := &extract.Record{
+		Path:        "README.md",
+		Type:        "markdown",
+		Frontmatter: map[string]any{"total": 99, "completed": 99},
+		Derived:     map[string]any{"total": 1, "completed": 1},
+	}
+	want := []string{"completed", "total"}
+
+	for run := 0; run < 128; run++ {
+		errs := Validate(context.Background(), record, stem)
+		if len(errs) != len(want) {
+			t.Fatalf("run %d: got %d errors, want %d: %+v", run, len(errs), len(want), errs)
+		}
+		for i, field := range want {
+			if errs[i].Rule != "aggregate" || errs[i].Field != field {
+				t.Fatalf("run %d: error %d = %+v, want aggregate error for %q", run, i, errs[i], field)
+			}
+		}
+	}
+}
+
 func TestValidate_AggregateConsistency_Match(t *testing.T) {
 	stem := &StemFile{
 		Path: "test/.stem",


### PR DESCRIPTION
[rootline-team]

Closes #233

## Problem

`validate --all` traversed `effective.Aggregate` directly. Go map iteration made aggregate-consistency errors change order between otherwise identical invocations, so JSON v2 and table output were not byte-stable.

## Behavior change

Aggregate fields are now sorted lexically before phase 1b validation. This makes aggregate-consistency errors deterministic while preserving:

- phase ordering and the explicit `validate:` rule order;
- aggregate evaluation and mismatch semantics;
- JSON v2 envelope and diagnostic text;
- exit status and read-only behavior.

No CLI, `.stem`, JSON schema, or documentation contract changes are introduced.

## Acceptance coverage

- Engine regression: 128 validations assert `completed`, then `total`.
- CLI regression: 64 JSON and 64 table invocations assert byte-stable output and lexical aggregate field order.
- TDD RED: both regressions failed before the production change with `total` preceding `completed`.
- TDD GREEN: focused tests passed for 10 repeated test-process runs.
- External product exercise: a fresh dev binary ran `validate --all` against real `.stem`/Markdown fixtures 256 times in JSON and 256 times in table format. Each format produced one unique hash; all 512 executions returned status 1 with empty stderr and `completed` before `total`. Fixture bytes and permissions were unchanged.

## Verification

Remote head: `73b7c1526b3d93dc060808c1af00d5229ecd4572`

Fresh dev binary SHA-256 (linux/amd64): `c38590ef96b33fbaea069665a6df8582506b96b14ef8576b44e04ebce84a4cd1`

Passed locally:

- `just check`
- `just test` (full suite with race detector)
- `just coverage-check` (90.0% total; all package floors passed)
- `just validate` (126/126 roadmap records, using the fresh local binary)
- `just test-install` shell installer
- `go mod tidy` (no diff)
- `govulncheck ./...` (no vulnerabilities)
- staged `gitleaks` scan (no leaks)

## Reproduce for QA

```sh
go build -o /tmp/rootline ./cmd/rootline/
cd <fixture-root>
/tmp/rootline validate --all . -o json
/tmp/rootline validate --all . -o table
```

Minimal `.stem`:

```yaml
version: 2
root: true
scope:
  match: "*.md"
schema:
  total:
    type: integer
  completed:
    type: integer
aggregate:
  total: "len(descendants)"
  completed: "len(filter(descendants, .status == 'Completed'))"
```

Use an index `README.md` with `total: 99` and `completed: 99`, plus one descendant with `status: Completed`.

## Limitations and status

PowerShell was unavailable locally, so the PowerShell installer was not executed locally; current-sha CI must supply the cross-platform installer evidence.

Implementation is complete and available for independent QA. This PR remains draft only while current-sha CI and QA are pending.