### PR TITLE
fix: repair empty frontmatter blocks

### DIFF
--- a/cmd/rootline/fix.go
+++ b/cmd/rootline/fix.go
@@ -154,9 +154,15 @@ func runFix(cmd *cobra.Command, args []string) error {
 			totalCorrected += len(corrected)
 			continue
 		}
+		if len(added) == 0 && len(corrected) == 0 {
+			continue
+		}
 
 		// Rewrite file
 		newContent := fix.RewriteFrontmatter(string(content), record.Frontmatter)
+		if newContent == string(content) {
+			return fmt.Errorf("frontmatter rewrite produced no changes for %s", file)
+		}
 		if err := os.WriteFile(absPath, []byte(newContent), 0644); err != nil { //nolint:gosec // fix intentionally rewrites the user-selected validated document path
 			return fmt.Errorf("writing %s: %w", file, err)
 		}

--- a/cmd/rootline/fix_empty_frontmatter_test.go
+++ b/cmd/rootline/fix_empty_frontmatter_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/fix"
+	"github.com/pablontiv/rootline/internal/proposal"
+)
+
+const emptyFrontmatterStem = `version: 2
+root: true
+scope:
+  match: "*.md"
+schema:
+  alpha:
+    type: string
+    required: true
+    default: alpha-default
+`
+
+const emptyFrontmatterDocument = "---\n---\n# Empty frontmatter\n\nBody\n\n---\n\ntail\n"
+const repairedEmptyFrontmatterDocument = "---\nalpha: alpha-default\n---\n# Empty frontmatter\n\nBody\n\n---\n\ntail\n"
+
+func newEmptyFrontmatterProject(t *testing.T) (root, target string, stemBefore []byte) {
+	t.Helper()
+
+	root = t.TempDir()
+	target = filepath.Join(root, "a.md")
+	mustWriteFile(t, filepath.Join(root, ".stem"), []byte(emptyFrontmatterStem), 0o644)
+	mustWriteFile(t, target, []byte(emptyFrontmatterDocument), 0o600)
+	return root, target, mustReadFile(t, filepath.Join(root, ".stem"))
+}
+
+func assertEmptyFrontmatterRepair(t *testing.T, root, target string, stemBefore []byte) {
+	t.Helper()
+
+	if got := string(mustReadFile(t, target)); got != repairedEmptyFrontmatterDocument {
+		t.Errorf("repaired document = %q, want %q", got, repairedEmptyFrontmatterDocument)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("target mode = %04o, want 0600", info.Mode().Perm())
+	}
+	if got := mustReadFile(t, filepath.Join(root, ".stem")); string(got) != string(stemBefore) {
+		t.Errorf(".stem changed:\nwant:\n%s\ngot:\n%s", stemBefore, got)
+	}
+	if out, err := runCmd(t, "validate", target, "--output", "json"); err != nil {
+		t.Fatalf("post-repair validate failed: %v\n%s", err, out)
+	}
+}
+
+func TestFixSingleRepairsEmptyFrontmatter(t *testing.T) {
+	root, target, stemBefore := newEmptyFrontmatterProject(t)
+	original := mustReadFile(t, target)
+
+	dryOut, err := runCmd(t, "fix", "--dry-run", target)
+	if err != nil {
+		t.Fatalf("fix dry-run: %v\n%s", err, dryOut)
+	}
+	if !strings.Contains(dryOut, `would add alpha="alpha-default"`) {
+		t.Errorf("dry-run did not preview the field addition: %s", dryOut)
+	}
+	if got := mustReadFile(t, target); string(got) != string(original) {
+		t.Errorf("dry-run changed target:\nwant:\n%s\ngot:\n%s", original, got)
+	}
+
+	out, err := runCmd(t, "fix", target)
+	if err != nil {
+		t.Fatalf("fix apply: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, `added alpha="alpha-default"`) || !strings.Contains(out, "Fixed: 1 fields added") {
+		t.Errorf("fix did not report the applied field: %s", out)
+	}
+	assertEmptyFrontmatterRepair(t, root, target, stemBefore)
+
+	beforeSecond := mustReadFile(t, target)
+	secondOut, err := runCmd(t, "fix", target)
+	if err != nil {
+		t.Fatalf("second fix: %v\n%s", err, secondOut)
+	}
+	if !strings.Contains(secondOut, "no errors to fix") {
+		t.Errorf("second fix was not reported as a no-op: %s", secondOut)
+	}
+	if got := mustReadFile(t, target); string(got) != string(beforeSecond) {
+		t.Errorf("second fix changed target:\nwant:\n%s\ngot:\n%s", beforeSecond, got)
+	}
+}
+
+func TestFixAllRepairsEmptyFrontmatter(t *testing.T) {
+	root, target, stemBefore := newEmptyFrontmatterProject(t)
+	original := mustReadFile(t, target)
+
+	dryOut, err := runCmd(t, "fix", "--all", root, "--dry-run", "--output", "json")
+	if err != nil {
+		t.Fatalf("fix --all dry-run: %v\n%s", err, dryOut)
+	}
+	var preview proposal.Report
+	if err := json.Unmarshal([]byte(dryOut), &preview); err != nil {
+		t.Fatalf("decode fix preview: %v\n%s", err, dryOut)
+	}
+	if preview.Version != 1 || preview.Kind != "rootline/proposals" || len(preview.Proposals) != 1 {
+		t.Fatalf("fix preview = %+v, want one v1 repair proposal", preview)
+	}
+	if got := mustReadFile(t, target); string(got) != string(original) {
+		t.Errorf("fix --all dry-run changed target:\nwant:\n%s\ngot:\n%s", original, got)
+	}
+
+	out, err := runCmd(t, "fix", "--all", root, "--output", "json")
+	if err != nil {
+		t.Fatalf("fix --all apply: %v\n%s", err, out)
+	}
+	var batch BatchFixResult
+	if err := json.Unmarshal([]byte(out), &batch); err != nil {
+		t.Fatalf("decode fix result: %v\n%s", err, out)
+	}
+	if batch.Version != 1 || batch.Kind != "rootline/fix-batch" || batch.Summary.Fixed != 1 {
+		t.Fatalf("fix result = %+v, want one fixed record in v1 envelope", batch)
+	}
+	if len(batch.Results) != 1 || !batch.Results[0].Fixed || batch.Results[0].FieldsAdded != 1 {
+		t.Errorf("record result = %+v, want one applied field", batch.Results)
+	}
+	assertEmptyFrontmatterRepair(t, root, target, stemBefore)
+
+	secondOut, err := runCmd(t, "fix", "--all", root, "--output", "json")
+	if err != nil {
+		t.Fatalf("second fix --all: %v\n%s", err, secondOut)
+	}
+	var second BatchFixResult
+	if err := json.Unmarshal([]byte(secondOut), &second); err != nil {
+		t.Fatalf("decode second fix result: %v\n%s", err, secondOut)
+	}
+	if second.Summary.Fixed != 0 {
+		t.Errorf("second fix --all fixed %d records, want 0: %s", second.Summary.Fixed, secondOut)
+	}
+}
+
+func TestRepairApplyRepairsEmptyFrontmatter(t *testing.T) {
+	root, target, stemBefore := newEmptyFrontmatterProject(t)
+	original := mustReadFile(t, target)
+
+	previewOut, err := runCmd(t, "fix", "--all", root, "--dry-run", "--output", "json")
+	if err != nil {
+		t.Fatalf("generate repair report: %v\n%s", err, previewOut)
+	}
+	reportFile := filepath.Join(t.TempDir(), "repair.json")
+	mustWriteFile(t, reportFile, []byte(previewOut), 0o644)
+
+	dryOut, err := runCmd(t, "repair", "apply", "--report", reportFile, "--dry-run", "--output", "json")
+	if err != nil {
+		t.Fatalf("repair apply dry-run: %v\n%s", err, dryOut)
+	}
+	var dry fix.RepairResult
+	if err := json.Unmarshal([]byte(dryOut), &dry); err != nil {
+		t.Fatalf("decode repair dry-run: %v\n%s", err, dryOut)
+	}
+	if dry.Version != 1 || dry.Kind != "rootline/repair" || !dry.Complete || len(dry.Changed) != 1 {
+		t.Fatalf("repair dry-run = %+v, want one complete v1 preview", dry)
+	}
+	if got := mustReadFile(t, target); string(got) != string(original) {
+		t.Errorf("repair dry-run changed target:\nwant:\n%s\ngot:\n%s", original, got)
+	}
+
+	out, err := runCmd(t, "repair", "apply", "--report", reportFile, "--output", "json")
+	if err != nil {
+		t.Fatalf("repair apply: %v\n%s", err, out)
+	}
+	var result fix.RepairResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("decode repair result: %v\n%s", err, out)
+	}
+	if result.Version != 1 || result.Kind != "rootline/repair" || !result.Complete || len(result.Changed) != 1 || len(result.RolledBack) != 0 {
+		t.Fatalf("repair result = %+v, want one complete applied change", result)
+	}
+	assertEmptyFrontmatterRepair(t, root, target, stemBefore)
+
+	secondOut, err := runCmd(t, "repair", "apply", "--report", reportFile, "--output", "json")
+	if err != nil {
+		t.Fatalf("second repair apply: %v\n%s", err, secondOut)
+	}
+	var second fix.RepairResult
+	if err := json.Unmarshal([]byte(secondOut), &second); err != nil {
+		t.Fatalf("decode second repair result: %v\n%s", err, secondOut)
+	}
+	if !second.Complete || len(second.Changed) != 0 || len(second.Skipped) != 1 {
+		t.Errorf("second repair result = %+v, want one idempotent skip", second)
+	}
+}

