### PR TITLE
fix: stabilize extend enum suggestion ordering

### DIFF
--- a/docs/fix.md
+++ b/docs/fix.md
@@ -108,6 +108,8 @@ rootline fix --all             # Apply data-only repairs to documents
 
 `fix` combines proposal generation and application in one step. It writes document frontmatter only. Schema-surface proposals such as `extend_enum`, `add_aggregate`, and `remove_stem_field` are withheld for review: in dry-run JSON they appear as a `schema_suggestions` array, while apply JSON reports a `schema_suggestions` integer count.
 
+Within each effective-schema scope, `extend_enum` suggestions are ordered lexicographically by field, then value; each suggestion's paths are also lexicographically ordered. This does not reorder other proposal phases or schema scopes.
+
 ### 2. `rootline repair apply` — Data-Only Bulk Repair (Current)
 
 Use this for applying the versioned `rootline/proposals` report produced by

--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -364,6 +364,13 @@ func detectExtendEnum(effective *rules.StemFile, errs map[string][]rules.Validat
 			Value:       fv.value,
 		})
 	}
+	// Canonicalize this detector's groups without reordering other proposal phases.
+	sort.Slice(proposals, func(i, j int) bool {
+		if proposals[i].Field != proposals[j].Field {
+			return proposals[i].Field < proposals[j].Field
+		}
+		return proposals[i].Value < proposals[j].Value
+	})
 	return proposals
 }
 

