### PR TITLE
fix: preserve comments in empty frontmatter

### DIFF
--- a/docs/fix.md
+++ b/docs/fix.md
@@ -399,6 +399,8 @@ Flags:
 
 When Rootline modifies a `.stem` or a frontmatter block, it rewrites through YAML nodes so comments and key order are preserved where possible. Inter-token whitespace, inline-comment spacing, and nested indentation are normalized by the YAML encoder; do not expect byte-identical formatting outside the edited value.
 
+When a valid frontmatter block uses LF newlines and contains only comments and blank lines, adding its first fields retains those comments inside the block, in their original order. The Markdown body and existing file permissions are preserved.
+
 ## Sibling Inference Logic
 
 To prevent noisy guesses, sibling inference requires:

--- a/internal/e2e/comment_frontmatter_test.go
+++ b/internal/e2e/comment_frontmatter_test.go
@@ -1,0 +1,129 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Adding the first field must not discard metadata comments that have no key.
+func TestCommentOnlyFrontmatterCLI(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "rootline")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", bin, "./cmd/rootline") //nolint:gosec // builds this checkout into a test-owned directory
+	build.Dir = filepath.Join("..", "..")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build dev CLI: %v\n%s", err, output)
+	}
+	for _, flow := range []string{"fix", "fix-all", "repair", "set"} {
+		t.Run(flow, func(t *testing.T) {
+			root := t.TempDir() // Product operation must not require Git.
+			body := "## QA body\n\nKeep café and <literal> unchanged.\n\n---\n\nTail\n"
+			original := "---\n# Keep this metadata comment.\n\n  # Keep this second note.\n---\n" + body
+			files := map[string]string{
+				".stem":         "version: 2\nroot: true\nscope:\n  match: '*.md'\nschema:\n  status:\n    type: string\n    required: true\n    default: ready\n",
+				"probe.md":      original,
+				"unrelated.txt": "Leave this file alone.\n",
+			}
+			stamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+			write := func(name, content string) {
+				t.Helper()
+				path := filepath.Join(root, name)
+				if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chtimes(path, stamp, stamp); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for name, content := range files {
+				write(name, content)
+			}
+			run := func(args ...string) string {
+				t.Helper()
+				cmd := exec.Command(bin, args...) //nolint:gosec // locally compiled CLI and test-owned fixture
+				cmd.Dir = root
+				var stdout, stderr bytes.Buffer
+				cmd.Stdout, cmd.Stderr = &stdout, &stderr
+				if err := cmd.Run(); err != nil || stderr.Len() != 0 {
+					t.Fatalf("%v: %v\nstdout: %s\nstderr: %s", args, err, &stdout, &stderr)
+				}
+				return stdout.String()
+			}
+			assertFiles := func() {
+				t.Helper()
+				for name, want := range files {
+					path := filepath.Join(root, name)
+					if got := string(mustReadE2EFile(t, path)); got != want {
+						t.Fatalf("%s changed unexpectedly: got %q, want %q", name, got, want)
+					}
+					info, err := os.Stat(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !info.ModTime().Equal(stamp) || (runtime.GOOS != "windows" && info.Mode().Perm() != 0o600) {
+						t.Fatalf("%s was rewritten or its permissions changed", name)
+					}
+				}
+			}
+			args := []string{"fix", "probe.md"}
+			switch flow {
+			case "fix-all":
+				args = []string{"fix", "--all", ".", "-o", "json"}
+			case "repair":
+				report := run("fix", "--all", ".", "--dry-run", "-o", "json")
+				assertFiles()
+				files["report.json"] = report
+				write("report.json", report)
+				args = []string{"repair", "apply", "--root", ".", "--report", "report.json", "-o", "json"}
+			case "set":
+				args = []string{"set", "probe.md", "status=ready"}
+			}
+			run(append(append([]string{}, args...), "--dry-run")...)
+			assertFiles()
+			output := run(args...)
+			if flow == "fix-all" || flow == "repair" {
+				var envelope struct {
+					Version int `json:"version"`
+				}
+				if err := json.Unmarshal([]byte(output), &envelope); err != nil || envelope.Version != 1 {
+					t.Fatalf("invalid mutation envelope: %v\n%s", err, output)
+				}
+			}
+			result := string(mustReadE2EFile(t, filepath.Join(root, "probe.md")))
+			parts := strings.SplitN(result, "---\n", 3)
+			if len(parts) != 3 || parts[0] != "" || parts[2] != body {
+				t.Fatalf("Markdown body changed: %q", result)
+			}
+			first, second := "# Keep this metadata comment.", "# Keep this second note."
+			if strings.Count(parts[1], first) != 1 || strings.Count(parts[1], second) != 1 || strings.Index(parts[1], first) >= strings.Index(parts[1], second) {
+				t.Fatalf("metadata comments lost, duplicated or reordered: %q", result)
+			}
+			if !strings.Contains(parts[1], "status: ready\n") {
+				t.Fatalf("requested/default field missing: %q", result)
+			}
+			files["probe.md"] = result
+			// A no-op rewrite must be observable even on coarse timestamp filesystems.
+			if err := os.Chtimes(filepath.Join(root, "probe.md"), stamp, stamp); err != nil {
+				t.Fatal(err)
+			}
+			run("validate", "--all", ".", "-o", "json")
+			assertFiles()
+			// set performs explicit writes even for equal assignments; the
+			// read-only replay contract here belongs to fix and repair.
+			if flow == "set" {
+				return
+			}
+			run(args...)
+			assertFiles()
+		})
+	}
+}

--- a/internal/fix/frontmatter.go
+++ b/internal/fix/frontmatter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"reflect"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -33,6 +34,20 @@ func renderPreservedFrontmatter(fmText string, fm map[string]any) (string, bool)
 
 	seen := reconcileMapping(mapping, fm)
 	appendNewKeys(mapping, fm, seen)
+
+	// yaml.v3 returns a zero document and discards standalone comments when
+	// there are no values. Attach them to the new mapping as one group so a
+	// later node round-trip keeps every note, including formerly orphan ones.
+	if doc.Kind == 0 {
+		var comments []string
+		for _, line := range strings.Split(fmText, "\n") {
+			line = strings.TrimLeft(line, " \t")
+			if strings.HasPrefix(line, "#") {
+				comments = append(comments, line)
+			}
+		}
+		mapping.HeadComment = strings.Join(comments, "\n")
+	}
 
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)