--- a/docs/fix.md
+++ b/docs/fix.md
@@ -250,6 +250,10 @@ jq -e .complete result.json                                    # ...and still an
 Recovering from a partial run is a re-run: the report is declarative, and re-applying it skips what
 is already correct. Take a `--dry-run` first if you want to see what remains.
 
+For `set_field`, an existing string equal to the requested value is skipped in both dry-run and
+apply, and the remaining paths are still processed. Equality is type-strict: a YAML boolean or
+integer is not the same as its string spelling, and a missing field is not an empty string.
+
 `repair apply` applies only repair-surface proposals to document frontmatter:
 - correct_value
 - add_field

--- a/internal/e2e/repair_set_field_test.go
+++ b/internal/e2e/repair_set_field_test.go
@@ -20,7 +20,7 @@ func TestRepairSetFieldResumeAndReplay(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		bin += ".exe"
 	}
-	build := exec.Command("go", "build", "-o", bin, "./cmd/rootline")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/rootline") //nolint:gosec // fixed compiler command; output path belongs to this test
 	build.Dir = filepath.Join("..", "..")
 	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("build dev CLI: %v\n%s", err, output)

--- a/internal/e2e/repair_set_field_test.go
+++ b/internal/e2e/repair_set_field_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pablontiv/rootline/internal/fix"
+)
+
+// A stored report must resume past satisfied paths, then become a read-only replay.
+func TestRepairSetFieldResumeAndReplay(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "rootline")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", bin, "./cmd/rootline")
+	build.Dir = filepath.Join("..", "..")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build dev CLI: %v\n%s", err, output)
+	}
+	root := t.TempDir() // Deliberately no Git repository.
+	body := "# Document\n\nKeep this text.\n\n---\n\nAnd this text.\n"
+	files := map[string]string{
+		".stem":         "version: 2\nroot: true\nscope:\n  match: '*.md'\nschema:\n  alpha:\n    type: string\n    required: true\n",
+		"a.md":          "---\n# Preserve formatting of an already satisfied field.\nalpha:  'new'\n---\n" + body,
+		"b.md":          "---\nalpha: old\n---\n" + body,
+		"report.json":   `{"version":1,"kind":"rootline/proposals","proposals":[{"type":"set_field","field":"alpha","value":"new","paths":["a.md","b.md"]}]}`,
+		"unrelated.txt": "Leave me alone.\n",
+	}
+	stamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertFile := func(name, want string, untouched bool) {
+		t.Helper()
+		path := filepath.Join(root, name)
+		if got := string(mustReadE2EFile(t, path)); got != want {
+			t.Fatalf("%s content: got %q, want %q", name, got, want)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+			t.Fatalf("%s mode changed to %o", name, info.Mode().Perm())
+		}
+		if untouched && !info.ModTime().Equal(stamp) {
+			t.Fatalf("%s was unexpectedly written", name)
+		}
+	}
+	run := func(dryRun bool, changed, skipped int) {
+		t.Helper()
+		args := []string{"repair", "apply", "--root", root, "--report", filepath.Join(root, "report.json"), "-o", "json"}
+		if dryRun {
+			args = append(args, "--dry-run")
+		}
+		cmd := exec.Command(bin, args...) //nolint:gosec // locally built CLI, isolated fixture paths
+		cmd.Dir = root
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("repair apply: %v\nstdout: %s\nstderr: %s", err, &stdout, &stderr)
+		}
+		var result fix.RepairResult
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("decode repair: %v\n%s", err, &stdout)
+		}
+		if stderr.Len() != 0 || result.Version != 1 || result.Kind != "rootline/repair" || !result.Complete || result.DryRun != dryRun ||
+			len(result.Errors) != 0 || len(result.Rejected) != 0 || len(result.RolledBack) != 0 || len(result.Changed) != changed || len(result.Skipped) != skipped {
+			t.Fatalf("unexpected repair result: %s\nstderr: %s", &stdout, &stderr)
+		}
+		if changed == 1 && !strings.Contains(result.Changed[0], "b.md") {
+			t.Fatalf("pending b.md was not selected: %v", result.Changed)
+		}
+	}
+	run(true, 1, 1)
+	for name, content := range files {
+		assertFile(name, content, true)
+	}
+	run(false, 1, 1)
+	files["b.md"] = "---\nalpha: new\n---\n" + body
+	for name, content := range files {
+		assertFile(name, content, name != "b.md")
+	}
+	// Reset only the timestamp, so a redundant atomic rewrite is observable.
+	if err := os.Chtimes(filepath.Join(root, "b.md"), stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+	run(true, 0, 2)
+	run(false, 0, 2)
+	for name, content := range files {
+		assertFile(name, content, true)
+	}
+	validate := exec.Command(bin, "validate", "--all", root, "-o", "json") //nolint:gosec // locally built CLI
+	if output, err := validate.CombinedOutput(); err != nil {
+		t.Fatalf("post-repair validation: %v\n%s", err, output)
+	}
+}

