### PR TITLE
fix(validate): stabilize requires condition rendering

### DIFF
--- a/cmd/rootline/validate_order_test.go
+++ b/cmd/rootline/validate_order_test.go
@@ -111,3 +111,56 @@ func TestValidateAggregateErrorsHaveStableSerializedOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRequiresConditionHasStableSerializedOrder(t *testing.T) {
+	root := setupValidateProject(t, map[string]string{
+		".stem":   "version: 2\nroot: true\nscope:\n  match: \"*.md\"\nschema:\n  status:\n    type: enum\n    values: [Draft, Completed]\n  priority:\n    type: enum\n    values: [Low, High]\n  owner:\n    type: string\nvalidate:\n  - rule: requires\n    if:\n      status: Completed\n      priority: High\n    then:\n      fields: [owner]\n",
+		"task.md": "---\nstatus: Completed\npriority: High\n---\n\n# Task\n",
+	})
+	mustChdir(t, root)
+
+	tests := []struct {
+		name   string
+		args   []string
+		format string
+	}{
+		{name: "single JSON", args: []string{filepath.Join(root, "task.md"), "-o", "json"}, format: "json"},
+		{name: "all JSON", args: []string{"--all", ".", "-o", "json"}, format: "json"},
+		{name: "single table", args: []string{filepath.Join(root, "task.md"), "-o", "table"}, format: "table"},
+		{name: "all table", args: []string{"--all", ".", "-o", "table"}, format: "table"},
+	}
+
+	const want = `field "owner" is required when priority = High and status = Completed`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var first string
+			for run := 0; run < 64; run++ {
+				stdout, err := executeValidate(t, tt.args...)
+				if err != ErrValidationFailed {
+					t.Fatalf("run %d: err = %v, want ErrValidationFailed\nstdout=%s", run, err, stdout)
+				}
+				if run == 0 {
+					first = stdout
+				} else if stdout != first {
+					t.Fatalf("run %d: output changed\nfirst:\n%s\ncurrent:\n%s", run, first, stdout)
+				}
+
+				if tt.format == "json" {
+					env := decodeEnvelope(t, stdout)
+					if env["version"] != float64(2) || env["kind"] != "rootline/validate-batch" {
+						t.Fatalf("run %d: unexpected envelope contract: version=%v kind=%v", run, env["version"], env["kind"])
+					}
+					errs := firstResult(t, stdout)["errors"].([]any)
+					if len(errs) != 1 || errs[0].(map[string]any)["message"] != want {
+						t.Fatalf("run %d: errors = %#v, want one canonical requires message", run, errs)
+					}
+					continue
+				}
+
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("run %d: table missing canonical requires message:\n%s", run, stdout)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/validate.go
+++ b/internal/rules/validate.go
@@ -520,9 +520,15 @@ func countYAMLDocuments(region string) int {
 
 // formatCondition renders a condition map as a readable string.
 func formatCondition(cond map[string]any) string {
-	parts := make([]string, 0, len(cond))
-	for k, v := range cond {
-		parts = append(parts, fmt.Sprintf("%s = %v", k, v))
+	keys := make([]string, 0, len(cond))
+	for key := range cond {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s = %v", key, cond[key]))
 	}
 	return strings.Join(parts, " and ")
 }

--- a/internal/rules/validate_test.go
+++ b/internal/rules/validate_test.go
@@ -288,6 +288,40 @@ func TestValidate_Requires_ConditionTrue_FieldMissing(t *testing.T) {
 	if errs[0].Field != "Fecha" {
 		t.Errorf("field = %q, want Fecha", errs[0].Field)
 	}
+	if errs[0].Message != `field "Fecha" is required when Estado = Completed` {
+		t.Errorf("message = %q, want single-key condition unchanged", errs[0].Message)
+	}
+}
+
+func TestValidate_RequiresConditionHasStableKeyOrder(t *testing.T) {
+	stem := &StemFile{
+		Validate: []ValidationRule{
+			{
+				Rule: "requires",
+				If: map[string]any{
+					"status":   "Completed",
+					"priority": "High",
+				},
+				Then:   map[string]any{"fields": []any{"owner"}},
+				Source: "root/.stem",
+			},
+		},
+	}
+	record := makeRecord(map[string]any{
+		"status":   "Completed",
+		"priority": "High",
+	})
+	const want = `field "owner" is required when priority = High and status = Completed`
+
+	for run := 0; run < 128; run++ {
+		errs := Validate(context.Background(), record, stem)
+		if len(errs) != 1 {
+			t.Fatalf("run %d: got %d errors, want 1: %+v", run, len(errs), errs)
+		}
+		if errs[0].Message != want {
+			t.Fatalf("run %d: message = %q, want %q", run, errs[0].Message, want)
+		}
+	}
 }
 
 func TestValidate_Requires_ConditionFalse_NoCheck(t *testing.T) {


### PR DESCRIPTION
[rootline-team]

Closes #235

## Problem

`validate` rendered the keys of a multi-key `requires.if` condition by ranging directly over a Go map. Identical inputs could therefore alternate the condition text in both JSON v2 and table output.

## Change

- collect and lexicographically sort condition keys before rendering the diagnostic;
- preserve matching semantics, `then.fields` order, explicit `validate:` rule order, and all diagnostic fields;
- preserve the exact existing message for single-key conditions;
- add unit and CLI regressions for single-file and `--all`, JSON and table.

The engine remains field-agnostic. There is no `.stem` syntax change, envelope change, or Git dependency.

## TDD evidence

Before the production edit:

- `TestValidate_RequiresConditionHasStableKeyOrder` failed with `status = Completed and priority = High` instead of the canonical `priority = High and status = Completed`;
- all four CLI cases failed for the same reason.

After the minimal edit, both focused suites passed.

## Local verification

Implementation SHA: `6db7444841dad1e098ecec2558533e126e9e04f3`
Base: `master` `9f572f979c0b78d3beebb5622dc00644ba0b18ac`
Platform: Linux 6.18.35 x86_64; official Go 1.27.1 (published archive SHA-256 verified).

`just` was unavailable locally, so I executed every underlying recipe command directly:

- format check, golangci-lint 2.13.1, and `go build ./...`: pass;
- `go test ./... -race`: pass;
- coverage report/check: 90.0% total, every package above its floor;
- `go mod tidy`: no tracked changes;
- govulncheck 1.7.0: no vulnerabilities;
- gitleaks 8.30.1: no leaks;
- `rootline validate --all docs/roadmap/ -o json`: valid v2 envelope with zero errors;
- Linux `install.sh` resolver tests: pass.

PowerShell was unavailable locally. [CI #847](https://github.com/pablontiv/rootline/actions/runs/34013877269) executed the applicable installer tests successfully on Linux, macOS, and Windows.

### Real binary regression

A dev binary from the implementation tree was run as 256 external processes over the issue fixture:

| Entry point / format | Runs | Distinct stdout hashes |
|---|---:|---:|
| `--all` / JSON | 64 | 1 |
| `--all` / table | 64 | 1 |
| single file / JSON | 64 | 1 |
| single file / table | 64 | 1 |

Every process emitted the canonical `priority`→`status` condition, returned `exit 1`, and wrote zero stderr bytes. JSON remained `rootline/validate-batch` v2. Fixture bytes, modes, sizes, and an unrelated sentinel were unchanged.

## QA handoff

Implementation is complete and available for independent QA at the SHA above. Build a dev binary to avoid auto-update:

```sh
go build -o /tmp/rootline ./cmd/rootline/
/tmp/rootline validate --all <fixture> -o json
/tmp/rootline validate --all <fixture> -o table
/tmp/rootline validate <fixture>/task.md -o json
/tmp/rootline validate <fixture>/task.md -o table
```

Use the multi-key fixture from #235. Please compare against `master`, repeat fresh processes, verify the canonical key order and stable bytes, and confirm the JSON v2 contract, single-key message, `then.fields`/rule order, exit status, stderr, bytes, and permissions.

## Risk and limitations

Risk is limited to choosing one deterministic presentation order for multi-key condition text. Evaluation semantics and serialized structure are untouched.

## Pending

Implementation is complete and CI #847 passed on the published SHA: build, tests with race/coverage, tidy, lint, vulnerability scan, gitleaks, docs validation, and installer tests on Linux/macOS/Windows. This draft remains only for independent `[rootline-team/qa]` validation of SHA `6db7444841dad1e098ecec2558533e126e9e04f3`. After QA passes this SHA, the reviewer may mark it ready and continue integration without another developer pass.