--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -354,6 +355,7 @@ func detectExtendEnum(effective *rules.StemFile, errs map[string][]rules.Validat
 		if strings.Contains(fv.value, "(") {
 			continue
 		}
+		sort.Strings(paths)
 		proposals = append(proposals, Proposal{
 			Type:        ExtendEnum,
 			Field:       fv.field,

--- a/internal/proposal/proposal_coverage_test.go
+++ b/internal/proposal/proposal_coverage_test.go
@@ -1,6 +1,8 @@
 package proposal
 
 import (
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/pablontiv/rootline/internal/extract"
@@ -1186,6 +1188,37 @@ func TestDetectExtendEnum_TwoRecords(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected extend_enum proposal for Obsoleto in 2 records")
+	}
+}
+
+func TestDetectExtendEnumSortsPaths(t *testing.T) {
+	effective := &rules.StemFile{
+		Schema: map[string]rules.SchemaField{
+			"estado": {
+				Type:   "enum",
+				Values: []string{"Pending", "Completed"},
+			},
+		},
+	}
+
+	errs := make(map[string][]rules.ValidationError)
+	for i := 15; i >= 0; i-- {
+		path := fmt.Sprintf("T%03d.md", i)
+		errs[path] = []rules.ValidationError{{
+			Field:   "estado",
+			Rule:    "enum",
+			Message: `value Obsoleto is not in allowed values: Pending, Completed`,
+		}}
+	}
+
+	for i := 0; i < 128; i++ {
+		proposals := detectExtendEnum(effective, errs)
+		if len(proposals) != 1 {
+			t.Fatalf("iteration %d: expected 1 proposal, got %d", i, len(proposals))
+		}
+		if got := proposals[0].Paths; len(got) != 16 || !slices.IsSorted(got) {
+			t.Fatalf("iteration %d: paths = %v, want 16 paths in lexical order", i, got)
+		}
 	}
 }
 

--- a/internal/proposal/proposal_coverage_test.go
+++ b/internal/proposal/proposal_coverage_test.go
@@ -1191,6 +1191,49 @@ func TestDetectExtendEnum_TwoRecords(t *testing.T) {
 	}
 }
 
+func TestDetectExtendEnumSortsGroupsAndTheirPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		groups [][2]string
+	}{
+		{"multiple fields", [][2]string{{"alpha", "Zulu"}, {"middle", "Shared"}, {"zeta", "Alpha"}}},
+		{"multiple values", [][2]string{{"state", "Alpha"}, {"state", "Shared"}, {"state", "Zulu"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			effective := &rules.StemFile{Schema: make(map[string]rules.SchemaField)}
+			errs := make(map[string][]rules.ValidationError)
+			for i := len(tc.groups) - 1; i >= 0; i-- {
+				group := tc.groups[i]
+				effective.Schema[group[0]] = rules.SchemaField{Type: "enum", Values: []string{"Open"}}
+				for _, name := range []string{"c.md", "a.md", "b.md"} {
+					path := fmt.Sprintf("%d/%s", i, name)
+					errs[path] = []rules.ValidationError{{
+						Field: group[0], Rule: "enum",
+						Message: fmt.Sprintf("value %q not in allowed values: Open", group[1]),
+					}}
+				}
+			}
+
+			for iteration := 0; iteration < 128; iteration++ {
+				got := detectExtendEnum(effective, errs)
+				if len(got) != len(tc.groups) {
+					t.Fatalf("iteration %d: got %d groups, want %d", iteration, len(got), len(tc.groups))
+				}
+				for i, want := range tc.groups {
+					p := got[i]
+					if p.Type != ExtendEnum || p.Field != want[0] || p.Value != want[1] {
+						t.Fatalf("iteration %d, group %d: got %s %s=%s, want extend_enum %s=%s", iteration, i, p.Type, p.Field, p.Value, want[0], want[1])
+					}
+					paths := []string{fmt.Sprintf("%d/a.md", i), fmt.Sprintf("%d/b.md", i), fmt.Sprintf("%d/c.md", i)}
+					if !slices.Equal(p.Paths, paths) {
+						t.Fatalf("iteration %d, group %d: paths = %v, want %v", iteration, i, p.Paths, paths)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestDetectExtendEnumSortsPaths(t *testing.T) {
 	effective := &rules.StemFile{
 		Schema: map[string]rules.SchemaField{


### PR DESCRIPTION
[rootline-team]

Closes #242

## Problem and change

Identical `fix --all --dry-run` inputs could emit different JSON v1/table bytes because both the paths inside each `extend_enum` suggestion and the field/value groups themselves came from Go maps.

The PR sorts each suggestion's paths lexicographically. R1 additionally sorts groups by field, then value **only inside detectExtendEnum**, preserving other detector phases and effective-schema scope ordering. Thresholds, descriptions, counts, withholding/application behavior and output versions are unchanged. `docs/fix.md` documents that ordering.

## R1 acceptance evidence — Developer verification, not independent QA

- Regression `TestDetectExtendEnumSortsGroupsAndTheirPaths` failed on previous head `b095826292f5194c3e6b395df749b2fab35e2935` for both multi-field and same-field/multi-value cases, on iteration 0. Both pass after the correction; each asserts groups and their exact path membership/order across 128 calls. Existing 16-path regression and CombineReports order regression also pass.
- 1,024 fresh external process invocations: two fixtures × base/fixed × JSON/table × 128.
- QA's two-field/three-record fixture: base 2 variants per format → fixed 1.
- Same-field three-value/nine-record fixture: base 5 JSON / 6 table variants → fixed 1 per format.
- All invocations exit 0 with empty stderr; JSON stays version 1/kind rootline/proposals. Reports remain semantically identical after normalizing group order. Every group's exact paths are checked.
- Markdown, .stem, unrelated text, directory entries and modes (documents 0600, schema 0640, unrelated file 0440) are unchanged. Product processes run with PATH=/nonexistent in fixtures without Git.
- Platform: Linux x86_64, Go 1.26.8. Official archive rechecked against fresh go.dev metadata before extraction: SHA-256 d0f743b33e8d8945e6b1f432edd15785c70507121d6e2a723b21285eddf8b57b.
- Locally tested corrected dev binary SHA-256: f49593b4e9541eab3aadc30c65587cf4e1d193f52a98db795e182c820a3876b2. Published source blobs were verified equal to the locally tested files.

## Local checks

`just` is absent; current recipe commands were run directly:

- `gofmt -l .` / `git diff --check`: clean.
- `go build ./...`, `go vet ./...`: pass.
- `go test ./... -race`: all 17 packages pass.
- `go mod tidy`: no go.mod/go.sum change.
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run`: 0 issues.
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`: no vulnerabilities.
- Dev binary `validate --all docs/roadmap/`: pass.
- `sh tests/installers/install-sh-test.sh`: pass. No native macOS/Windows execution locally; current-SHA CI remains required.
- `go test ./... -coverprofile=coverage.out` passes; pkcov report totals 89.0%, internal/proposal 90.1%. `pkcov check` exits 1 on unchanged internal/skilldist at 84.8% < 85%. This same base failure was already documented/reproduced before R1; it is not claimed fixed. No thresholds or protections changed. Local gitleaks unavailable; CI required.

## Reproduce for independent QA

Build the exact head with updater disabled:

```sh
go build -mod=readonly -ldflags '-X main.version=dev' -o /tmp/rootline ./cmd/rootline/
go test ./internal/proposal -run 'TestDetectExtendEnum|TestCombineReportsPreservesOrder' -count=1
```

Use the exact two-field fixture in [QA R1](https://github.com/pablontiv/rootline/pull/248#issuecomment-5562015353). Also use a .stem with only `state: {type: enum, values: [Open]}` and nine files: `0-a.md,0-b.md,0-c.md` have `state: Alpha`; `1-a.md,1-b.md,1-c.md` have `state: Shared`; `2-a.md,2-b.md,2-c.md` have `state: Zulu`. Keep root:true/version:2/scope match:"*.md" and the QA Markdown body.

From each fixture, store outputs outside the governed directory:

```sh
OUT=$(mktemp -d)
for i in $(seq 1 128); do
  env PATH=/nonexistent /tmp/rootline fix --all . --dry-run -o json > "$OUT/json-$i.out"
  env PATH=/nonexistent /tmp/rootline fix --all . --dry-run -o table > "$OUT/table-$i.out"
done
sha256sum "$OUT"/json-*.out | awk '{print $1}' | sort -u
sha256sum "$OUT"/table-*.out | awk '{print $1}' | sort -u
```

Expect one hash per format/fixture. Expected groups are state=Shared then tier=Faraway, or state=Alpha,Shared,Zulu; each group retains its own lexically sorted paths. Check unchanged JSON semantics, exit/stderr, bytes/modes, no-Git operation and original one-group fixture. This does not promise deterministic unrelated detector phases.

## Status

Implementation complete and available for independent QA at **0ecf8e831b75339031e39ef10f80595ca4de9cb3**. [CI #862](https://github.com/pablontiv/rootline/actions/runs/34069620978) completed successfully on this exact SHA: build, race/coverage (90.1% total; internal/skilldist 85.4% on Go 1.27.1), tidy, lint, vulnerabilities, gitleaks, docs validation and native installer tests on Linux/macOS/Windows. The test job's executed logs and job steps were inspected; release and installer-smoke are post-release jobs skipped for this PR, not counted as tests.

The local Go 1.26.8 coverage discrepancy remains documented above; no threshold changes. Draft only pending **new independent QA for R1 and technical review**. Previous QA_FAIL is not superseded by Developer testing. No merge or independent QA verdict issued by Developer. Once all gates pass, the Reviewer may remove draft and integrate under the existing authorization.