### PR TITLE
fix: respect effective schemas in fix all

### DIFF
--- a/cmd/rootline/fix.go
+++ b/cmd/rootline/fix.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/pablontiv/rootline/internal/derive"
@@ -251,21 +252,24 @@ func runFixAll(ctx context.Context, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Use the effective stem with the richest schema (most fields defined).
-	var effective *rules.StemFile
-	for _, s := range effectiveStems {
-		if effective == nil || len(s.Schema) > len(effective.Schema) {
-			effective = s
-		}
+	stemGroups := groupRecordsByEffectiveStem(validRecords, effectiveStems, allErrs)
+	groupReports := make([]*proposal.Report, 0, len(stemGroups))
+	for _, group := range stemGroups {
+		groupReports = append(groupReports, proposal.Analyze(group.records, group.stem, group.errs))
 	}
-
-	report := proposal.Analyze(validRecords, effective, allErrs)
+	report := proposal.CombineReports(groupReports...)
 	report.Path = scanRoot
 	report.Root = root
 	if !unresolvedPopulation {
-		appendAggregateProposals(report, root, validRecords, effective)
-		if !fixNoPropagate {
-			appendPropagateProposals(report, validRecords, effective)
+		rootStemEntries, err := rules.WalkUp(root)
+		if err != nil {
+			return emitFixResult(cmd, failedBatchFixResult(fmt.Sprintf("resolving scan-root .stem: %v", err)))
+		}
+		appendAggregateProposals(report, root, validRecords, rules.MergeStemFiles(rootStemEntries))
+		for _, group := range stemGroups {
+			if !fixNoPropagate {
+				appendPropagateProposals(report, validRecords, group.records, group.stem)
+			}
 		}
 	}
 	appendStemHealthProposals(report, ctx, root)
@@ -348,6 +352,46 @@ func appendStemHealthProposals(report *proposal.Report, ctx context.Context, roo
 	}
 }
 
+type effectiveStemGroup struct {
+	stem    *rules.StemFile
+	records []*extract.Record
+	errs    map[string][]rules.ValidationError
+}
+
+// groupRecordsByEffectiveStem preserves scan order while isolating proposal
+// inference to records with the same fully resolved schema. Comparing the
+// effective value, rather than only its source path, also separates fields
+// governed by match and required_match within one .stem file.
+func groupRecordsByEffectiveStem(records []*extract.Record, stems map[string]*rules.StemFile, errs map[string][]rules.ValidationError) []effectiveStemGroup {
+	groups := make([]effectiveStemGroup, 0)
+
+	for _, record := range records {
+		stem := stems[record.Path]
+		groupIndex := -1
+		for i := range groups {
+			if reflect.DeepEqual(groups[i].stem, stem) {
+				groupIndex = i
+				break
+			}
+		}
+
+		if groupIndex < 0 {
+			groupIndex = len(groups)
+			groups = append(groups, effectiveStemGroup{
+				stem: stem,
+				errs: make(map[string][]rules.ValidationError),
+			})
+		}
+
+		groups[groupIndex].records = append(groups[groupIndex].records, record)
+		if recordErrs, ok := errs[record.Path]; ok {
+			groups[groupIndex].errs[record.Path] = recordErrs
+		}
+	}
+
+	return groups
+}
+
 // separateSchemaAndDataProposals splits proposals into data-only (applied) and
 // schema-only (suggestions). This allows dry-run to show both, and apply to
 // skip schema proposals.
@@ -368,8 +412,8 @@ func separateSchemaAndDataProposals(report *proposal.Report) {
 }
 
 // appendPropagateProposals detects stale aggregate values in index files and appends proposals to the report.
-func appendPropagateProposals(report *proposal.Report, records []*extract.Record, effective *rules.StemFile) {
-	propProposals := proposal.DetectPropagateAggregate(records, effective)
+func appendPropagateProposals(report *proposal.Report, records, targetRecords []*extract.Record, effective *rules.StemFile) {
+	propProposals := proposal.DetectPropagateAggregateForRecords(records, targetRecords, effective)
 	if len(propProposals) > 0 {
 		report.Proposals = append(report.Proposals, propProposals...)
 		report.Summary.PropagateAggregate += len(propProposals)

--- a/cmd/rootline/fix_test.go
+++ b/cmd/rootline/fix_test.go
@@ -676,16 +676,16 @@ func TestFixAllDryRunWithProposals(t *testing.T) {
 	}
 }
 
-// TestFixAllSelectsRichestStem verifies that runFixAll picks the stem with the
-// richest schema (most fields) instead of a random map entry. This prevents
-// losing enum definitions like estado/tipo when multiple stems coexist.
-func TestFixAllSelectsRichestStem(t *testing.T) {
+// TestFixAllKeepsRootProposalsWithRicherNestedStem verifies that a nested
+// schema with additional fields does not suppress proposals from its parent
+// scope.
+func TestFixAllKeepsRootProposalsWithRicherNestedStem(t *testing.T) {
 	root := t.TempDir()
 	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Rich stem at root: has estado enum with known values.
+	// Root stem has estado enum with known values.
 	richStem := `version: 2
 scope:
   match: "*.md"
@@ -701,7 +701,7 @@ schema:
 	mustWriteFile(t, filepath.Join(root, ".stem"), []byte(richStem), 0644)
 	declareTestBoundary(t, root)
 
-	// Subdirectory with a poor stem (only id field, no enums).
+	// The nested stem adds a field, making its effective schema richer.
 	subdir := filepath.Join(root, "sub")
 	if err := os.MkdirAll(subdir, 0755); err != nil {
 		t.Fatal(err)
@@ -737,11 +737,140 @@ schema:
 			t.Fatalf("iteration %d: invalid JSON: %v\nraw: %s", i, err, out)
 		}
 
-		// The richest stem has estado as enum. Two files use "Archivado"
-		// which is not in the enum -> extend_enum proposal.
+		// Two root files use "Archivado", so their own effective stem should
+		// still produce an extend_enum proposal.
 		if report.Summary.ExtendEnum == 0 {
 			t.Errorf("iteration %d: expected extend_enum > 0, got 0.\nFull output: %s", i, out)
 		}
+	}
+}
+
+func TestFixAllUsesEachRecordsEffectiveStem(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, ".stem"), []byte(`version: 2
+root: true
+scope:
+  match: "*.md"
+`), 0o644)
+
+	for _, fixture := range []struct {
+		dir, field, value string
+	}{
+		{dir: "alpha", field: "alpha", value: "alpha-default"},
+		{dir: "beta", field: "beta", value: "beta-default"},
+	} {
+		dir := filepath.Join(root, fixture.dir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stem := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  " + fixture.field +
+			":\n    type: string\n    required: true\n    default: " + fixture.value + "\n"
+		mustWriteFile(t, filepath.Join(dir, ".stem"), []byte(stem), 0o644)
+		mustWriteFile(t, filepath.Join(dir, fixture.dir[:1]+".md"), []byte("---\nseed: present\n---\n# "+fixture.dir+"\n"), 0o644)
+	}
+	declareTestBoundary(t, root)
+	mustChdir(t, root)
+
+	out, err := runCmd(t, "fix", "--all", "--dry-run", "--output", "json")
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	var report proposal.Report
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode dry-run: %v\n%s", err, out)
+	}
+	want := []proposal.Proposal{
+		{Type: proposal.AddField, Field: "alpha", Paths: []string{"alpha/a.md"}, Value: "alpha-default"},
+		{Type: proposal.AddField, Field: "beta", Paths: []string{"beta/b.md"}, Value: "beta-default"},
+	}
+	if len(report.Proposals) != len(want) {
+		t.Fatalf("got %d proposals, want %d: %#v", len(report.Proposals), len(want), report.Proposals)
+	}
+	for i := range want {
+		got := report.Proposals[i]
+		if got.Type != want[i].Type || got.Field != want[i].Field || got.Value != want[i].Value ||
+			len(got.Paths) != 1 || got.Paths[0] != want[i].Paths[0] {
+			t.Errorf("proposal[%d] = %#v, want type=%q field=%q value=%q path=%q", i, got, want[i].Type, want[i].Field, want[i].Value, want[i].Paths[0])
+		}
+	}
+
+	if _, err := runCmd(t, "fix", "--all", "--output", "json"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, fixture := range []struct {
+		path, field, value string
+	}{
+		{path: "alpha/a.md", field: "alpha", value: "alpha-default"},
+		{path: "beta/b.md", field: "beta", value: "beta-default"},
+	} {
+		content := string(mustReadFile(t, filepath.Join(root, fixture.path)))
+		if !strings.Contains(content, fixture.field+": "+fixture.value) {
+			t.Errorf("%s missing applied default %s=%s:\n%s", fixture.path, fixture.field, fixture.value, content)
+		}
+	}
+	if out, err := runCmd(t, "validate", "--all", "--output", "json"); err != nil {
+		t.Fatalf("post-apply validate: %v\n%s", err, out)
+	}
+
+	out, err = runCmd(t, "fix", "--all", "--output", "json")
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	var second BatchFixResult
+	if err := json.Unmarshal([]byte(out), &second); err != nil {
+		t.Fatalf("decode second apply: %v\n%s", err, out)
+	}
+	if second.Summary.Fixed != 0 {
+		t.Errorf("second apply fixed %d records, want 0: %s", second.Summary.Fixed, out)
+	}
+}
+
+func TestFixAllKeepsEnumInferenceWithinEffectiveStem(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, ".stem"), []byte("version: 2\nroot: true\nscope:\n  match: \"*.md\"\n"), 0o644)
+
+	for _, fixture := range []struct {
+		dir, allowed string
+		files        []string
+	}{
+		{dir: "alpha", allowed: "Alpha", files: []string{"a1.md", "a2.md"}},
+		{dir: "beta", allowed: "Beta", files: []string{"b1.md"}},
+	} {
+		dir := filepath.Join(root, fixture.dir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stem := "version: 2\nscope:\n  match: \"*.md\"\nschema:\n  state:\n    type: enum\n    values: [" + fixture.allowed + "]\n"
+		mustWriteFile(t, filepath.Join(dir, ".stem"), []byte(stem), 0o644)
+		for _, name := range fixture.files {
+			mustWriteFile(t, filepath.Join(dir, name), []byte("---\nstate: Shared\n---\n# Record\n"), 0o644)
+		}
+	}
+	declareTestBoundary(t, root)
+	mustChdir(t, root)
+
+	out, err := runCmd(t, "fix", "--all", "--dry-run", "--output", "json")
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	var report proposal.Report
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode dry-run: %v\n%s", err, out)
+	}
+	if len(report.SchemaSuggestions) != 1 {
+		t.Fatalf("got %d schema suggestions, want 1: %#v", len(report.SchemaSuggestions), report.SchemaSuggestions)
+	}
+
+	got := report.SchemaSuggestions[0]
+	if got.Type != proposal.ExtendEnum || got.Field != "state" || got.Value != "Shared" {
+		t.Fatalf("unexpected schema suggestion: %#v", got)
+	}
+	gotPaths := make(map[string]bool, len(got.Paths))
+	for _, path := range got.Paths {
+		gotPaths[path] = true
+	}
+	if len(gotPaths) != 2 || !gotPaths["alpha/a1.md"] || !gotPaths["alpha/a2.md"] || gotPaths["beta/b1.md"] {
+		t.Errorf("extend_enum paths crossed effective stems: %v", got.Paths)
 	}
 }
 

--- a/internal/proposal/propagate.go
+++ b/internal/proposal/propagate.go
@@ -17,19 +17,19 @@ import (
 // string in the aggregate expression. If any value is missing, the formula
 // may produce incorrect results, so propagation is skipped for that field.
 func DetectPropagateAggregate(records []*extract.Record, effective *rules.StemFile) []Proposal {
+	return DetectPropagateAggregateForRecords(records, records, effective)
+}
+
+// DetectPropagateAggregateForRecords evaluates only targetRecords while using
+// the complete record population to verify aggregate formula coverage.
+func DetectPropagateAggregateForRecords(records, targetRecords []*extract.Record, effective *rules.StemFile) []Proposal {
 	if effective == nil || len(effective.Aggregate) == 0 {
 		return nil
 	}
 
-	// Build map of records by path for descendant lookup.
-	recordMap := make(map[string]*extract.Record)
-	for _, rec := range records {
-		recordMap[rec.Path] = rec
-	}
-
 	var proposals []Proposal
 
-	for _, rec := range records {
+	for _, rec := range targetRecords {
 		// Only index files (README.md) can have aggregate values.
 		if !strings.HasSuffix(rec.Path, "README.md") {
 			continue

--- a/internal/proposal/propagate_test.go
+++ b/internal/proposal/propagate_test.go
@@ -66,6 +66,33 @@ func TestDetectPropagateAggregate_Consistent(t *testing.T) {
 	}
 }
 
+func TestDetectPropagateAggregateForRecordsLimitsTargetsButKeepsPopulation(t *testing.T) {
+	first := &extract.Record{
+		Path:        "S001/README.md",
+		Frontmatter: map[string]any{"estado": "Pending"},
+		Derived:     map[string]any{"estado": "Completed"},
+	}
+	second := &extract.Record{
+		Path:        "S002/README.md",
+		Frontmatter: map[string]any{"estado": "Pending"},
+		Derived:     map[string]any{"estado": "Completed"},
+	}
+	records := []*extract.Record{
+		first,
+		{Path: "S001/T001.md", Frontmatter: map[string]any{"estado": "Completed"}},
+		second,
+		{Path: "S002/T001.md", Frontmatter: map[string]any{"estado": "Completed"}},
+	}
+	stem := &rules.StemFile{Aggregate: map[string]any{
+		"estado": `all(descendants, {.estado == "Completed"}) ? "Completed" : "Pending"`,
+	}}
+
+	proposals := DetectPropagateAggregateForRecords(records, []*extract.Record{first}, stem)
+	if len(proposals) != 1 || len(proposals[0].Paths) != 1 || proposals[0].Paths[0] != first.Path {
+		t.Fatalf("proposals = %#v, want only %s", proposals, first.Path)
+	}
+}
+
 func TestDetectPropagateAggregate_MissingFrontmatter(t *testing.T) {
 	records := []*extract.Record{
 		{

--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -230,6 +230,48 @@ func Analyze(records []*extract.Record, effective *rules.StemFile, errs map[stri
 	typeRepairs, typeFindings := detectTypeRepresentationRepairs(records, errs)
 	proposals = append(proposals, typeRepairs...)
 
+	return newReport(proposals, typeFindings)
+}
+
+// CombineReports joins reports produced for independent effective-schema scopes.
+// Caller order is preserved so a deterministically scanned record set yields a
+// deterministic cross-scope proposal order.
+func CombineReports(reports ...*Report) *Report {
+	var proposals []Proposal
+	var schemaSuggestions []Proposal
+	var linkFindings []LinkFinding
+	var typeFindings []TypeFinding
+
+	for _, report := range reports {
+		if report == nil {
+			continue
+		}
+		proposals = append(proposals, report.Proposals...)
+		schemaSuggestions = append(schemaSuggestions, report.SchemaSuggestions...)
+		linkFindings = append(linkFindings, report.LinkFindings...)
+		typeFindings = append(typeFindings, report.TypeFindings...)
+	}
+
+	combined := newReport(proposals, typeFindings)
+	combined.SchemaSuggestions = schemaSuggestions
+	combined.LinkFindings = linkFindings
+	allProposals := append(append([]Proposal(nil), proposals...), schemaSuggestions...)
+	combined.Summary = summarize(allProposals)
+	return combined
+}
+
+func newReport(proposals []Proposal, typeFindings []TypeFinding) *Report {
+	summary := summarize(proposals)
+	return &Report{
+		Version:      1,
+		Kind:         "rootline/proposals",
+		Proposals:    proposals,
+		TypeFindings: typeFindings,
+		Summary:      summary,
+	}
+}
+
+func summarize(proposals []Proposal) Summary {
 	summary := Summary{Total: len(proposals)}
 	for _, p := range proposals {
 		switch p.Type {
@@ -271,14 +313,7 @@ func Analyze(records []*extract.Record, effective *rules.StemFile, errs map[stri
 			summary.LoosenSeverity++
 		}
 	}
-
-	return &Report{
-		Version:      1,
-		Kind:         "rootline/proposals",
-		Proposals:    proposals,
-		TypeFindings: typeFindings,
-		Summary:      summary,
-	}
+	return summary
 }
 
 // detectExtendEnum finds enum values rejected by validation that appear in

--- a/internal/proposal/proposal_coverage_test.go
+++ b/internal/proposal/proposal_coverage_test.go
@@ -7,6 +7,33 @@ import (
 	"github.com/pablontiv/rootline/internal/rules"
 )
 
+func TestCombineReportsPreservesOrderAndRecountsSummary(t *testing.T) {
+	first := &Report{
+		Proposals:         []Proposal{{Type: AddField, Field: "alpha"}},
+		SchemaSuggestions: []Proposal{{Type: ExtendEnum, Field: "state", Value: "Alpha"}},
+		LinkFindings:      []LinkFinding{{Path: "alpha/a.md", Rule: "link_resolve"}},
+		TypeFindings:      []TypeFinding{{Path: "alpha/a.md", Field: "alpha"}},
+	}
+	second := &Report{
+		Proposals:    []Proposal{{Type: CorrectValue, Field: "beta"}},
+		TypeFindings: []TypeFinding{{Path: "beta/b.md", Field: "beta"}},
+	}
+
+	got := CombineReports(first, nil, second)
+	if got.Version != 1 || got.Kind != "rootline/proposals" {
+		t.Fatalf("unexpected envelope: version=%d kind=%q", got.Version, got.Kind)
+	}
+	if len(got.Proposals) != 2 || got.Proposals[0].Field != "alpha" || got.Proposals[1].Field != "beta" {
+		t.Fatalf("proposal order changed: %#v", got.Proposals)
+	}
+	if got.Summary.Total != 3 || got.Summary.AddField != 1 || got.Summary.CorrectValue != 1 || got.Summary.ExtendEnum != 1 {
+		t.Errorf("summary was not recomputed: %#v", got.Summary)
+	}
+	if len(got.SchemaSuggestions) != 1 || len(got.LinkFindings) != 1 || len(got.TypeFindings) != 2 {
+		t.Errorf("findings were not combined: %#v", got)
+	}
+}
+
 // TestAnalyze_Basic tests the top-level Analyze orchestrator with various scenarios.
 func TestAnalyze_Basic(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
[rootline-team]

Closes #239

## Problem

`fix --all` validated each record with its effective `.stem`, then discarded that association and ran proposal analysis with one globally selected schema. Equal-sized divergent scopes therefore omitted valid repairs nondeterministically.

## Change

- Group records by their fully resolved effective stem while preserving deterministic scan order.
- Run schema-dependent proposal detection independently for each group and combine the reports without changing the version-1 envelope.
- Keep sibling/outlier/enum inference inside its governing scope.
- Evaluate aggregate propagation only for records governed by the corresponding stem while retaining the full descendant population for formula safety.
- Evaluate root aggregate suggestions against the scan-root stem rather than an arbitrary record stem.
- Preserve field-agnostic behavior and operation without Git.

## Verification

TDD reproduction on `master` `83898e5d9bc864803f38838192e3383fb5884606` failed as expected: the regression test observed 1 proposal instead of the required 2.

Fresh local verification after the final change:

- `gofmt -l .`: clean
- `go build ./...`: passed
- `go test ./... -race`: passed
- `go test ./... -coverprofile=coverage.out` plus `pkcov check`: passed, 90.1% total; `internal/proposal` 91.2%
- `go vet ./...`: passed
- `go mod tidy`: no `go.mod` or `go.sum` diff
- Built `rootline version dev` and validated all 126 roadmap documents: 126 valid
- External no-Git fixture: 128 JSON dry-runs produced one byte-identical output and all contained both repairs; 128 table dry-runs also produced one byte-identical output
- Dry-run preserved all document/`.stem` bytes and modes
- Apply wrote both defaults, post-apply `validate --all` passed, and a second apply reported `fixed: 0`
- Final Linux/amd64 binary SHA-256: `11778ce5c3566eb37939c5ac03099d35192895a72f50438778472b6875345bac`

[CI #851](https://github.com/pablontiv/rootline/actions/runs/34019255462) passed on the current SHA: build/test with coverage, lint, tidy, vulnerability scan, gitleaks, docs validation, and installer resolver tests on Ubuntu, macOS, and Windows. Release and post-release installer-smoke were correctly skipped for this PR.

## Status

Implementation is complete at `c2ef716f38de9f1cd1625533ae71a0a1ba7863ac` and available for independent QA. This PR remains draft only pending QA for this SHA; after QA passes, the reviewer may perform technical review, mark it ready, and integrate it under the current repository rules.