### PR TITLE
fix(repair): reject mixed-containment proposals

### DIFF
--- a/internal/fix/repair.go
+++ b/internal/fix/repair.go
@@ -132,7 +132,7 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string, fillMi
 	targets := make(map[string]*repairTarget)
 	reg := extract.NewRegistry()
 
-	for path, absPath := range accepted {
+	for path, absPath := range applicableProposalPaths(proposals, accepted, rejected) {
 		// A directory otherwise reaches os.ReadFile and comes back as
 		// "read docs: is a directory" — the syscall that tripped over the path
 		// rather than an answer about the report. Repair takes document paths.
@@ -170,6 +170,11 @@ func ApplyRepair(proposals []proposal.Proposal, dryRun bool, root string, fillMi
 
 	// Third pass: classify and apply proposals.
 	for _, p := range proposals {
+		// A proposal is applied whole or not at all, so one bad path discards it.
+		if hasRejectedPath(p, rejected) {
+			continue
+		}
+
 		// A value the engine picked because the schema declared none stays out
 		// of the document unless the caller explicitly asked for it.
 		if p.Type == proposal.AddField && proposal.IsEngineChosen(p.ValueSource) && !fillMissing {
@@ -401,6 +406,35 @@ func acceptedProposalPaths(p proposal.Proposal, accepted map[string]string) []st
 		}
 	}
 	return paths
+}
+
+// applicableProposalPaths returns the contained paths that belong to at least
+// one wholly contained proposal. A contained path named only by a rejected
+// proposal must not be read merely because that proposal also named an escape.
+// Paths shared with another, valid proposal remain eligible for that proposal.
+func applicableProposalPaths(proposals []proposal.Proposal, accepted, rejected map[string]string) map[string]string {
+	paths := make(map[string]string)
+	for _, p := range proposals {
+		if hasRejectedPath(p, rejected) {
+			continue
+		}
+		for _, path := range p.Paths {
+			if absPath, ok := accepted[path]; ok {
+				paths[path] = absPath
+			}
+		}
+	}
+	return paths
+}
+
+// hasRejectedPath reports whether any path of the proposal failed containment.
+func hasRejectedPath(p proposal.Proposal, rejected map[string]string) bool {
+	for _, path := range p.Paths {
+		if _, bad := rejected[path]; bad {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneFrontmatter(fm map[string]any) map[string]any {

--- a/internal/fix/repair_proposal_containment_test.go
+++ b/internal/fix/repair_proposal_containment_test.go
@@ -1,0 +1,184 @@
+package fix
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pablontiv/rootline/internal/proposal"
+)
+
+func mixedContainmentRepairProposal(proposalType proposal.Type) proposal.Proposal {
+	p := proposal.Proposal{
+		Type:        proposalType,
+		Field:       "status",
+		Description: "repair mixed containment targets",
+		Paths:       []string{"inside.md", "../outside.md"},
+		From:        "old",
+		To:          "new",
+		Value:       "new",
+		Heading:     "## Status",
+		Mode:        "replace",
+	}
+	if proposalType == proposal.AddField || proposalType == proposal.ExtractBody ||
+		proposalType == proposal.InferFromChildren || proposalType == proposal.InferFromSiblings {
+		p.Field = "added"
+	}
+	return p
+}
+
+func writeMixedContainmentFixture(t *testing.T) (root, inside, outside, original string, mode os.FileMode) {
+	t.Helper()
+	base := t.TempDir()
+	root = filepath.Join(base, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original = "---\nstatus: old\nallowed: old\n---\n# Document\n\nold\n\n## Status\n\nold section\n"
+	inside = filepath.Join(root, "inside.md")
+	outside = filepath.Join(base, "outside.md")
+	mode = 0o640
+	if err := os.WriteFile(inside, []byte(original), mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("outside stays untouched\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root, inside, outside, original, mode
+}
+
+func assertMixedContainmentProposalRejected(t *testing.T, result *RepairResult, inside, outside, original string, mode os.FileMode) {
+	t.Helper()
+	if !result.Complete || len(result.Errors) != 0 || len(result.RolledBack) != 0 {
+		t.Fatalf("complete=%v errors=%v rolled_back=%v", result.Complete, result.Errors, result.RolledBack)
+	}
+	if len(result.Rejected) != 1 || !strings.Contains(result.Rejected[0], "../outside.md") {
+		t.Fatalf("rejected=%v, want one containment rejection", result.Rejected)
+	}
+	if len(result.Changed) != 0 || len(result.Skipped) != 0 {
+		t.Fatalf("changed=%v skipped=%v, want proposal wholly unattempted", result.Changed, result.Skipped)
+	}
+	got, err := os.ReadFile(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("contained path was modified by rejected proposal:\n%s", got)
+	}
+	info, err := os.Stat(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != mode.Perm() {
+		t.Fatalf("mode=%#o, want %#o", info.Mode().Perm(), mode.Perm())
+	}
+	gotOutside, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotOutside) != "outside stays untouched\n" {
+		t.Fatalf("outside path was modified: %q", gotOutside)
+	}
+}
+
+func TestApplyRepairRejectsMixedContainmentProposalWhole(t *testing.T) {
+	proposalTypes := []proposal.Type{
+		proposal.CorrectValue,
+		proposal.MigrateValue,
+		proposal.AddField,
+		proposal.ExtractBody,
+		proposal.InferFromChildren,
+		proposal.InferFromSiblings,
+		proposal.SetField,
+		proposal.SetSection,
+		proposal.CorrectOutlier,
+		proposal.PropagateAggregate,
+		proposal.CorrectLink,
+	}
+	for _, proposalType := range proposalTypes {
+		for _, dryRun := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/dry-run=%t", proposalType, dryRun), func(t *testing.T) {
+				root, inside, outside, original, mode := writeMixedContainmentFixture(t)
+				result, err := ApplyRepair([]proposal.Proposal{mixedContainmentRepairProposal(proposalType)}, dryRun, root, false)
+				if err != nil {
+					t.Fatalf("ApplyRepair: %v", err)
+				}
+				assertMixedContainmentProposalRejected(t, result, inside, outside, original, mode)
+				if dryRun {
+					if result.ResolvedTargets == nil || result.ResolvedTargets.Accepted["inside.md"] != inside ||
+						result.ResolvedTargets.Rejected["../outside.md"] != "escapes root" {
+						t.Fatalf("resolved_targets=%+v", result.ResolvedTargets)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestApplyRepairMixedProposalDoesNotReadSoleContainedPath(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	if err := os.MkdirAll(filepath.Join(root, "documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	result, err := ApplyRepair([]proposal.Proposal{{
+		Type:  proposal.AddField,
+		Field: "added",
+		Value: "new",
+		Paths: []string{"documents", "../outside.md"},
+	}}, false, root, false)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if !result.Complete || len(result.Errors) != 0 || len(result.Changed) != 0 || len(result.Rejected) != 1 {
+		t.Fatalf("result=%+v, want policy rejection without attempting the contained directory", result)
+	}
+}
+
+func TestApplyRepairMixedProposalWithRepeatedPathIsRejectedOnce(t *testing.T) {
+	root, inside, outside, original, mode := writeMixedContainmentFixture(t)
+	p := mixedContainmentRepairProposal(proposal.AddField)
+	p.Paths = []string{"inside.md", "inside.md", "../outside.md", "../outside.md"}
+	result, err := ApplyRepair([]proposal.Proposal{p}, true, root, false)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	assertMixedContainmentProposalRejected(t, result, inside, outside, original, mode)
+	if len(result.ResolvedTargets.Accepted) != 1 || len(result.ResolvedTargets.Rejected) != 1 {
+		t.Fatalf("resolved_targets=%+v, want globally deduplicated paths", result.ResolvedTargets)
+	}
+}
+
+func TestApplyRepairValidProposalMaySharePathWithRejectedProposal(t *testing.T) {
+	root, inside, outside, _, mode := writeMixedContainmentFixture(t)
+	result, err := ApplyRepair([]proposal.Proposal{
+		{Type: proposal.SetField, Field: "blocked", Value: "no", Paths: []string{"inside.md", "../outside.md"}},
+		{Type: proposal.SetField, Field: "allowed", Value: "new", Paths: []string{"inside.md"}},
+	}, false, root, false)
+	if err != nil {
+		t.Fatalf("ApplyRepair: %v", err)
+	}
+	if !result.Complete || len(result.Errors) != 0 || len(result.Rejected) != 1 || len(result.Changed) != 1 {
+		t.Fatalf("result=%+v", result)
+	}
+	got, err := os.ReadFile(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "blocked:") || !strings.Contains(string(got), "allowed: new") {
+		t.Fatalf("shared target content=%q, want only the valid proposal applied", got)
+	}
+	info, err := os.Stat(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != mode.Perm() {
+		t.Fatalf("mode=%#o, want %#o", info.Mode().Perm(), mode.Perm())
+	}
+	gotOutside, err := os.ReadFile(outside)
+	if err != nil || string(gotOutside) != "outside stays untouched\n" {
+		t.Fatalf("outside content=%q err=%v", gotOutside, err)
+	}
+}


### PR DESCRIPTION
[rootline-team]

Closes #244

## Problem

`repair apply` filtered an escaping path out of a multi-path proposal and then applied the remaining contained paths. That contradicted the documented proposal-level contract and could partially mutate a proposal that policy had rejected.

## Change

- Reject the entire proposal when any of its paths fails containment.
- Read only paths belonging to at least one wholly contained proposal.
- Preserve global path deduplication and the dry-run `resolved_targets` envelope.
- Allow an independent valid proposal to keep using a path that it shares with a rejected proposal.
- No CLI, JSON v1, `.stem`, schema, or Git requirement changes.

## Tests added

The regression suite covers apply and dry-run for every multi-path repair handler:

- `correct_value`, `migrate_value`, `add_field`, `extract_body`
- `infer_from_children`, `infer_from_siblings`
- `set_field`, `set_section`
- `correct_outlier`, `propagate_aggregate`, `correct_link`

It also covers a contained path that must not be read, repeated paths, and a path shared by accepted and rejected proposals.

TDD evidence: the tests first failed because every handler changed `inside.md`; the directory sentinel also produced an I/O error. They pass after the proposal-level gate was restored.

## Verification

Exact head SHA: `6b8cbbce2c99e4fc9cfe64f6b7a2125c3554d1bc`

Environment: Linux 6.18.35 x86_64; official Go 1.26.8 linux/amd64 archive verified against the published SHA-256 `d0f743b33e8d8945e6b1f432edd15785c70507121d6e2a723b21285eddf8b57b`.

Passed locally:

- `gofmt` clean, `go vet ./...`, `go build ./...`
- `go test ./... -race`
- focused regressions repeated 10 times
- `go mod tidy` with no diff
- dev binary build and real external `repair apply` dry-run/apply/replay on Markdown + JSON report, without Git
- roadmap validation: 126/126 valid
- `tests/installers/install-sh-test.sh`
- modified package coverage: `internal/fix` 90.4%; total 89.0%

Local `pkcov check` remains red only because `internal/skilldist` measured 84.8% against its 85% floor; the same 84.8% was reproduced from unchanged `master` `6407ce7838c6c899681c0c9bbe77032e6d42d540`. `just`, `golangci-lint`, `govulncheck`, `gitleaks`, PowerShell, macOS, and Windows were unavailable locally; the current full CI is required for those gates.

Exact dev binary SHA-256: `97b56bc266596dd60d2be4a4f4b2c085384728182ed78db426b61277e2091eb5`.

## Reproduce

```bash
go build -ldflags "-X main.version=dev" -o /tmp/rootline ./cmd/rootline/
go test -race -count=1 ./internal/fix -run 'TestApplyRepairRejectsMixedContainmentProposalWhole|TestApplyRepairMixedProposalDoesNotReadSoleContainedPath|TestApplyRepairMixedProposalWithRepeatedPathIsRejectedOnce|TestApplyRepairValidProposalMaySharePathWithRejectedProposal'
```

For the external flow, create a report beside `inside.md` with one `set_field` proposal using `paths: ["inside.md", "../outside.md"]` and a second valid proposal using `paths: ["inside.md"]`, then run:

```bash
/tmp/rootline repair apply --report /tmp/qa244/root/report.json --dry-run -o json
/tmp/rootline repair apply --report /tmp/qa244/root/report.json -o json
/tmp/rootline repair apply --report /tmp/qa244/root/report.json -o json
```

Expected: `exit 0`, `complete: true`, one containment rejection, no change from the mixed proposal, only the separate valid proposal applied, and an idempotent replay. The outside file and permissions remain unchanged.

## Status

Implementation is complete and available for independent QA at the exact SHA above. This PR is draft only while current CI, independent QA, and technical review are pending. Any new commit invalidates the QA/review SHA.