### PR TITLE
fix(graph): stabilize broken link ordering

### DIFF
--- a/.claude/skills/rootline/ref-advanced.md
+++ b/.claude/skills/rootline/ref-advanced.md
@@ -41,8 +41,10 @@ Default global output is JSON, so `--format dot|mermaid` only produces diagram t
 
 Output is deterministic: `nodes` is sorted lexically by path, `edges` by
 `(source, target, line, type)`, and `cycles` by canonical rotation — each cycle starts at its
-lexicographically smallest member and the list is sorted element-wise — so JSON, DOT, Mermaid and
-the numbered `--check` enumeration are byte-stable across runs and safe to commit or diff. Cycle
+lexicographically smallest member and the list is sorted element-wise. `broken_links` uses the
+same edge order, while each `suggestions` array is ranked by Levenshtein distance and then path.
+JSON, DOT, Mermaid and the numbered `--check` enumeration are therefore byte-stable across runs
+and safe to commit or diff. Cycle
 detection reports back edges over a canonical spanning forest, not every elementary circuit, so
 `len(cycles)` is a stable count of detected back edges rather than of distinct circuits. `tree`
 likewise picks its status column by sorting the enum-typed schema field names and taking the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Rel
 
 ### Fixed
 
+- `graph` now orders `broken_links` by `(source, target, line, type)` and ranks equal-distance suggestions lexically before keeping the closest three, so JSON and `--check` no longer change byte output or tied suggestion membership across identical runs.
 - `rootline skill install` now verifies staged symlink preimages by the link identity recorded in the plan and backup, so an Agents/Pi link pointing at the Claude destination is not falsely rejected after the same installation replaces Claude first.
 - `fix` now detects native YAML timestamp, boolean and integer values in governed string fields, preserves their exact scalar text while quoting them, and reports unsupported `rule: type` mismatches under `type_findings`. Stored repair reports carry optional `from_representation` evidence and reject stale lexeme or representation changes without weakening historical `correct_value` guards. Fix findings remain informational; `validate` remains the corpus-validity command. Closes #196.
 - CI ran on crossbeam's default `light` profile, so `Lint`, `Tidy` and `Vulnerability check` reported "skipping" on every run and the test job never used `-race`. `ci.yml` now passes `profile: full`, which is what `CLAUDE.md` already described.

--- a/cmd/rootline/graph_test.go
+++ b/cmd/rootline/graph_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -183,6 +184,62 @@ func TestGraphCheck_WithBrokenLink(t *testing.T) {
 	}
 	if !strings.Contains(out, "Broken links: 1") {
 		t.Errorf("expected broken link report, got: %s", out)
+	}
+}
+
+func TestGraphBrokenLinks_DeterministicOrdering(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, ".stem"), []byte("version: 2\n"), 0o644)
+	declareTestBoundary(t, dir)
+	for _, name := range []string{"c", "b", "a"} {
+		content := "---\n---\n# " + strings.ToUpper(name) + "\n[[missing-" + name + ".md]]\n"
+		mustWriteFile(t, filepath.Join(dir, name+".md"), []byte(content), 0o644)
+	}
+	for _, name := range []string{"rat", "mat", "hat", "bat"} {
+		mustWriteFile(t, filepath.Join(dir, name+".md"), []byte("---\n---\n# Candidate\n"), 0o644)
+	}
+	mustWriteFile(t, filepath.Join(dir, "source.md"), []byte("---\n---\n# Source\n[[cat.md]]\n"), 0o644)
+
+	wantSources := []string{"a.md", "b.md", "c.md", "source.md"}
+	wantSuggestions := []string{"bat.md", "hat.md", "mat.md"}
+	var firstJSON, firstCheck string
+	for run := 1; run <= 100; run++ {
+		jsonOut, err := runCmd(t, "graph", dir)
+		if err != nil {
+			t.Fatalf("run %d JSON: %v\n%s", run, err, jsonOut)
+		}
+		var result GraphResult
+		if err := json.Unmarshal([]byte(jsonOut), &result); err != nil {
+			t.Fatalf("run %d invalid JSON: %v\n%s", run, err, jsonOut)
+		}
+		if result.Version != 1 || result.Kind != "rootline/graph" {
+			t.Fatalf("run %d envelope = version %d kind %q", run, result.Version, result.Kind)
+		}
+		gotSources := make([]string, len(result.BrokenLinks))
+		for i, broken := range result.BrokenLinks {
+			gotSources[i] = broken.Source
+			if broken.Source == "source.md" && !slices.Equal(broken.Suggestions, wantSuggestions) {
+				t.Fatalf("run %d suggestions = %v, want %v", run, broken.Suggestions, wantSuggestions)
+			}
+		}
+		if !slices.Equal(gotSources, wantSources) {
+			t.Fatalf("run %d sources = %v, want %v", run, gotSources, wantSources)
+		}
+
+		checkOut, err := runCmd(t, "graph", "--check", dir)
+		if err != ErrValidationFailed {
+			t.Fatalf("run %d check error = %v, want ErrValidationFailed\n%s", run, err, checkOut)
+		}
+		if run == 1 {
+			firstJSON, firstCheck = jsonOut, checkOut
+			continue
+		}
+		if jsonOut != firstJSON {
+			t.Fatalf("run %d JSON differs from run 1", run)
+		}
+		if checkOut != firstCheck {
+			t.Fatalf("run %d check output differs from run 1", run)
+		}
 	}
 }
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -120,9 +120,11 @@ diff, or assert on in CI:
 | `nodes` | lexical by path |
 | `edges` | `(source, target, line, type)` |
 | `cycles` | each cycle rotated to start at its lexicographically smallest member and closed by repeating it; the list sorted element-wise, shorter first on a tie |