--- a/internal/fix/coverage_gaps_test.go
+++ b/internal/fix/coverage_gaps_test.go
@@ -1036,6 +1036,46 @@ estado: Pending
 	}
 }
 
+func TestApplyRepairAddField_RejectsUnchangedRewrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPath := filepath.Join(tmpDir, "test.md")
+	original := "---\n# missing closing delimiter\n"
+	if err := os.WriteFile(testPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	targets := map[string]*repairTarget{
+		"test.md": {
+			abs: testPath,
+			record: &extract.Record{
+				Path:        "test.md",
+				Frontmatter: map[string]any{},
+			},
+			original: []byte(original),
+		},
+	}
+	p := proposal.Proposal{
+		Type:  proposal.AddField,
+		Field: "alpha",
+		Value: "alpha-default",
+		Paths: []string{"test.md"},
+	}
+	result := &RepairResult{}
+
+	err := applyRepairAddField(&p, targets, result, false)
+	if err == nil || !strings.Contains(err.Error(), "produced no changes") {
+		t.Fatalf("applyRepairAddField() error = %v, want unchanged-rewrite error", err)
+	}
+	if len(result.Changed) != 0 || targets["test.md"].written {
+		t.Errorf("unchanged rewrite reported a write: result=%+v target=%+v", result, targets["test.md"])
+	}
+	if got, readErr := os.ReadFile(testPath); readErr != nil {
+		t.Fatalf("read: %v", readErr)
+	} else if string(got) != original {
+		t.Errorf("unchanged rewrite modified target: %q", got)
+	}
+}
+
 // TestApplyRepairCorrectValue_DryRun tests CorrectValue in dry-run mode
 func TestApplyRepairCorrectValue_DryRun(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -170,12 +170,20 @@ func RewriteFrontmatter(original string, fm map[string]any) string {
 		return b.String()
 	}
 
-	endIdx := strings.Index(original[4:], "\n---\n")
-	if endIdx == -1 {
+	rest := original[4:]
+	closingIdx := 0
+	if !strings.HasPrefix(rest, "---\n") {
+		closingIdx = strings.Index(rest, "\n---\n")
+		if closingIdx == -1 {
+			return original
+		}
+		closingIdx++ // move from the preceding newline to the delimiter
+	}
+	if closingIdx+4 > len(rest) {
 		return original
 	}
-	fmText := original[4 : 4+endIdx+1]
-	body := original[4+endIdx+5:]
+	fmText := rest[:closingIdx]
+	body := rest[closingIdx+4:]
 
 	if rendered, ok := renderPreservedFrontmatter(fmText, fm); ok {
 		return "---\n" + rendered + "---\n" + body
@@ -187,6 +195,21 @@ func RewriteFrontmatter(original string, fm map[string]any) string {
 	b.WriteString("---\n")
 	b.WriteString(body)
 	return b.String()
+}
+
+func rewriteChangedFrontmatter(original string, fm map[string]any, path string) (string, error) {
+	rewritten := RewriteFrontmatter(original, fm)
+	if err := requireContentChange(original, rewritten, path); err != nil {
+		return "", fmt.Errorf("frontmatter rewrite produced no changes for %s", path)
+	}
+	return rewritten, nil
+}
+
+func requireContentChange(original, rewritten, path string) error {
+	if rewritten == original {
+		return fmt.Errorf("rewrite produced no changes for %s", path)
+	}
+	return nil
 }
 
 // WriteFrontmatterFields writes frontmatter fields to a builder in sorted order.
@@ -392,6 +415,9 @@ func applyMigrateValue(p proposal.Proposal, root string, recordMap map[string]*e
 		if len(p.WikiLinks) > 0 {
 			newContent = InsertWikiLinksBeforeHeading(newContent, p.WikiLinks)
 		}
+		if err := requireContentChange(string(content), newContent, path); err != nil {
+			return err
+		}
 
 		if err := fsx.WriteFileAtomic(absPath, []byte(newContent), newFileMode); err != nil {
 			return err
@@ -438,7 +464,10 @@ func rewriteRecordFile(root, path string, fm map[string]any) error {
 	if err != nil {
 		return err
 	}
-	newContent := RewriteFrontmatter(string(content), fm)
+	newContent, err := rewriteChangedFrontmatter(string(content), fm, path)
+	if err != nil {
+		return err
+	}
 	return fsx.WriteFileAtomic(absPath, []byte(newContent), newFileMode)
 }
 

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -632,6 +632,25 @@ func TestRewriteRecordFile(t *testing.T) {
 	}
 }
 
+func TestRewriteRecordFile_RejectsUnchangedRewrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "task.md")
+	original := "---\nestado: old\n# missing closing delimiter\n"
+	mustWriteFile(t, target, []byte(original))
+
+	err := rewriteRecordFile(dir, "task.md", map[string]any{"estado": "new"})
+	if err == nil || !strings.Contains(err.Error(), "produced no changes") {
+		t.Fatalf("rewriteRecordFile() error = %v, want unchanged-rewrite error", err)
+	}
+	content, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("reading target: %v", readErr)
+	}
+	if string(content) != original {
+		t.Errorf("unchanged rewrite modified the target: %q", content)
+	}
+}
+
 // --- addEnumValueToNode ---
 
 func TestAddEnumValueToNode(t *testing.T) {

--- a/internal/fix/frontmatter_preserve_test.go
+++ b/internal/fix/frontmatter_preserve_test.go
@@ -73,6 +73,33 @@ func TestRewriteFrontmatter_AppendsNewKeyAfterExisting(t *testing.T) {
 	}
 }
 
+func TestRewriteFrontmatter_AppendsToEmptyLeadingBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		original string
+	}{
+		{
+			name:     "adjacent delimiters",
+			original: "---\n---\n# Doc\n\nbody\n",
+		},
+		{
+			name:     "blank line between delimiters",
+			original: "---\n\n---\n# Doc\n\nbody\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RewriteFrontmatter(tt.original, map[string]any{"alpha": "alpha-default"})
+
+			want := "---\nalpha: alpha-default\n---\n# Doc\n\nbody\n"
+			if result != want {
+				t.Errorf("RewriteFrontmatter() = %q, want %q", result, want)
+			}
+		})
+	}
+}
+
 func TestRewriteFrontmatter_RemovesDroppedKey(t *testing.T) {
 	original := "---\ntitle: A\nobsolete: gone\nstatus: open\n---\n\n# Doc\n"
 	fm := map[string]any{"title": "A", "status": "open"}

--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -568,6 +568,12 @@ func applyRepairSetField(p *proposal.Proposal, targets map[string]*repairTarget,
 			continue
 		}
 
+		if current, exists := tgt.record.Frontmatter[p.Field]; exists && proposalValueMatches(current, p.Value) {
+			result.Skipped = append(result.Skipped,
+				fmt.Sprintf("%s already %q in %s", p.Field, p.Value, path))
+			continue
+		}
+
 		tgt.record.Frontmatter[p.Field] = p.Value
 		invalidateFrontmatterScalar(tgt.record, p.Field)
 

--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -486,6 +486,9 @@ func applyRepairCorrectValue(p *proposal.Proposal, targets map[string]*repairTar
 		if p.Type == proposal.MigrateValue && len(p.WikiLinks) > 0 {
 			newContent = InsertWikiLinksBeforeHeading(newContent, p.WikiLinks)
 		}
+		if err := requireContentChange(string(content), newContent, path); err != nil {
+			return err
+		}
 		if err := fsx.WriteFileAtomic(tgt.abs, []byte(newContent), newFileMode); err != nil {
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
@@ -541,7 +544,10 @@ func applyRepairAddField(p *proposal.Proposal, targets map[string]*repairTarget,
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		newContent := RewriteFrontmatter(string(content), candidate)
+		newContent, err := rewriteChangedFrontmatter(string(content), candidate, path)
+		if err != nil {
+			return err
+		}
 		if err := fsx.WriteFileAtomic(tgt.abs, []byte(newContent), newFileMode); err != nil {
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
@@ -577,7 +583,10 @@ func applyRepairSetField(p *proposal.Proposal, targets map[string]*repairTarget,
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		newContent := RewriteFrontmatter(string(content), tgt.record.Frontmatter)
+		newContent, err := rewriteChangedFrontmatter(string(content), tgt.record.Frontmatter, path)
+		if err != nil {
+			return err
+		}
 		if err := fsx.WriteFileAtomic(tgt.abs, []byte(newContent), newFileMode); err != nil {
 			return fmt.Errorf("writing %s: %w", path, err)
 		}

--- a/internal/fix/repair_set_field_test.go
+++ b/internal/fix/repair_set_field_test.go
@@ -1,0 +1,41 @@
+package fix
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/proposal"
+)
+
+func TestApplyRepairSetFieldStrictEquality(t *testing.T) {
+	for _, tt := range []struct {
+		name, yaml, value, want string
+		skipped                 int
+	}{
+		{"same string", "alpha: new", "new", "alpha: new", 1},
+		{"boolean is not string", "alpha: true", "true", "alpha: \"true\"", 0},
+		{"integer is not string", "alpha: 1", "1", "alpha: \"1\"", 0},
+		{"missing is not empty string", "other: kept", "", "other: kept\nalpha: \"\"", 0},
+	} {
+		for _, dryRun := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/dry=%v", tt.name, dryRun), func(t *testing.T) {
+				before := "---\n" + tt.yaml + "\n---\n# Body\n"
+				root, rel, path, stamp := writeFixedRepairDoc(t, before)
+				result, err := ApplyRepair([]proposal.Proposal{{Type: proposal.SetField, Field: "alpha", Value: tt.value, Paths: []string{rel}}}, dryRun, root, false)
+				if err != nil || !result.Complete || len(result.Errors) != 0 || len(result.Skipped) != tt.skipped || len(result.Changed) != 1-tt.skipped {
+					t.Fatalf("result=%+v err=%v", result, err)
+				}
+				if dryRun || tt.skipped == 1 {
+					assertUnchangedRepairDoc(t, path, before, stamp)
+				} else {
+					got, err := os.ReadFile(filepath.Join(root, rel))
+					if err != nil || string(got) != "---\n"+tt.want+"\n---\n# Body\n" {
+						t.Fatalf("unexpected rewrite: %q, err=%v", got, err)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
[rootline-team]

Closes #240

## Problem

Valid Markdown with an empty leading frontmatter block (`---\n---\n`) is parsed correctly, but the repair writer did not recognize the adjacent closing delimiter. `fix` and `fix --all` could report a successful field addition while leaving the file unchanged; `repair apply` rolled the unchanged result back.

## Behavior change

- Recognize adjacent closing delimiters and insert fields inside the empty YAML mapping.
- Reject any mutation path whose frontmatter rewrite produces unchanged bytes, so success is never reported without a write.
- Apply the same guard to single-file fix, batch fix, repair add/set/correct/migrate paths.
- Preserve the existing v1 envelopes, body bytes, file mode, `.stem`, dry-run behavior, and Git-optional operation.

## Acceptance coverage

- `fix <file>`, `fix --all`, and `repair apply` repair the empty-frontmatter fixture and validation passes afterward.
- Both dry-run paths preview the repair without changing bytes.
- A second application is idempotent.
- Regression coverage includes adjacent delimiters, a blank line inside an empty block, normal non-empty frontmatter, malformed/unterminated blocks, body thematic breaks, permissions, and truthful unchanged-write rejection.

## R1 correction

Skip an already satisfied `set_field` using strict value equality before mutating frontmatter, invalidating scalar metadata, or simulating a write. Continue to the remaining paths. The unchanged-rewrite error is retained for mutations that are actually needed.

Regression tests cover mixed satisfied/pending paths, dry-run/apply parity, replay, byte and timestamp preservation, mode 0600, unchanged schema/report/unrelated files, and strict distinctions between strings, booleans, integers, and absent fields. Documentation clarifies the existing replay contract.

## Verification

Current published SHA: `4415716fb35aabe1047e04ea1947148a723f6f96`.

Linux x86_64, Go 1.26.8 revalidated. The GitHub tree `6d502a6f791e286c44d8a8d8e0f71231d14fbe59` matches the local checkout. The final delta after the full local race/coverage runs is one comment explaining the trusted test compiler invocation.

- Before the fix, `TestApplyRepairSetFieldStrictEquality` failed for both preview and apply; apply returned `complete:false` with `frontmatter rewrite produced no changes`. `TestRepairSetFieldResumeAndReplay` also failed against the previous head.
- Both regression tests now PASS. The process test builds a dev CLI and runs against a real no-Git fixture: one pending path changed/one satisfied path skipped, followed by zero changed/two skipped on replay; validation passes.
- `just test` — PASS, complete suite with race, including the original empty-frontmatter and body preservation regressions.
- Dev binary build, `go vet ./...`, `go mod tidy` with no module diff, `just validate` (126/126 records), and `git diff --check` — PASS.
- `just check` — could not complete locally: `golangci-lint` is absent (exit 127). Formatting was checked; current-SHA CI #855 executed golangci-lint successfully with 0 issues, covering the missing local linter.
- `just coverage-check` — FAIL: total 88.9%, `internal/fix` 90.2%; untouched `internal/skilldist` remains 84.8% against 85%. This is the pre-existing discrepancy already reproduced on master in the earlier implementation report. No threshold or quality rule was modified. This local failure is not a passing gate.
- [CI #854](https://github.com/pablontiv/rootline/actions/runs/34048291093) passed all applicable jobs except one gosec G204 finding in the new test's compiler invocation. The final commit adds a narrowly scoped justification: the command is fixed, and its output directory is owned by the test; no runtime input or shell is used, and no global lint rule changed. [CI #855](https://github.com/pablontiv/rootline/actions/runs/34048398891) — PASS for the current SHA: build, full-profile tests with race, coverage gate (90.1% total; internal/fix 91.2%, internal/skilldist 85.4%), tidy, lint (0 issues), vulnerability scan, gitleaks, docs-validate and native installer-tests on Ubuntu/macOS/Windows. Release and post-release installer-smoke are not applicable to this PR event and were skipped. Local vulnerability/gitleaks scans were not rerun; the current CI jobs executed them.

Final-SHA dev binary rebuilt locally: SHA-256 `1b864a8829540887a5664cdc0521f706b94f33dc2e336fcf3d927637546b0e9b`. The two focused regression tests were rerun and passed on the final checkout. No production binaries were installed.

## QA handoff

Implementation, including R1, is complete and available for independent QA at `4415716fb35aabe1047e04ea1947148a723f6f96`. This is a developer handoff, not QA or technical approval. The existing review thread is left for the reviewer to re-evaluate.

Build and reproduce:

```sh
git checkout --detach 4415716fb35aabe1047e04ea1947148a723f6f96
go build -o /tmp/rootline-qa ./cmd/rootline/
go test ./internal/fix -run '^TestApplyRepairSetFieldStrictEquality$' -count=1
go test ./internal/e2e -run '^TestRepairSetFieldResumeAndReplay$' -count=1
```

The complete no-Git fixture and external commands are in `internal/e2e/repair_set_field_test.go`; the independent reviewer fixture is in [R1](https://github.com/pablontiv/rootline/pull/243#pullrequestreview-5125994979). With a stored set_field report targeting `[a.md=new,b.md=old]`, expect dry-run/apply: exit 0, complete=true, one changed/one skipped; replay: exit 0, zero changed/two skipped. Verify bytes/modes and the body thematic break fixture from #240 across fix, fix --all, and repair apply.

Remaining: independent QA_PASS and technical re-review of R1 for the current SHA, including assessment of the documented pre-existing local coverage discrepancy. CI is complete. Draft is retained only for these validations; the reviewer may mark ready and integrate after all gates are satisfied, without another administrative developer pass. #242 remains queued.