--- a/internal/fix/frontmatter_preserve_test.go
+++ b/internal/fix/frontmatter_preserve_test.go
@@ -3,6 +3,8 @@ package fix
 import (
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // These tests cover the format-preserving frontmatter rewrite required by
@@ -95,6 +97,52 @@ func TestRewriteFrontmatter_AppendsToEmptyLeadingBlock(t *testing.T) {
 			want := "---\nalpha: alpha-default\n---\n# Doc\n\nbody\n"
 			if result != want {
 				t.Errorf("RewriteFrontmatter() = %q, want %q", result, want)
+			}
+		})
+	}
+}
+
+func TestRewriteFrontmatter_PreservesStandaloneComments(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		comments []string
+	}{
+		{"one comment", "# Keep this metadata comment.\n", []string{"# Keep this metadata comment."}},
+		{"blank and indented comments", "\n# First note.\n\n  # Second note: café.\n\n", []string{"# First note.", "# Second note: café."}},
+		{"comment punctuation", "# ---\n# status: do not infer from this note\n", []string{"# ---", "# status: do not infer from this note"}},
+	}
+	body := "## Body\n\nKeep café and <literal> unchanged.\n\n---\n\nTail\n"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RewriteFrontmatter("---\n"+tt.text+"---\n"+body, map[string]any{"status": "ready"})
+			// A comment containing --- is not a frontmatter delimiter.
+			end := strings.Index(result, "\n---\n")
+			if end < 0 || result[end+5:] != body || !strings.HasPrefix(result, "---\n") {
+				t.Fatalf("body or frontmatter boundaries changed: %q", result)
+			}
+			frontmatter := result[4 : end+1]
+			var values map[string]any
+			if err := yaml.Unmarshal([]byte(frontmatter), &values); err != nil {
+				t.Fatalf("invalid rewritten YAML: %v\n%s", err, result)
+			}
+			if len(values) != 1 || values["status"] != "ready" {
+				t.Fatalf("requested field was not added: %v", values)
+			}
+			previous := -1
+			for _, comment := range tt.comments {
+				position := strings.Index(frontmatter, comment)
+				if position <= previous || strings.Count(frontmatter, comment) != 1 {
+					t.Errorf("comment %q lost, duplicated or reordered in %q", comment, frontmatter)
+				}
+				previous = position
+			}
+			// Once populated, a later field mutation must still retain the notes.
+			next := RewriteFrontmatter(result, map[string]any{"status": "done"})
+			for _, comment := range tt.comments {
+				if strings.Count(next, comment) != 1 {
+					t.Errorf("later mutation lost or duplicated comment %q: %q", comment, next)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
[rootline-team]

Closes #246

## Problem and change

Adding a first field to comment-only frontmatter discarded the original YAML notes. The schema became valid and the command exited successfully despite that loss.

The shared writer now recovers standalone comment lines when yaml.v3 returns an empty document and attaches them to the newly populated mapping. Notes retain their contents and order, including on a later field mutation. Blank lines and leading comment indentation can normalize, within the existing preservation contract. Nonempty mappings follow the existing path.

Added shared-writer regressions and real-process CLI coverage for `fix`, `fix --all`, generated-report `repair apply`, and the first `set` mutation. The fix/repair flows also prove read-only replay. The tests use temporary Markdown/.stem files without Git, check dry-run, complete body preservation, current modes, file timestamps, unrelated files, and JSON v1. The writer test additionally changes the populated field a second time to verify comment survival.

Updated `docs/fix.md` with the bounded LF-frontmatter behavior. No schema, JSON, exit-code, delimiter-parser, dependency, installer or workflow changes.

## Implementation status and handoff

**Implementation complete and available for independent QA at `3ac273a1794180e78b6b89e02a4d7cdf3c1a2c7b`.**

Base: `4044a388ddaf24ef77cbc231ec30d5e3a0e29216` (`master`, v9.13.22).
Branch: `rootline-team/issue-246`.

Draft is for pending validation only, not unfinished implementation:
- CI of this published SHA **passed**: [CI #859](https://github.com/pablontiv/rootline/actions/runs/34054776337).
- Independent `[rootline-team/qa] QA_PASS` for this SHA is pending.
- Independent technical review is pending, including assessment of the documented pre-existing local coverage failure below.

When the required validations are satisfied, the reviewer is authorized to remove draft and continue the normal integration gates. No administrative developer pass or extra commit is needed. The developer has not emitted a QA verdict, approval or merge.

## Executed developer verification

Linux 6.18.35 x86_64, official Go 1.26.8 (archive checksum verified against go.dev); temporary just 1.58.0 and golangci-lint 2.13.1 from checksum-verified releases.

- Baseline `go test ./internal/fix -count=1`: passed.
- TDD: the new writer test failed on all three fixtures before the production change; external `fix`, `fix --all`, `repair apply`, and `set` all independently failed on lost comments. The final implementation passes these regressions.
- `just check`: passed; 0 lint findings, build passed.
- `just test`: passed, full `go test ./... -race` across all 17 packages.
- `just validate`: passed, 126/126 roadmap records valid, no diagnostics.
- `go mod tidy`: passed, go.mod/go.sum unchanged.
- `sh tests/installers/install-sh-test.sh`: passed locally on Linux. Windows/macOS have not been tested locally.
- `git diff --check`: passed.
- **`just coverage-check`: FAILED locally**, identically on the branch and a clean isolated checkout of the exact base. `internal/skilldist=84.8% < 85%` in both; total 89.0% in both. `internal/fix` improves 90.4% → 90.5%. The failing package is unmodified. Neither its tests nor coverage configuration was changed; no local coverage PASS is claimed.

The native GitHub publication preserves the tested tree and its exact parent. The published commit was fetched back, its tree matched the local staged tree, and the working checkout was clean. A dev binary rebuilt from the exact published SHA has SHA-256 `a9df886ab5565a03c210dd01822e77541a15881495dc8e74df4c2bf2b3976a2f`; the focused writer and external CLI regressions passed again there.

[CI #859](https://github.com/pablontiv/rootline/actions/runs/34054776337) completed successfully on `3ac273a1794180e78b6b89e02a4d7cdf3c1a2c7b`. Job steps were checked: build; full-profile tests with race; coverage threshold; tidy; lint; govulncheck; gitleaks; docs-validate; and native installer resolver tests on Ubuntu, macOS and Windows all executed successfully. The CI log records Go 1.27.1, total coverage **90.1%**, `internal/fix=91.4%`, and `internal/skilldist=85.4%`; every measured package is at least 85%. This does not relabel the separately observed local Go 1.26.8 coverage failure as a PASS. Release and installer-smoke are correctly skipped for this PR event and are not counted as validation.

## Reproducible QA entry points

From an isolated checkout of the PR SHA:

```sh
go build -o /tmp/rootline-qa246 ./cmd/rootline/
go test ./internal/fix ./internal/e2e \
  -run 'TestRewriteFrontmatter_PreservesStandaloneComments|TestCommentOnlyFrontmatterCLI' \
  -count=1
```

The build defaults to `rootline version dev` and does not update a global binary. The standalone fixture and exact before/after hashes in #246 can be run with this binary. For a fresh temporary fixture:

```yaml
# .stem
version: 2
root: true
scope:
  match: "*.md"
schema:
  status:
    type: string
    required: true
    default: ready
```

```markdown
---
# Keep this metadata comment.

  # Keep this second note.
---
## QA body

Keep café and <literal> unchanged.

---

Tail
```

Set the Markdown file to mode 0600. On separately reset copies, exercise:

```sh
/tmp/rootline-qa246 fix probe.md --dry-run
/tmp/rootline-qa246 fix probe.md
/tmp/rootline-qa246 fix --all . --dry-run -o json > report.json
/tmp/rootline-qa246 fix --all . -o json
/tmp/rootline-qa246 repair apply --root . --report report.json --dry-run -o json
/tmp/rootline-qa246 repair apply --root . --report report.json -o json
/tmp/rootline-qa246 validate --all . -o json
```

Generate the repair report on a fresh, unrepaired copy so it actually contains `add_field`. Expected: both comments remain inside frontmatter in order, `status: ready` is added, body bytes/mode/schema/sentinel remain unchanged, and fix/repair replay makes no writes or duplicate notes. Also compare a normal nonempty mapping and update an already populated field. `set` remains an explicit write command; this PR does not introduce a no-write replay contract for it.

## Limits

This fixes the existing preservation bug; it makes no older-version regression claim. CRLF delimiter handling and preservation of arbitrary YAML formatting remain outside #246. No consumer repository or live corpus was touched. #242 remains unstarted; this is the only team PR in implementation/validation.