+| `broken_links` | `(source, target, line, type)` |
+| `broken_links[].suggestions` | ascending Levenshtein distance, then lexical by path; at most three |
 
-The `--check` numbered enumeration prints the same `cycles` order, so `1:` is always the same
-cycle for the same input.
+The `--check` numbered enumeration prints the same `cycles` order and its broken-link report uses
+the same `broken_links` and suggestion order, so every line is stable for the same input.
 
 A cycle through `b.md → c.md → a.md → b.md` therefore always prints as
 `a.md → b.md → c.md → a.md`: rotating a directed cycle does not change which links it contains,

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -309,29 +309,44 @@ func dedupeCycles(sorted [][]string) [][]string {
 // validate disagree in issue #62. Edges nothing resolved keep the historical
 // node-membership check.
 func (g *Graph) BrokenLinks() []BrokenLink {
-	nodeNames := make([]string, 0, len(g.Nodes))
-	for name := range g.Nodes {
-		nodeNames = append(nodeNames, name)
-	}
+	nodeNames := g.SortedNodes()
 
 	var broken []BrokenLink
-	for _, edges := range g.Edges {
-		for _, edge := range edges {
-			if edge.isBroken(g.Nodes) {
-				bl := BrokenLink{
-					Source: edge.Source,
-					Target: edge.Target,
-					Type:   edge.Type,
-					Line:   edge.Line,
-				}
-				if suggestions := fuzzy.MatchN(edge.Target, nodeNames, 3); len(suggestions) > 0 {
-					bl.Suggestions = suggestions
-				}
-				broken = append(broken, bl)
+	for _, edge := range g.SortedEdges() {
+		if edge.isBroken(g.Nodes) {
+			bl := BrokenLink{
+				Source: edge.Source,
+				Target: edge.Target,
+				Type:   edge.Type,
+				Line:   edge.Line,
 			}
+			if suggestions := brokenLinkSuggestions(edge.Target, nodeNames); len(suggestions) > 0 {
+				bl.Suggestions = suggestions
+			}
+			broken = append(broken, bl)
 		}
 	}
 	return broken
+}
+
+// brokenLinkSuggestions preserves fuzzy.MatchN's threshold while adding the
+// total order its distance-only ranking lacks. Asking for every in-threshold
+// candidate before truncating means an equal-distance tie is resolved
+// lexically rather than by the map order that supplied the candidates.
+func brokenLinkSuggestions(target string, nodeNames []string) []string {
+	suggestions := fuzzy.MatchN(target, nodeNames, len(nodeNames))
+	sort.Slice(suggestions, func(i, j int) bool {
+		iDistance := fuzzy.Distance(target, suggestions[i])
+		jDistance := fuzzy.Distance(target, suggestions[j])
+		if iDistance != jDistance {
+			return iDistance < jDistance
+		}
+		return suggestions[i] < suggestions[j]
+	})
+	if len(suggestions) > 3 {
+		suggestions = suggestions[:3]
+	}
+	return suggestions
 }
 
 // TraceOptions controls trace traversal behavior.

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -254,6 +254,56 @@ func TestBrokenLinks_MultipleFromSameSource(t *testing.T) {
 	}
 }
 
+func TestBrokenLinks_TotalOrder(t *testing.T) {
+	records := []*extract.Record{
+		makeRecord("z-source.md", []extract.Link{
+			{Target: "missing.md", Type: "reference", Line: 8},
+		}),
+		makeRecord("a-source.md", []extract.Link{
+			{Target: "z-missing.md", Type: "reference", Line: 7},
+			{Target: "a-missing.md", Type: "reference", Line: 9},
+			{Target: "a-missing.md", Type: "blocks", Line: 3},
+		}),
+	}
+
+	got := Build(context.Background(), records).BrokenLinks()
+	want := []BrokenLink{
+		{Source: "a-source.md", Target: "a-missing.md", Type: "blocks", Line: 3},
+		{Source: "a-source.md", Target: "a-missing.md", Type: "reference", Line: 9},
+		{Source: "a-source.md", Target: "z-missing.md", Type: "reference", Line: 7},
+		{Source: "z-source.md", Target: "missing.md", Type: "reference", Line: 8},
+	}
+	if !slices.EqualFunc(got, want, func(a, b BrokenLink) bool {
+		return a.Source == b.Source && a.Target == b.Target && a.Type == b.Type && a.Line == b.Line
+	}) {
+		t.Fatalf("BrokenLinks() = %+v, want %+v", got, want)
+	}
+}
+
+func TestBrokenLinks_SuggestionTiesUseLexicalOrder(t *testing.T) {
+	records := []*extract.Record{
+		makeRecord("rat.md", nil),
+		makeRecord("mat.md", nil),
+		makeRecord("hat.md", nil),
+		makeRecord("bat.md", nil),
+		makeRecord("source.md", []extract.Link{
+			{Target: "cat.md", Type: "reference", Line: 3},
+		}),
+	}
+	g := Build(context.Background(), records)
+	want := []string{"bat.md", "hat.md", "mat.md"}
+
+	for run := 1; run <= 100; run++ {
+		broken := g.BrokenLinks()
+		if len(broken) != 1 {
+			t.Fatalf("run %d: BrokenLinks() len = %d, want 1: %+v", run, len(broken), broken)
+		}
+		if !slices.Equal(broken[0].Suggestions, want) {
+			t.Fatalf("run %d: suggestions = %v, want %v", run, broken[0].Suggestions, want)
+		}
+	}
+}
+
 func TestBuild_EmptyGraph(t *testing.T) {
 	g := Build(context.Background(), []*extract.Record{})
 	if len(g.Nodes) != 0 {


### PR DESCRIPTION
[rootline-team]

## What

Makes `graph` broken-link output deterministic without changing graph semantics:

- `broken_links[]` now follows the existing edge total order `(source, target, line, type)`.
- Suggestions remain governed by picokit's existing adaptive fuzzy threshold, then use distance plus lexical path as a total order before keeping at most three.
- JSON and `graph --check` consume the same canonical slice.
- The graph contract, changelog, and distributed Rootline skill document the ordering.

## Related issue

Closes #237

## Why

Identical graphs leaked Go map iteration order into both the outer broken-link list and equal-distance fuzzy ties. This changed byte output and could change which tied candidate survived the top-three limit.

Before the change on base `4de3ee8c7c2bc19d45128523f75c25c5276b6e80`:

- 128 JSON runs: 6 distinct outputs.
- 128 `--check` runs: 6 distinct outputs.
- 256 equal-distance runs: 4 distinct suggestion selections.

## How

`Graph.BrokenLinks()` now walks `SortedEdges()` and uses `SortedNodes()`. It requests every in-threshold match from `fuzzy.MatchN`, applies the explicit total order `(Levenshtein distance, path)`, and only then truncates to three. This preserves picokit's threshold and the existing maximum.

TDD evidence: the new internal and CLI regressions first failed on the base because source order and suggestion membership varied, then passed after the minimal implementation.

## Verification

Exact head SHA: `ab79dc89f7bef20d0e1eee5a4b70e171960b22e5`

Local environment: Linux x86_64; official Go 1.27.1 archive verified against SHA-256 `63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445`.

- `just check`: passed with golangci-lint v2.13.1, 0 issues.
- `just test`: passed with `-race`.
- `just coverage-check`: passed, 90.0% total and every package at or above its floor.
- `just validate`: 126/126 roadmap records valid; no structural or stem-health errors.
- `just test-install`: Unix resolver passed; PowerShell unavailable locally and remains covered by CI.
- `go vet ./...`: passed.
- `go mod tidy`: no diff.
- `govulncheck ./...`: no vulnerabilities found.
- [CI #849](https://github.com/pablontiv/rootline/actions/runs/34016564780): passed Test & Build with race/coverage, Tidy, Lint, Vulnerability check, gitleaks, docs validation, and installer tests on Linux, macOS, and Windows.
- External candidate binary SHA-256: `19982781e5a3efd57c73f023fbda200e80dd8bb7b9eca987167f7c594750ced4`.
- 1,024 external candidate invocations: one JSON and one `--check` output for the multi-source fixture; one JSON and one `--check` output for the equal-distance fixture.
- JSON stayed `version: 1` / `kind: rootline/graph`; `--check` stayed exit 1 for broken links.
- Healthy graph stayed `broken_links: []` and exit 0.
- Fixture bytes and permissions were identical before and after all reads.
- Fixtures were outside Git, confirming product operation without a repository.

## QA handoff

Implementation is complete and available for independent QA at `ab79dc89f7bef20d0e1eee5a4b70e171960b22e5`. Rebuild with:

```bash
go build -o /tmp/rootline ./cmd/rootline/
```

Exercise both a multi-source broken-link fixture and a `cat.md` target with equal-distance candidates `bat.md`, `hat.md`, `mat.md`, and `rat.md` in JSON and `--check`. Expected tied selection is `bat.md, hat.md, mat.md`.

CI is complete. The PR remains draft only for independent `QA_PASS` on the exact head SHA; no implementation work is pending.

## Checklist

- [x] Tests pass (`go test ./... -race`)
- [x] Code is clean (`go vet ./...`)
- [x] Changes are documented if user-facing
- [x] Linked to its issue with a closing keyword
